### PR TITLE
fix(executor): surface swallowed errors and trim wasteful test sleep

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -369,10 +369,12 @@ func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *B
 				arb.Id, len(arb.Hops), arb.TotalGas, arb.BlockNumber)
 
 			submitted, err := processArb(ctx, arb, receivedAt, rm, bundler, submitter, executorAddr, ethBalance)
-			if err != nil {
+			switch {
+			case err != nil:
 				log.Printf("Error processing arb %s: %v", arb.Id, err)
+			case !submitted:
+				log.Printf("Skipped arb %s (risk-manager veto or below threshold)", arb.Id)
 			}
-			_ = submitted
 		}
 	}
 }

--- a/cmd/executor/submitter.go
+++ b/cmd/executor/submitter.go
@@ -277,7 +277,10 @@ func (s *Submitter) submitToBuilder(ctx context.Context, builder BuilderConfig, 
 		BundleHash string `json:"bundleHash"`
 	}
 	if rpcResp.Result != nil {
-		_ = json.Unmarshal(rpcResp.Result, &result)
+		if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
+			log.Printf("warn: builder %s returned unparseable result (%v): %s",
+				builder.Name, err, string(rpcResp.Result))
+		}
 	}
 
 	bundleHash := result.BundleHash

--- a/cmd/executor/submitter_test.go
+++ b/cmd/executor/submitter_test.go
@@ -383,7 +383,10 @@ func TestSubmitToBuilder_Timeout(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second)
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-r.Context().Done():
+		}
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- Log a warning when a builder returns an unparseable bundle-hash result (instead of silently falling back to a random ID).
- Cut `TestSubmitToBuilder_Timeout` handler sleep from 5s to 300ms and make it context-aware, so `srv.Close()` returns immediately.
- Log a distinct "skipped arb" line when `processArb` returns `(false, nil)`, so risk-manager vetoes are observable.

## Files Changed
| File | Change |
|---|---|
| `cmd/executor/submitter.go` | Log warning on bundle-hash unmarshal failure |
| `cmd/executor/submitter_test.go` | Reduce 5s handler sleep to 300ms, respect `r.Context()` |
| `cmd/executor/main.go` | Log when arb is skipped (not errored) by risk manager |

## Acceptance Criteria
- [x] Bundle-hash unmarshal failures produce a warning log with builder name and raw result
- [x] `TestSubmitToBuilder_Timeout` completes in <1s instead of ~5s
- [x] Risk-manager vetoes log a distinct "arb skipped" line (not an error)
- [x] `go test ./cmd/executor/...`, `go vet ./...`, `go build ./...` all clean
- [x] `start.sh` smoke boots cleanly with no new noise on happy path

## Test plan
- [x] `go test ./cmd/executor/... -run TestSubmitToBuilder_Timeout -v` — runtime <1s
- [x] `go test ./cmd/executor/...` — full package green
- [x] `go test ./...` and `cargo test --workspace --release` — green
- [x] `./start.sh` 30s smoke — clean

Closes #76