### PR TITLE
feat(docs): add VitePress documentation site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs-site
+
+      - name: Build docs
+        run: npm run build
+        working-directory: docs-site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-site/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vitepress/dist/
+.vitepress/cache/

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -14,7 +14,6 @@ export default withMermaid(
     ],
 
     themeConfig: {
-      logo: '/logo.svg',
       siteTitle: 'Aether',
 
       nav: [

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -5,6 +5,7 @@ export default withMermaid(
   defineConfig({
     title: 'Aether',
     description: 'Production-grade cross-DEX arbitrage engine for Ethereum Mainnet',
+    base: '/aether/',
 
     head: [
       ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
@@ -85,7 +86,7 @@ export default withMermaid(
       },
 
       socialLinks: [
-        { icon: 'github', link: 'https://github.com/aether-arb/aether' },
+        { icon: 'github', link: 'https://github.com/Pablosinyores/aether' },
       ],
 
       search: {
@@ -93,7 +94,7 @@ export default withMermaid(
       },
 
       editLink: {
-        pattern: 'https://github.com/aether-arb/aether/edit/main/docs-site/:path',
+        pattern: 'https://github.com/Pablosinyores/aether/edit/main/docs-site/:path',
         text: 'Edit this page on GitHub',
       },
 

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -1,0 +1,110 @@
+import { defineConfig } from 'vitepress'
+import { withMermaid } from 'vitepress-plugin-mermaid'
+
+export default withMermaid(
+  defineConfig({
+    title: 'Aether',
+    description: 'Production-grade cross-DEX arbitrage engine for Ethereum Mainnet',
+
+    head: [
+      ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+      ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+      ['link', { href: 'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap', rel: 'stylesheet' }],
+    ],
+
+    themeConfig: {
+      logo: '/logo.svg',
+      siteTitle: 'Aether',
+
+      nav: [
+        { text: 'Guide', link: '/guide/introduction' },
+        { text: 'Architecture', link: '/architecture/overview' },
+        { text: 'Operations', link: '/operations/deployment' },
+        { text: 'Development', link: '/development/contributing' },
+        { text: 'Reference', link: '/reference/configuration' },
+      ],
+
+      sidebar: {
+        '/guide/': [
+          {
+            text: 'Guide',
+            items: [
+              { text: 'Introduction', link: '/guide/introduction' },
+              { text: 'How It Works', link: '/guide/how-it-works' },
+              { text: 'Getting Started', link: '/guide/getting-started' },
+              { text: 'Configuration', link: '/guide/configuration' },
+            ],
+          },
+        ],
+        '/architecture/': [
+          {
+            text: 'Architecture',
+            items: [
+              { text: 'Overview', link: '/architecture/overview' },
+              { text: 'Rust Core', link: '/architecture/rust-core' },
+              { text: 'Go Services', link: '/architecture/go-services' },
+              { text: 'Smart Contract', link: '/architecture/smart-contract' },
+              { text: 'gRPC Protocol', link: '/architecture/grpc-protocol' },
+              { text: 'Design Decisions', link: '/architecture/design-decisions' },
+            ],
+          },
+        ],
+        '/operations/': [
+          {
+            text: 'Operations',
+            items: [
+              { text: 'Deployment', link: '/operations/deployment' },
+              { text: 'Runbook', link: '/operations/runbook' },
+              { text: 'Incident Response', link: '/operations/incident-response' },
+              { text: 'Monitoring', link: '/operations/monitoring' },
+            ],
+          },
+        ],
+        '/development/': [
+          {
+            text: 'Development',
+            items: [
+              { text: 'Contributing', link: '/development/contributing' },
+              { text: 'Adding a DEX', link: '/development/adding-a-dex' },
+              { text: 'Testing', link: '/development/testing' },
+              { text: 'Tooling & Scripts', link: '/development/tooling' },
+            ],
+          },
+        ],
+        '/reference/': [
+          {
+            text: 'Reference',
+            items: [
+              { text: 'Configuration', link: '/reference/configuration' },
+              { text: 'Metrics', link: '/reference/metrics' },
+              { text: 'Risk Parameters', link: '/reference/risk-parameters' },
+              { text: 'gRPC API', link: '/reference/api' },
+            ],
+          },
+        ],
+      },
+
+      socialLinks: [
+        { icon: 'github', link: 'https://github.com/aether-arb/aether' },
+      ],
+
+      search: {
+        provider: 'local',
+      },
+
+      editLink: {
+        pattern: 'https://github.com/aether-arb/aether/edit/main/docs-site/:path',
+        text: 'Edit this page on GitHub',
+      },
+
+      footer: {
+        message: 'Released under the MIT License.',
+        copyright: 'Copyright 2024-present Aether Contributors',
+      },
+    },
+
+    mermaid: {
+      theme: 'dark',
+    },
+  })
+)

--- a/docs-site/.vitepress/theme/components/Accordion.vue
+++ b/docs-site/.vitepress/theme/components/Accordion.vue
@@ -1,0 +1,21 @@
+<script setup>
+</script>
+
+<template>
+  <div class="accordion">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.accordion {
+  border: 1px solid var(--vp-c-bg-soft);
+  border-radius: 12px;
+  overflow: hidden;
+  margin: 1.5rem 0;
+}
+
+.accordion :deep(.accordion-item + .accordion-item) {
+  border-top: 1px solid var(--vp-c-bg-soft);
+}
+</style>

--- a/docs-site/.vitepress/theme/components/AccordionItem.vue
+++ b/docs-site/.vitepress/theme/components/AccordionItem.vue
@@ -1,0 +1,119 @@
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  title: { type: String, required: true },
+  icon: { type: String, default: '' },
+})
+
+const open = ref(false)
+</script>
+
+<template>
+  <div class="accordion-item" :class="{ open }">
+    <button class="accordion-trigger" @click="open = !open">
+      <span class="trigger-content">
+        <span v-if="icon" class="trigger-icon">{{ icon }}</span>
+        <span class="trigger-title">{{ title }}</span>
+      </span>
+      <span class="trigger-chevron">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="6 9 12 15 18 9"></polyline>
+        </svg>
+      </span>
+    </button>
+    <div class="accordion-body">
+      <div class="accordion-content">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.accordion-item {
+  background: var(--vp-c-bg);
+}
+
+.accordion-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--vp-font-family-base);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  transition: background 0.2s ease;
+}
+
+.accordion-trigger:hover {
+  background: var(--vp-c-bg-soft);
+}
+
+.trigger-content {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.trigger-icon {
+  font-size: 1.1rem;
+}
+
+.trigger-chevron {
+  display: flex;
+  align-items: center;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  opacity: 0.5;
+}
+
+.open .trigger-chevron {
+  transform: rotate(180deg);
+}
+
+.accordion-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.open .accordion-body {
+  grid-template-rows: 1fr;
+}
+
+.accordion-content {
+  overflow: hidden;
+  padding: 0 1.25rem;
+}
+
+.open .accordion-content {
+  padding: 0 1.25rem 1.25rem;
+}
+
+.accordion-content :deep(p) {
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  opacity: 0.85;
+}
+
+.accordion-content :deep(code) {
+  font-size: 0.85rem;
+}
+
+.accordion-content :deep(ul) {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+
+.accordion-content :deep(li) {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+</style>

--- a/docs-site/.vitepress/theme/components/AnimatedCard.vue
+++ b/docs-site/.vitepress/theme/components/AnimatedCard.vue
@@ -1,0 +1,102 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+defineProps({
+  title: String,
+  icon: { type: String, default: '' },
+})
+
+const visible = ref(false)
+const card = ref(null)
+
+onMounted(() => {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        visible.value = true
+        observer.disconnect()
+      }
+    },
+    { threshold: 0.1 }
+  )
+  if (card.value) observer.observe(card.value)
+})
+</script>
+
+<template>
+  <div
+    ref="card"
+    class="animated-card"
+    :class="{ visible }"
+  >
+    <div class="card-glow" />
+    <div v-if="icon" class="card-icon">{{ icon }}</div>
+    <h3 v-if="title" class="card-title">{{ title }}</h3>
+    <div class="card-content">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.animated-card {
+  position: relative;
+  background: var(--vp-c-bg-alt);
+  border: 1px solid var(--vp-c-bg-soft);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin: 0.75rem 0;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.animated-card.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.animated-card:hover {
+  border-color: var(--vp-c-brand-soft);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(124, 106, 246, 0.08);
+}
+
+.card-glow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--vp-c-brand-1), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.animated-card:hover .card-glow {
+  opacity: 1;
+}
+
+.card-icon {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.card-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.01em;
+}
+
+.card-content {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.card-content :deep(p) {
+  margin: 0;
+}
+</style>

--- a/docs-site/.vitepress/theme/components/Timeline.vue
+++ b/docs-site/.vitepress/theme/components/Timeline.vue
@@ -1,0 +1,32 @@
+<script setup>
+</script>
+
+<template>
+  <div class="timeline">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.timeline {
+  position: relative;
+  margin: 2rem 0;
+  padding-left: 2rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 7px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    var(--vp-c-brand-1),
+    var(--vp-c-brand-3),
+    var(--vp-c-bg-soft)
+  );
+  border-radius: 1px;
+}
+</style>

--- a/docs-site/.vitepress/theme/components/TimelineItem.vue
+++ b/docs-site/.vitepress/theme/components/TimelineItem.vue
@@ -1,0 +1,143 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+defineProps({
+  time: { type: String, default: '' },
+  title: { type: String, required: true },
+  color: { type: String, default: 'brand' },
+})
+
+const visible = ref(false)
+const item = ref(null)
+
+onMounted(() => {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        visible.value = true
+        observer.disconnect()
+      }
+    },
+    { threshold: 0.2 }
+  )
+  if (item.value) observer.observe(item.value)
+})
+</script>
+
+<template>
+  <div
+    ref="item"
+    class="timeline-item"
+    :class="{ visible }"
+  >
+    <div class="timeline-dot" :class="color" />
+    <div class="timeline-card">
+      <div class="timeline-header">
+        <span v-if="time" class="timeline-time">{{ time }}</span>
+        <span class="timeline-title">{{ title }}</span>
+      </div>
+      <div class="timeline-body">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.5rem;
+  opacity: 0;
+  transform: translateX(-12px);
+  transition: all 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.timeline-item.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.timeline-item:nth-child(1) { transition-delay: 0.05s; }
+.timeline-item:nth-child(2) { transition-delay: 0.1s; }
+.timeline-item:nth-child(3) { transition-delay: 0.15s; }
+.timeline-item:nth-child(4) { transition-delay: 0.2s; }
+.timeline-item:nth-child(5) { transition-delay: 0.25s; }
+.timeline-item:nth-child(6) { transition-delay: 0.3s; }
+.timeline-item:nth-child(7) { transition-delay: 0.35s; }
+.timeline-item:nth-child(8) { transition-delay: 0.4s; }
+
+.timeline-dot {
+  position: absolute;
+  left: -1.65rem;
+  top: 0.85rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--vp-c-brand-1);
+  background: var(--vp-c-bg);
+  z-index: 1;
+  transition: all 0.3s ease;
+}
+
+.timeline-item.visible .timeline-dot {
+  background: var(--vp-c-brand-1);
+  box-shadow: 0 0 8px rgba(124, 106, 246, 0.4);
+}
+
+.timeline-dot.green {
+  border-color: #10b981;
+}
+.timeline-item.visible .timeline-dot.green {
+  background: #10b981;
+  box-shadow: 0 0 8px rgba(16, 185, 129, 0.4);
+}
+
+.timeline-card {
+  background: var(--vp-c-bg-alt);
+  border: 1px solid var(--vp-c-bg-soft);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  transition: border-color 0.3s ease;
+}
+
+.timeline-item:hover .timeline-card {
+  border-color: var(--vp-c-brand-soft);
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.timeline-time {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.timeline-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.timeline-body {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  opacity: 0.8;
+}
+
+.timeline-body :deep(p) {
+  margin: 0.25rem 0;
+}
+
+.timeline-body :deep(code) {
+  font-size: 0.8rem;
+}
+</style>

--- a/docs-site/.vitepress/theme/custom.css
+++ b/docs-site/.vitepress/theme/custom.css
@@ -1,0 +1,253 @@
+/* ── Fonts ── */
+:root {
+  --vp-font-family-base: 'Space Grotesk', sans-serif;
+  --vp-font-family-mono: 'JetBrains Mono', monospace;
+}
+
+/* ── Brand Colors ── */
+:root {
+  --vp-c-brand-1: #7c6af6;
+  --vp-c-brand-2: #9580ff;
+  --vp-c-brand-3: #b4a0ff;
+  --vp-c-brand-soft: rgba(124, 106, 246, 0.14);
+}
+
+.dark {
+  --vp-c-brand-1: #9580ff;
+  --vp-c-brand-2: #b4a0ff;
+  --vp-c-brand-3: #d0c4ff;
+  --vp-c-brand-soft: rgba(149, 128, 255, 0.16);
+
+  --vp-c-bg: #0f0f14;
+  --vp-c-bg-alt: #15151c;
+  --vp-c-bg-elv: #1a1a24;
+  --vp-c-bg-soft: #1e1e2a;
+}
+
+/* ── Hero Section ── */
+.VPHero .name {
+  background: linear-gradient(135deg, #9580ff 0%, #6c5ce7 50%, #a29bfe 100%) !important;
+  -webkit-background-clip: text !important;
+  -webkit-text-fill-color: transparent !important;
+  background-clip: text !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.02em;
+}
+
+.VPHero .text {
+  font-weight: 600 !important;
+  letter-spacing: -0.01em;
+}
+
+.VPHero .tagline {
+  font-size: 1.1rem !important;
+  line-height: 1.6 !important;
+  opacity: 0.85;
+}
+
+/* Hero gradient glow */
+.VPHero .image-bg {
+  background: radial-gradient(circle at center, rgba(124, 106, 246, 0.2) 0%, transparent 70%) !important;
+  animation: pulse-glow 4s ease-in-out infinite;
+}
+
+@keyframes pulse-glow {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.05); }
+}
+
+/* ── Feature Cards ── */
+.VPFeatures .VPFeature {
+  border: 1px solid var(--vp-c-bg-soft);
+  border-radius: 12px;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.VPFeatures .VPFeature::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--vp-c-brand-1), transparent);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.VPFeatures .VPFeature:hover {
+  transform: translateY(-4px);
+  border-color: var(--vp-c-brand-soft);
+  box-shadow: 0 12px 40px rgba(124, 106, 246, 0.12);
+}
+
+.VPFeatures .VPFeature:hover::before {
+  opacity: 1;
+}
+
+.VPFeature .title {
+  font-weight: 600 !important;
+  letter-spacing: -0.01em;
+}
+
+.VPFeature .details {
+  opacity: 0.8;
+  line-height: 1.6;
+}
+
+/* ── Staggered feature card entrance ── */
+.VPFeatures .VPFeature {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: card-enter 0.5s ease forwards;
+}
+
+.VPFeatures .VPFeature:nth-child(1) { animation-delay: 0.1s; }
+.VPFeatures .VPFeature:nth-child(2) { animation-delay: 0.2s; }
+.VPFeatures .VPFeature:nth-child(3) { animation-delay: 0.3s; }
+.VPFeatures .VPFeature:nth-child(4) { animation-delay: 0.4s; }
+.VPFeatures .VPFeature:nth-child(5) { animation-delay: 0.5s; }
+.VPFeatures .VPFeature:nth-child(6) { animation-delay: 0.6s; }
+
+@keyframes card-enter {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Sidebar ── */
+.VPSidebar .group .text {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* ── Content ── */
+.vp-doc h1 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--vp-c-brand-1), var(--vp-c-brand-3));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.vp-doc h2 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  border-bottom: 1px solid var(--vp-c-bg-soft);
+  padding-bottom: 0.5rem;
+}
+
+.vp-doc h3 {
+  font-weight: 600;
+}
+
+/* ── Code blocks ── */
+.vp-doc div[class*='language-'] {
+  border-radius: 10px;
+  border: 1px solid var(--vp-c-bg-soft);
+}
+
+.dark .vp-doc div[class*='language-'] {
+  background-color: #12121a !important;
+}
+
+/* ── Tables ── */
+.vp-doc table {
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-bg-soft);
+}
+
+.vp-doc th {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  background: var(--vp-c-bg-soft) !important;
+}
+
+.vp-doc tr {
+  transition: background 0.2s ease;
+}
+
+.vp-doc tr:hover {
+  background: var(--vp-c-bg-soft);
+}
+
+/* ── Custom containers (tip, warning, danger) ── */
+.vp-doc .custom-block {
+  border-radius: 10px;
+  border-left-width: 3px;
+}
+
+/* ── Mermaid diagrams ── */
+.mermaid {
+  background: var(--vp-c-bg-alt) !important;
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid var(--vp-c-bg-soft);
+  margin: 1.5rem 0;
+}
+
+/* ── Smooth page transitions ── */
+.VPContent {
+  animation: page-fade 0.3s ease;
+}
+
+@keyframes page-fade {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Nav bar blur ── */
+.VPNav {
+  backdrop-filter: blur(12px) !important;
+}
+
+.dark .VPNav {
+  background: rgba(15, 15, 20, 0.85) !important;
+}
+
+/* ── Scrollbar (dark mode) ── */
+.dark ::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dark ::-webkit-scrollbar-track {
+  background: var(--vp-c-bg);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: var(--vp-c-bg-soft);
+  border-radius: 3px;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: var(--vp-c-brand-soft);
+}
+
+/* ── Action buttons ── */
+.VPHero .actions .VPButton.brand {
+  background: linear-gradient(135deg, #7c6af6, #6c5ce7) !important;
+  border: none !important;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.VPHero .actions .VPButton.brand:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(124, 106, 246, 0.3);
+}
+
+.VPHero .actions .VPButton.alt {
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.VPHero .actions .VPButton.alt:hover {
+  transform: translateY(-2px);
+}

--- a/docs-site/.vitepress/theme/index.ts
+++ b/docs-site/.vitepress/theme/index.ts
@@ -1,0 +1,19 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import AnimatedCard from './components/AnimatedCard.vue'
+import Accordion from './components/Accordion.vue'
+import AccordionItem from './components/AccordionItem.vue'
+import Timeline from './components/Timeline.vue'
+import TimelineItem from './components/TimelineItem.vue'
+import './custom.css'
+
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('AnimatedCard', AnimatedCard)
+    app.component('Accordion', Accordion)
+    app.component('AccordionItem', AccordionItem)
+    app.component('Timeline', Timeline)
+    app.component('TimelineItem', TimelineItem)
+  },
+} satisfies Theme

--- a/docs-site/architecture/design-decisions.md
+++ b/docs-site/architecture/design-decisions.md
@@ -1,0 +1,118 @@
+# Design Decisions
+
+This page explains the key architectural choices in Aether and the reasoning behind them.
+
+## Rust for Hot Path, Go for Coordination
+
+**Decision:** All latency-critical code (ingestion, detection, simulation) is written in Rust. All coordination code (execution, risk, monitoring) is written in Go.
+
+**Why:** MEV arbitrage is a latency competition. The bot that detects and submits fastest wins. Rust's zero-cost abstractions, control over memory layout, and lack of garbage collector are critical for sub-millisecond detection. But Rust's ecosystem for network coordination (HTTP clients, Prometheus, concurrent goroutine-style patterns) is less mature than Go's. Go excels at concurrent network I/O — exactly what bundle submission and monitoring need.
+
+**Tradeoff:** Two languages means two build systems, two sets of dependencies, and a serialization boundary (gRPC). The ~1μs gRPC overhead is negligible compared to the performance gains.
+
+## Negative Log Edge Weights (`-ln(rate)`)
+
+**Decision:** Exchange rates in the price graph are stored as `-ln(rate)` instead of raw rates.
+
+**Why:** Arbitrage detection is fundamentally about finding cycles where the product of exchange rates exceeds 1.0:
+
+```
+rate_1 × rate_2 × ... × rate_n > 1.0
+```
+
+By taking `-ln()` of each rate, this multiplicative condition becomes additive:
+
+```
+-ln(rate_1) + -ln(rate_2) + ... + -ln(rate_n) < 0
+```
+
+A **negative sum** around a cycle means a profitable trade. This transforms the problem into classic negative cycle detection — exactly what Bellman-Ford solves.
+
+**Tradeoff:** Floating-point precision loss in the log transformation. Mitigated by using `f64` (which has more than enough precision for exchange rate ratios) and validating with full-precision U256 simulation before execution.
+
+## SPFA over Standard Bellman-Ford
+
+**Decision:** Use SPFA (Shortest Path Faster Algorithm) with SLF (Shortest-Label-First) optimization instead of standard Bellman-Ford.
+
+**Why:** Standard Bellman-Ford relaxes all edges V-1 times (O(V×E)). SPFA uses a queue-based approach that only processes nodes whose distances were actually updated. For the sparse, partially-updated graphs typical in DEX arbitrage, SPFA is 2-3x faster.
+
+SLF further optimizes by inserting nodes with shorter labels at the front of the deque instead of the back, reducing redundant relaxations.
+
+**Tradeoff:** SPFA has the same worst-case complexity as standard Bellman-Ford (O(V×E)), but in practice the average case is much faster for sparse graphs with localized updates.
+
+## MVCC Snapshots for Price Graph
+
+**Decision:** The price graph uses MVCC (Multi-Version Concurrency Control) via `Arc<ArcSwap<GraphSnapshot>>`.
+
+**Why:** The detection engine reads the price graph while the ingestion engine writes to it. A naive approach (RwLock) would block the detection engine during writes — unacceptable on the hot path. MVCC eliminates this:
+
+- **Writers** create a new graph snapshot and atomically swap it in
+- **Readers** hold a reference to an immutable snapshot — no locks, no blocking
+- Old snapshots are automatically freed when all readers release their references
+
+**Tradeoff:** Higher memory usage (multiple graph versions in flight). In practice, only 2-3 versions exist simultaneously, and the graph is small enough (~5K nodes, ~20K edges) that this is negligible.
+
+## Flash Loan Execution (Zero Capital at Risk)
+
+**Decision:** All arbitrage trades use Aave V3 flash loans. The bot holds no trading capital.
+
+**Why:**
+1. **Zero capital risk** — If a trade is unprofitable, the flash loan reverts atomically. No capital is ever lost.
+2. **No capital requirements** — The bot only needs ~0.5 ETH for gas. Flash loans provide the trading capital.
+3. **Larger trade sizes** — Can execute trades up to the flash loan pool depth (millions of dollars), far more than any capital the bot could hold.
+
+**Tradeoff:** Flash loan premium (0.05% on Aave V3) reduces profit margins. For most arbitrage opportunities, this is negligible compared to the profit.
+
+## Multi-Builder Bundle Submission
+
+**Decision:** Submit bundles to all configured block builders simultaneously (Flashbots, Titan, Beaver, rsync).
+
+**Why:** No single builder produces every block. By submitting to all builders, the probability of bundle inclusion increases from ~15-20% (single builder) to ~50-70% (all major builders).
+
+**Tradeoff:** Bundle contents are visible to all builders. This is acceptable because:
+- Bundles are already signed and target a specific block
+- Builder competition incentivizes inclusion (they keep the tip)
+- Private mempool (Flashbots Protect) prevents public frontrunning
+
+## gRPC over Unix Domain Sockets
+
+**Decision:** Rust and Go communicate via gRPC over UDS instead of TCP, shared memory, or direct FFI.
+
+**Why:**
+- **UDS** adds sub-microsecond latency (vs ~100μs for TCP localhost)
+- **gRPC** provides structured schemas, streaming, and ecosystem tooling
+- **Protobuf** gives a single source of truth for message types across Rust and Go
+- **vs. shared memory:** More complex, error-prone, and only marginally faster for the message sizes involved
+- **vs. FFI:** Would tightly couple Rust and Go, complicating deployment and debugging
+
+**Tradeoff:** Protobuf serialization/deserialization adds ~1-5μs overhead. Acceptable given the overall 15ms pipeline budget.
+
+## DashMap over RwLock for Pool State
+
+**Decision:** Pool states are stored in `DashMap<Address, Box<dyn Pool>>` instead of a `HashMap` behind an `RwLock`.
+
+**Why:** `DashMap` is a concurrent hashmap with fine-grained locking (sharded internally). Multiple ingestion tasks can update different pools simultaneously without blocking each other or blocking the detection engine.
+
+**Tradeoff:** Slightly higher per-operation overhead than a raw `HashMap`. Negligible compared to the contention cost of a single `RwLock`.
+
+## Tiered Pool Management (Hot/Warm/Cold)
+
+**Decision:** Pools are classified into tiers with different update frequencies.
+
+**Why:** Monitoring 5,000+ pools at full frequency wastes CPU on pools with minimal activity. Tiering focuses resources:
+
+| Tier | Frequency | Criteria |
+|---|---|---|
+| Hot | Every block | High liquidity, high volume, frequently arbed |
+| Warm | Every N blocks | Medium liquidity, moderate volume |
+| Cold | On-demand | Low liquidity, checked only when price graph changes suggest opportunity |
+
+**Tradeoff:** Cold pools may have stale state, causing missed opportunities. Mitigated by the qualification pipeline promoting pools that show activity.
+
+## EIP-1559 Transactions (not legacy)
+
+**Decision:** All transactions use EIP-1559 `DynamicFeeTx` format.
+
+**Why:** EIP-1559 transactions have more predictable inclusion behavior. The `maxFeePerGas` / `maxPriorityFeePerGas` split allows precise control over gas bidding. Legacy transactions with a single `gasPrice` can overpay when base fee fluctuates.
+
+**Tradeoff:** None significant. EIP-1559 is the standard for all modern Ethereum transactions.

--- a/docs-site/architecture/go-services.md
+++ b/docs-site/architecture/go-services.md
@@ -141,13 +141,13 @@ HTTP dashboard server on `:8080` providing:
 
 ### Alerter (`alerter.go`)
 
-Dispatches alerts to multiple channels based on severity:
+Dispatches alerts to **Slack** with severity-based channel routing:
 
 | Channel | Severity | Configuration |
 |---|---|---|
-| PagerDuty | SEV1, SEV2 | `config/risk.yaml → alerting.pagerduty` |
-| Telegram | SEV2, SEV3 | `config/risk.yaml → alerting.telegram` |
-| Discord | All | `config/risk.yaml → alerting.discord` |
+| `#aether-alerts-sev1` | SEV1 | `config/risk.yaml → alerting.slack` |
+| `#aether-alerts-sev2` | SEV2 | `config/risk.yaml → alerting.slack` |
+| `#aether-alerts` | SEV3, SEV4 | `config/risk.yaml → alerting.slack` |
 
 ## Runtime Configuration
 

--- a/docs-site/architecture/go-services.md
+++ b/docs-site/architecture/go-services.md
@@ -1,0 +1,161 @@
+# Go Services
+
+The Go execution layer receives validated arbitrage opportunities from the Rust core and handles bundle construction, submission, risk management, and monitoring. It consists of three services in the `cmd/` directory.
+
+## `cmd/executor/` — Bundle Construction & Submission
+
+### Bundle Structure
+
+Every Flashbots bundle contains two transactions:
+
+1. **Arb transaction** — Calls `AetherExecutor.executeArb()` with the swap steps
+2. **Tip transaction** — Sends a share of expected profit to the builder's coinbase address
+
+```
+Bundle = [arb_tx, tip_tx]
+```
+
+### Transaction Construction (`bundle.go`)
+
+Arb transactions use **EIP-1559 `DynamicFeeTx`** with:
+- `maxFeePerGas` = current base fee + suggested priority fee
+- `maxPriorityFeePerGas` = from the gas oracle
+- `to` = `AetherExecutor` contract address
+- `data` = `executeArb()` calldata (received from Rust via gRPC)
+
+The tip transaction sends **90% of expected profit** to `block.coinbase` to incentivize builders to include the bundle.
+
+### Multi-Builder Submission (`submitter.go`)
+
+Bundles are submitted to all configured builders **simultaneously** via goroutine fan-out:
+
+```mermaid
+graph LR
+    B["Signed Bundle"] --> G1["goroutine"]
+    B --> G2["goroutine"]
+    B --> G3["goroutine"]
+    B --> G4["goroutine"]
+
+    G1 --> FB["Flashbots"]
+    G2 --> TT["Titan"]
+    G3 --> BV["Beaver"]
+    G4 --> RC["rsync"]
+
+    style B fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+```
+
+Each builder receives `eth_sendBundle` with the target block number. The first builder to include the bundle wins.
+
+Submission respects `context.Context` for cancellation — if the target block passes, all pending submissions are cancelled.
+
+### Nonce Management (`nonce.go`)
+
+- **Atomic local counter** — Incremented on each transaction, lock-free via `sync/atomic`
+- **Periodic sync** — `eth_getTransactionCount` every N blocks to correct drift
+- **Pending tracker** — Tracks in-flight transactions to avoid nonce gaps
+
+### Gas Oracle (`gas_oracle.go`)
+
+EIP-1559 base fee prediction and priority fee estimation:
+
+- Tracks base fee trends across recent blocks
+- Suggests priority fee based on builder competition
+- Feeds into both arb transaction construction and profitability calculations
+
+## `cmd/risk/` — Risk Management
+
+### System State Machine (`state.go`)
+
+The risk manager maintains a finite state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running
+    Running --> Degraded: node latency > 500ms
+    Degraded --> Running: condition clears
+    Running --> Paused: consecutive reverts
+    Paused --> Running: 10min cooldown
+    Running --> Halted: gas / loss / balance
+    Degraded --> Halted: gas / loss / balance
+    Halted --> Running: manual reset
+```
+
+| State | Meaning | Recovery |
+|---|---|---|
+| **Running** | Normal operation | — |
+| **Degraded** | Reduced functionality (e.g., high node latency) | Automatic when condition clears |
+| **Paused** | Detection paused (e.g., consecutive reverts) | Automatic after cooldown (10 min) |
+| **Halted** | All operations stopped | **Manual reset required** |
+
+### Circuit Breakers (`manager.go`)
+
+The `PreflightCheck` function runs before every bundle submission:
+
+| Condition | Action |
+|---|---|
+| Gas price >300 gwei | **HALT** |
+| 10 consecutive reverts in 10 min | **PAUSE** |
+| Daily loss >0.5 ETH | **HALT** |
+| ETH balance <0.1 ETH | **HALT** |
+| Node latency >500ms | **DEGRADE** |
+| Bundle miss rate >80% in 1 hour | **ALERT** |
+
+Each circuit breaker is implemented as a stateful controller using `sync/atomic` for lock-free state transitions.
+
+### Position Limits
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| Max single trade | 50 ETH | Cap per-trade exposure |
+| Max daily volume | 500 ETH | Cap daily throughput |
+| Min profit | 0.001 ETH | Reject dust-level opportunities |
+| Min tip share | 50% | Minimum builder incentive |
+| Max tip share | 95% | Retain minimum profit |
+
+## `cmd/monitor/` — Monitoring & Observability
+
+### Prometheus Metrics (`metrics.go`)
+
+Exposes all system metrics on `:9090/metrics`. Key metrics include:
+
+- `aether_opportunities_detected_total` (Counter) — Arbitrage opportunities found
+- `aether_bundles_submitted_total` (Counter) — Bundles submitted to builders
+- `aether_bundles_included_total` (Counter) — Bundles included on-chain
+- `aether_detection_latency_ms` (Histogram) — Detection pipeline latency
+- `aether_simulation_latency_ms` (Histogram) — EVM simulation latency
+- `aether_end_to_end_latency_ms` (Histogram) — Full pipeline latency
+- `aether_gas_price_gwei` (Gauge) — Current gas price
+- `aether_daily_pnl_eth` (Gauge) — Daily profit/loss
+- `aether_eth_balance` (Gauge) — Searcher wallet balance
+
+See [Metrics Reference](/reference/metrics) for the complete list.
+
+### Dashboard (`dashboard.go`)
+
+HTTP dashboard server on `:8080` providing:
+
+- Real-time system state and health status
+- Recent opportunities and bundle results
+- Performance metrics and latency percentiles
+- Circuit breaker status
+
+### Alerter (`alerter.go`)
+
+Dispatches alerts to multiple channels based on severity:
+
+| Channel | Severity | Configuration |
+|---|---|---|
+| PagerDuty | SEV1, SEV2 | `config/risk.yaml → alerting.pagerduty` |
+| Telegram | SEV2, SEV3 | `config/risk.yaml → alerting.telegram` |
+| Discord | All | `config/risk.yaml → alerting.discord` |
+
+## Runtime Configuration
+
+The Go executor uses these production settings:
+
+```
+GOMAXPROCS=2      # Limit to 2 OS threads (pinned to CPU 4-5)
+GOGC=200          # Reduce GC frequency (trade memory for latency)
+```
+
+All goroutines must respect `context.Context` for cancellation propagation. The executor gracefully drains in-flight bundles on shutdown.

--- a/docs-site/architecture/grpc-protocol.md
+++ b/docs-site/architecture/grpc-protocol.md
@@ -1,0 +1,219 @@
+# gRPC Protocol
+
+Aether uses gRPC over Unix Domain Sockets for communication between the Rust core and Go execution layer. The Protobuf schema in `proto/aether.proto` is the single source of truth.
+
+## Transport
+
+- **Protocol:** gRPC (HTTP/2)
+- **Transport:** Unix Domain Socket (sub-microsecond latency)
+- **Serialization:** Protocol Buffers v3
+- **Rust framework:** `tonic`
+- **Go framework:** `google.golang.org/grpc`
+
+UDS was chosen over TCP because both services run on the same machine. UDS eliminates the network stack entirely — data transfer is effectively a memory copy.
+
+## Services
+
+### ArbService
+
+Handles arbitrage opportunity flow from Rust to Go.
+
+```protobuf
+service ArbService {
+    rpc SubmitArb(ValidatedArb) returns (SubmitArbResponse);
+    rpc StreamArbs(StreamArbsRequest) returns (stream ValidatedArb);
+}
+```
+
+**`SubmitArb`** — Single arb submission. Rust sends a validated opportunity, Go returns acceptance status and bundle hash.
+
+**`StreamArbs`** — Server-side streaming. Go subscribes to a stream of opportunities from Rust, optionally filtered by minimum profit threshold.
+
+### HealthService
+
+Health checks from Go to Rust.
+
+```protobuf
+service HealthService {
+    rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+}
+```
+
+Returns engine health including: healthy/unhealthy status, uptime, last processed block, and active pool count.
+
+### ControlService
+
+Operational control from Go to Rust.
+
+```protobuf
+service ControlService {
+    rpc SetState(SetStateRequest) returns (SetStateResponse);
+    rpc ReloadConfig(ReloadConfigRequest) returns (ReloadConfigResponse);
+}
+```
+
+**`SetState`** — Pause/resume the detection engine. Used by the risk manager to halt detection when circuit breakers trip.
+
+**`ReloadConfig`** — Hot-reload the pool configuration (`pools.toml`) without restarting the Rust core.
+
+## Enums
+
+### ProtocolType
+
+```protobuf
+enum ProtocolType {
+    PROTOCOL_UNKNOWN = 0;
+    UNISWAP_V2 = 1;
+    UNISWAP_V3 = 2;
+    SUSHISWAP = 3;
+    CURVE = 4;
+    BALANCER_V2 = 5;
+    BANCOR_V3 = 6;
+}
+```
+
+Maps 1:1 with the Rust `ProtocolType` enum and the Solidity protocol constants in `AetherExecutor.sol`.
+
+### SystemState
+
+```protobuf
+enum SystemState {
+    STATE_UNKNOWN = 0;
+    RUNNING = 1;
+    DEGRADED = 2;
+    PAUSED = 3;
+    HALTED = 4;
+}
+```
+
+## Messages
+
+### ValidatedArb
+
+The core message — a simulation-verified arbitrage opportunity:
+
+```protobuf
+message ValidatedArb {
+    string id = 1;                    // Unique opportunity ID
+    repeated ArbHop hops = 2;         // Hop sequence (detection output)
+    bytes total_profit_wei = 3;       // Gross profit in wei
+    uint64 total_gas = 4;             // Estimated total gas
+    bytes gas_cost_wei = 5;           // Gas cost in wei
+    bytes net_profit_wei = 6;         // Net profit (gross - gas - premium)
+    uint64 block_number = 7;          // Target block number
+    int64 timestamp_ns = 8;           // Detection timestamp (nanoseconds)
+    bytes flashloan_token = 9;        // Token to borrow
+    bytes flashloan_amount = 10;      // Amount to borrow
+    repeated SwapStep steps = 11;     // Execution steps (for calldata)
+    bytes calldata = 12;              // Pre-built AetherExecutor calldata
+}
+```
+
+### ArbHop
+
+A single hop in the arbitrage path (detection-level detail):
+
+```protobuf
+message ArbHop {
+    ProtocolType protocol = 1;
+    bytes pool_address = 2;
+    bytes token_in = 3;
+    bytes token_out = 4;
+    bytes amount_in = 5;
+    bytes expected_out = 6;
+    uint64 estimated_gas = 7;
+}
+```
+
+### SwapStep
+
+A single swap step for on-chain execution:
+
+```protobuf
+message SwapStep {
+    ProtocolType protocol = 1;
+    bytes pool_address = 2;
+    bytes token_in = 3;
+    bytes token_out = 4;
+    bytes amount_in = 5;
+    bytes min_amount_out = 6;
+    bytes calldata = 7;
+}
+```
+
+### Request/Response Messages
+
+```protobuf
+message SubmitArbResponse {
+    bool accepted = 1;
+    string bundle_hash = 2;
+    string error = 3;
+}
+
+message StreamArbsRequest {
+    double min_profit_eth = 1;    // Minimum net profit filter
+}
+
+message HealthCheckResponse {
+    bool healthy = 1;
+    string status = 2;
+    int64 uptime_seconds = 3;
+    uint64 last_block = 4;
+    uint32 active_pools = 5;
+}
+
+message SetStateRequest {
+    SystemState state = 1;
+    string reason = 2;
+}
+
+message SetStateResponse {
+    bool success = 1;
+    SystemState previous_state = 2;
+}
+
+message ReloadConfigRequest {
+    string config_path = 1;
+}
+
+message ReloadConfigResponse {
+    bool success = 1;
+    uint32 pools_loaded = 2;
+    string error = 3;
+}
+```
+
+## Usage Examples
+
+### Check Engine Health
+
+```bash
+grpcurl -plaintext localhost:50051 aether.HealthService/Check
+```
+
+### Pause Detection
+
+```bash
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "PAUSED", "reason": "manual maintenance"}'
+```
+
+### Resume Detection
+
+```bash
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+```
+
+### Hot-Reload Pool Config
+
+```bash
+grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig
+```
+
+### Stream Opportunities (min 0.01 ETH profit)
+
+```bash
+grpcurl -plaintext localhost:50051 aether.ArbService/StreamArbs \
+    -d '{"min_profit_eth": 0.01}'
+```

--- a/docs-site/architecture/overview.md
+++ b/docs-site/architecture/overview.md
@@ -1,0 +1,224 @@
+# Architecture Overview
+
+Aether is organized into three distinct layers — a Rust core for latency-critical work, a Go coordination layer for execution and monitoring, and a Solidity contract for on-chain settlement.
+
+## System Diagram
+
+```mermaid
+graph TB
+    subgraph ETH["Ethereum Network"]
+        N1["Alchemy WS"]
+        N2["QuickNode WS"]
+        N3["Local Reth IPC"]
+    end
+
+    subgraph RUST["Rust Core — Latency-Critical Path"]
+        direction TB
+        IG["Ingestion<br/><i>WebSocket, ABI decode</i>"]
+        PR["Pool Registry<br/><i>6 DEX protocols</i>"]
+        SM["State Management<br/><i>Price graph, MVCC</i>"]
+        DT["Detector<br/><i>Bellman-Ford SPFA</i>"]
+        SIM["Simulator<br/><i>revm fork mode</i>"]
+        GRPC["gRPC Server<br/><i>tonic</i>"]
+
+        IG --> PR --> SM --> DT --> SIM --> GRPC
+    end
+
+    subgraph GO["Go Execution Layer — Coordination"]
+        direction TB
+        EX["Executor<br/><i>Bundle build + sign</i>"]
+        RS["Risk Manager<br/><i>Circuit breakers</i>"]
+        MN["Monitor<br/><i>Prometheus, alerts</i>"]
+        GO_G["Gas Oracle<br/><i>EIP-1559</i>"]
+
+        RS -.->|"PreflightCheck"| EX
+        GO_G -.->|"fee estimate"| EX
+        MN -.->|"metrics"| RS
+    end
+
+    subgraph BUILDERS["Block Builders"]
+        FB["Flashbots"]
+        TT["Titan"]
+        BV["Beaver"]
+        RC["rsync"]
+    end
+
+    subgraph CHAIN["On-Chain"]
+        AE["AetherExecutor.sol"]
+        AAVE["Aave V3 Flash Loans"]
+        DEXES["DEX Pools"]
+
+        AE --> AAVE
+        AAVE --> AE
+        AE --> DEXES
+    end
+
+    N1 & N2 & N3 -->|events| IG
+    GRPC -->|"gRPC over UDS<br/>‹1μs"| EX
+    EX -->|"eth_sendBundle"| FB & TT & BV & RC
+    FB & TT & BV & RC --> AE
+
+    style RUST fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style GO fill:#151a20,stroke:#5ce6c7,stroke-width:2px,color:#fff
+    style CHAIN fill:#1a1815,stroke:#f5a623,stroke-width:2px,color:#fff
+    style ETH fill:#15151c,stroke:#666,stroke-width:1px,color:#fff
+    style BUILDERS fill:#15151c,stroke:#666,stroke-width:1px,color:#fff
+```
+
+## Layer Responsibilities
+
+### Rust Core (Latency-Critical)
+
+The Rust core handles everything on the hot path — from event ingestion to validated arbitrage output.
+
+<Accordion>
+  <AccordionItem title="Ingestion — WebSocket event processing">
+
+Manages 3+ node connections with automatic failover. ABI decoding via `alloy::sol!` at compile time. Lock-free broadcast channels for event dispatch.
+
+  </AccordionItem>
+  <AccordionItem title="Pools — 6 DEX protocol implementations">
+
+Uniswap V2/V3, SushiSwap, Curve, Balancer, Bancor. Each implements the `Pool` trait. Factory monitoring for new pool discovery. Tiered management (Hot/Warm/Cold).
+
+  </AccordionItem>
+  <AccordionItem title="State — Price graph and MVCC snapshots">
+
+Directed graph with `-ln(rate)` edge weights. Dirty bit tracking for incremental updates. Lock-free MVCC via `Arc<ArcSwap<GraphSnapshot>>` — readers never block writers.
+
+  </AccordionItem>
+  <AccordionItem title="Detector — Bellman-Ford arbitrage detection">
+
+SPFA variant with SLF optimization, 2-3x faster than standard. Ternary search for optimal input. Per-protocol gas estimation.
+
+  </AccordionItem>
+  <AccordionItem title="Simulator — EVM simulation via revm">
+
+Fork latest block into `CacheDB`, execute exact calldata, validate profit. Must use same block state as execution target.
+
+  </AccordionItem>
+  <AccordionItem title="gRPC Server — Binary entry point">
+
+tonic-based gRPC server exposing `ArbService`, `HealthService`, `ControlService`. Listens on Unix Domain Socket.
+
+  </AccordionItem>
+</Accordion>
+
+See [Rust Core](/architecture/rust-core) for a deep dive into each crate.
+
+### Go Execution Layer (Coordination)
+
+<Accordion>
+  <AccordionItem title="Executor — Bundle construction and submission">
+
+Builds Flashbots bundles (arb_tx + tip_tx), signs with searcher key, fans out to all builders via goroutines. Atomic nonce management.
+
+  </AccordionItem>
+  <AccordionItem title="Risk Manager — Circuit breakers and limits">
+
+State machine: Running / Degraded / Paused / Halted. Circuit breakers for gas price, reverts, daily loss, balance. Position limits for trade size, volume, and tip share.
+
+  </AccordionItem>
+  <AccordionItem title="Monitor — Prometheus and alerting">
+
+Exposes all metrics on `:9090/metrics`. HTTP dashboard on `:8080`. Alert dispatch to PagerDuty, Telegram, Discord.
+
+  </AccordionItem>
+</Accordion>
+
+See [Go Services](/architecture/go-services) for details.
+
+### On-Chain (Solidity)
+
+`AetherExecutor.sol` receives flash loans from Aave V3 and executes multi-hop swaps. If any trade is unprofitable, it reverts atomically.
+
+See [Smart Contract](/architecture/smart-contract) for the contract walkthrough.
+
+## Data Flow
+
+<Timeline>
+  <TimelineItem time="< 1ms" title="Event Ingestion">
+
+WebSocket event arrives → ABI decoded → pool state updated → price graph edges recomputed
+
+  </TimelineItem>
+  <TimelineItem time="< 3ms" title="Detection">
+
+Bellman-Ford scans dirty subgraph → negative cycle found → input optimized → gas estimated
+
+  </TimelineItem>
+  <TimelineItem time="< 5ms" title="Simulation">
+
+revm fork created → calldata built → simulation executed → profit verified
+
+  </TimelineItem>
+  <TimelineItem time="< 1ms" title="Handoff">
+
+ValidatedArb sent to Go executor via gRPC over UDS
+
+  </TimelineItem>
+  <TimelineItem time="< 2ms" title="Bundle Build">
+
+EIP-1559 transactions constructed and signed (arb_tx + tip_tx)
+
+  </TimelineItem>
+  <TimelineItem time="—" title="Submission" color="green">
+
+`eth_sendBundle` fan-out to all configured block builders
+
+  </TimelineItem>
+</Timeline>
+
+## Inter-Service Communication
+
+Rust and Go communicate via **gRPC over Unix Domain Sockets** — sub-microsecond transport.
+
+```mermaid
+graph LR
+    subgraph RUST["Rust Core"]
+        AS["ArbService"]
+        HS["HealthService"]
+        CS["ControlService"]
+    end
+
+    subgraph GO["Go Executor"]
+        EX["Executor"]
+        RM["Risk Manager"]
+    end
+
+    AS -->|"SubmitArb()"| EX
+    AS -->|"StreamArbs()"| EX
+    RM -->|"Check()"| HS
+    RM -->|"SetState()"| CS
+    RM -->|"ReloadConfig()"| CS
+
+    style RUST fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style GO fill:#151a20,stroke:#5ce6c7,stroke-width:2px,color:#fff
+```
+
+| Service | Direction | Purpose |
+|---|---|---|
+| `ArbService.SubmitArb()` | Rust → Go | Submit validated arb for execution |
+| `ArbService.StreamArbs()` | Rust → Go | Server-side streaming of opportunities |
+| `HealthService.Check()` | Go → Rust | Engine health check |
+| `ControlService.SetState()` | Go → Rust | Pause/resume detection |
+| `ControlService.ReloadConfig()` | Go → Rust | Hot-reload pool config |
+
+See [gRPC Protocol](/architecture/grpc-protocol) for the full schema reference.
+
+## Performance Targets
+
+| Metric | Target |
+|---|---|
+| Event decode + state update | <1ms |
+| Bellman-Ford detection | <3ms |
+| EVM simulation (revm) | <5ms |
+| gRPC Rust → Go | <1ms |
+| Bundle build + sign | <2ms |
+| **Total end-to-end** | **<15ms** |
+| Events processed per block | 10,000+ |
+| Pools monitored simultaneously | 5,000+ |
+| Opportunities evaluated per block | 500+ |
+| Simulations per second | 200+ |
+| Rust core memory | <2 GB RSS |
+| Go executor memory | <512 MB RSS |

--- a/docs-site/architecture/overview.md
+++ b/docs-site/architecture/overview.md
@@ -121,7 +121,7 @@ State machine: Running / Degraded / Paused / Halted. Circuit breakers for gas pr
   </AccordionItem>
   <AccordionItem title="Monitor — Prometheus and alerting">
 
-Exposes all metrics on `:9090/metrics`. HTTP dashboard on `:8080`. Alert dispatch to PagerDuty, Telegram, Discord.
+Exposes all metrics on `:9090/metrics`. HTTP dashboard on `:8080`. Alert dispatch to Slack with severity-based channel routing.
 
   </AccordionItem>
 </Accordion>

--- a/docs-site/architecture/rust-core.md
+++ b/docs-site/architecture/rust-core.md
@@ -170,7 +170,7 @@ Per-protocol base gas costs:
 | Protocol | Base Gas | Notes |
 |---|---|---|
 | Uniswap V2 | 60,000 | Constant product, single storage read |
-| Uniswap V3 | 100,000 + 5,000/tick | Varies with ticks crossed |
+| Uniswap V3 | 180,000 + 5,000/tick | Varies with ticks crossed |
 | SushiSwap | 60,000 | Same as UniV2 |
 | Curve | 130,000 | Newton's method iterations |
 | Balancer V2 | 120,000 | Weighted math |

--- a/docs-site/architecture/rust-core.md
+++ b/docs-site/architecture/rust-core.md
@@ -1,0 +1,224 @@
+# Rust Core
+
+The Rust core handles all latency-critical work — from ingesting Ethereum events to producing validated arbitrage opportunities. It consists of 7 crates in the `crates/` directory.
+
+## Crate Dependency Graph
+
+```
+common ← ingestion ← pools ← state ← detector ← simulator ← grpc-server
+```
+
+`grpc-server` is the binary entry point that wires everything together.
+
+## `crates/common/` — Shared Types
+
+Defines types shared across all crates:
+
+- **`ProtocolType`** enum — `UniswapV2`, `UniswapV3`, `SushiSwap`, `Curve`, `BalancerV2`, `BancorV3`
+- **`ArbOpportunity`** / **`ArbHop`** — Detected arbitrage with hop details
+- **`SwapStep`** — Execution step (protocol, pool, tokens, amounts)
+- **`ValidatedArb`** — Simulation-verified arb ready for execution
+- **`SimulationResult`** — EVM simulation output (success/revert, gas, profit)
+- **`AetherError`** — Structured error types via `thiserror`
+
+## `crates/ingestion/` — Data Ingestion
+
+WebSocket/IPC event ingestion from Ethereum nodes.
+
+### Node Pool
+
+Manages connections to multiple Ethereum node providers with a per-connection state machine:
+
+```
+Connected → Healthy → Degraded → Reconnecting → Failed
+```
+
+- Maintains 3+ providers (Alchemy WS, QuickNode WS, local Reth IPC)
+- Exponential backoff on reconnection
+- Minimum 2 healthy nodes required for operation
+- Nodes are prioritized: IPC (lowest latency) > WebSocket
+
+### Event Decoder
+
+Compile-time ABI decoding via the `alloy::sol!` macro. Handles events from all supported protocols:
+
+| Event | Protocol | Trigger |
+|---|---|---|
+| `Sync(uint112, uint112)` | Uniswap V2, SushiSwap | Reserve update |
+| `Swap(...)` | Uniswap V2, SushiSwap | Trade executed |
+| `SwapV3(...)` | Uniswap V3 | Trade executed |
+| `TokenExchange(...)` | Curve | StableSwap trade |
+| `BalancerSwap(...)` | Balancer V2 | Weighted pool trade |
+| `TokensTraded(...)` | Bancor V3 | Bonding curve trade |
+| `PairCreated(...)` | Factory contracts | New pool deployed |
+
+Performance: topic matching ~4 CPU cycles, full decode <200ns/event.
+
+### Dispatch
+
+Decoded events are broadcast through lock-free channels:
+
+- `pool_updates_tx` — Pool state changes (reserves, ticks, etc.)
+- `new_block_tx` — New block headers
+- `pending_tx_tx` — Pending mempool transactions
+
+Uses `tokio::sync::broadcast` for multi-consumer, lock-free delivery.
+
+## `crates/pools/` — DEX Pool Implementations
+
+### The `Pool` Trait
+
+Every DEX protocol implements this trait:
+
+```rust
+trait Pool {
+    fn protocol(&self) -> ProtocolType;
+    fn address(&self) -> Address;
+    fn tokens(&self) -> (Address, Address);
+    fn fee_bps(&self) -> u32;
+    fn get_amount_out(&self, amount_in: U256, token_in: Address) -> U256;
+    fn get_amount_in(&self, amount_out: U256, token_out: Address) -> U256;
+    fn update_state(&mut self, event: &DecodedEvent);
+    fn encode_swap(&self, step: &SwapStep) -> Bytes;
+    fn liquidity_depth(&self) -> U256;
+}
+```
+
+### Protocol Implementations
+
+**Uniswap V2 / SushiSwap** — Constant product AMM, O(1):
+```
+dy = (dx * 997 * y) / (x * 1000 + dx * 997)
+```
+
+**Uniswap V3** — Concentrated liquidity, O(n_ticks):
+- Q96 fixed-point math for `sqrtPriceX96`
+- Tick traversal for cross-tick swaps
+- Complexity depends on number of ticks crossed
+
+**Curve** — StableSwap invariant, O(iterations):
+- Newton's method to solve the StableSwap invariant
+- Converges in ~10 iterations for typical pools
+
+**Balancer V2** — Weighted constant product, O(1):
+- Generalized constant product with configurable token weights
+- `outAmount = balance_out * (1 - (balance_in / (balance_in + amount_in))^(w_in/w_out))`
+
+**Bancor V3** — Bonding curve, O(1):
+- BNT intermediary token
+- Separate pricing for BNT leg and target token leg
+
+### Pool Registry
+
+Discovery and lifecycle management:
+
+1. **Factory monitoring** — Watches `PairCreated`/`PoolCreated` events for new pools
+2. **Static registry** — Pools configured in `config/pools.toml`
+3. **On-chain scan** — Periodic scan for missed pools
+4. **Qualification** — Filters: liquidity >$10K, 24h volume >$1K, age >100 blocks, rug-pull score <0.3
+5. **Tiering** — Pools are tiered as Hot (every block), Warm (periodic), or Cold (on-demand)
+
+## `crates/state/` — State Management
+
+### Price Graph
+
+A directed graph where:
+- **Nodes** = token addresses (mapped to `usize` indices via `TokenIndex`)
+- **Edges** = negative log-transformed exchange rates: **`-ln(rate)`**
+
+This transformation is the key insight: a **negative weight cycle** in this graph represents a profitable arbitrage path. The sum of edge weights around a cycle being negative means the product of exchange rates exceeds 1.0.
+
+Only edges affected by incoming events are recomputed — dirty flags tracked via `BitVec` for O(1) marking and scanning.
+
+### MVCC Snapshots
+
+```rust
+Arc<ArcSwap<GraphSnapshot>>
+```
+
+- **Writers** atomically swap in new graph versions
+- **Readers** get zero-copy immutable references to the current snapshot
+- No locks on the hot path — readers never block writers
+
+### Token Index
+
+Bidirectional mapping between token `Address` and graph node `usize` index. Enables O(1) lookup in both directions.
+
+## `crates/detector/` — Arbitrage Detection
+
+### Bellman-Ford (SPFA Variant)
+
+The detection engine uses a modified Bellman-Ford algorithm — specifically the **Shortest Path Faster Algorithm (SPFA)** with **Shortest-Label-First (SLF)** optimization:
+
+- ~2-3x faster than standard Bellman-Ford for sparse graphs
+- Detects negative cycles by checking if a node is relaxed N times (where N = number of nodes)
+- **Early exit** on first negative cycle found
+- Only scans the subgraph affected by recent state updates (dirty nodes)
+
+### Input Optimizer
+
+Once a profitable cycle is found, **ternary search** finds the optimal input amount:
+
+- Searches over the profit function (which is concave for AMM-based DEXes)
+- ~100 iterations, converges in ~60 for U256 precision
+- Accounts for price impact: larger inputs reduce marginal returns
+
+### Gas Estimation
+
+Per-protocol base gas costs:
+
+| Protocol | Base Gas | Notes |
+|---|---|---|
+| Uniswap V2 | 60,000 | Constant product, single storage read |
+| Uniswap V3 | 100,000 + 5,000/tick | Varies with ticks crossed |
+| SushiSwap | 60,000 | Same as UniV2 |
+| Curve | 130,000 | Newton's method iterations |
+| Balancer V2 | 120,000 | Weighted math |
+| Bancor V3 | 150,000 | Two-leg swap through BNT |
+
+Additional overhead: 80,000 (flash loan) + 21,000 (base tx) + 30,000 (executor contract).
+
+### Output
+
+Top-K `ArbOpportunity` structs sorted by net profit descending. Each contains:
+- The hop sequence (pools, tokens, amounts)
+- Gross profit, gas cost, net profit
+- Estimated gas usage
+- Flash loan parameters
+
+## `crates/simulator/` — EVM Simulation
+
+### Engine
+
+Uses `revm` in fork mode to simulate arbitrage execution before submission:
+
+1. **Fork** — Create a `CacheDB` backed by `EthersDB` with the latest block state
+2. **Build calldata** — ABI-encode `AetherExecutor.executeArb(steps, flashloanToken, flashloanAmount)`
+3. **Execute** — Run the transaction in the forked EVM
+4. **Validate** — Check result: `Success` / `Revert` / `Halt`
+5. **Extract** — Actual profit, gas used, revert reason (if any)
+
+::: danger Critical Rule
+Simulation **must** use the same block state as the execution target block. Stale simulations → reverted bundles → wasted gas.
+:::
+
+### Calldata Builder
+
+Generates the exact calldata that will be submitted on-chain:
+
+```rust
+// ABI-encodes: executeArb(SwapStep[] steps, address flashloanToken, uint256 flashloanAmount)
+fn build_calldata(opportunity: &ValidatedArb) -> Bytes
+```
+
+Each `SwapStep` includes the protocol-specific calldata for the swap (generated by the pool's `encode_swap()` method).
+
+## `crates/grpc-server/` — Entry Point
+
+The Rust binary entry point. Initializes all crates and exposes three gRPC services:
+
+- **`ArbService`** — `SubmitArb()` and `StreamArbs()` RPCs for sending validated opportunities to Go
+- **`HealthService`** — Health checks (pool count, last block, uptime)
+- **`ControlService`** — `SetState()` (pause/resume) and `ReloadConfig()` (hot-reload pools.toml)
+
+Listens on a Unix Domain Socket for sub-microsecond transport to the Go executor.

--- a/docs-site/architecture/rust-core.md
+++ b/docs-site/architecture/rust-core.md
@@ -193,7 +193,7 @@ Top-K `ArbOpportunity` structs sorted by net profit descending. Each contains:
 Uses `revm` in fork mode to simulate arbitrage execution before submission:
 
 1. **Fork** — Create a `CacheDB` backed by `EthersDB` with the latest block state
-2. **Build calldata** — ABI-encode `AetherExecutor.executeArb(steps, flashloanToken, flashloanAmount)`
+2. **Build calldata** — ABI-encode `AetherExecutor.executeArb(steps, flashloanToken, flashloanAmount, deadline, minProfitOut, tipBps)`
 3. **Execute** — Run the transaction in the forked EVM
 4. **Validate** — Check result: `Success` / `Revert` / `Halt`
 5. **Extract** — Actual profit, gas used, revert reason (if any)
@@ -207,7 +207,8 @@ Simulation **must** use the same block state as the execution target block. Stal
 Generates the exact calldata that will be submitted on-chain:
 
 ```rust
-// ABI-encodes: executeArb(SwapStep[] steps, address flashloanToken, uint256 flashloanAmount)
+// ABI-encodes: executeArb(SwapStep[] steps, address flashloanToken,
+//   uint256 flashloanAmount, uint256 deadline, uint256 minProfitOut, uint256 tipBps)
 fn build_calldata(opportunity: &ValidatedArb) -> Bytes
 ```
 

--- a/docs-site/architecture/smart-contract.md
+++ b/docs-site/architecture/smart-contract.md
@@ -19,7 +19,7 @@ sequenceDiagram
     participant DEX2 as DEX Pool 2
     participant DEXN as DEX Pool N
 
-    EOA->>EX: executeArb(steps, token, amount)
+    EOA->>EX: executeArb(steps, token, amount, deadline, minProfitOut, tipBps)
     EX->>AAVE: flashLoanSimple(token, amount)
     AAVE->>EX: Transfer loan amount
     AAVE->>EX: executeOperation() callback
@@ -44,16 +44,29 @@ sequenceDiagram
 function executeArb(
     SwapStep[] calldata steps,
     address flashloanToken,
-    uint256 flashloanAmount
+    uint256 flashloanAmount,
+    uint256 deadline,
+    uint256 minProfitOut,
+    uint256 tipBps
 ) external onlyOwner nonReentrant
 ```
 
+| Parameter | Description |
+|---|---|
+| `steps` | Ordered array of swap hops to execute |
+| `flashloanToken` | Token to borrow from Aave V3 |
+| `flashloanAmount` | Amount to borrow |
+| `deadline` | Block timestamp after which the transaction reverts (`DeadlineExpired`) |
+| `minProfitOut` | Minimum profit floor — reverts if net profit is below this |
+| `tipBps` | Basis points (0–10,000) of profit sent to `block.coinbase` as builder tip |
+
 This is the main entry point, called by the searcher's EOA. It:
 
-1. Encodes the swap steps into the flash loan params
-2. Calls `POOL.flashLoanSimple()` on the Aave V3 lending pool
-3. Aave sends `flashloanAmount` of `flashloanToken` to this contract
-4. Aave then calls back into `executeOperation()`
+1. Validates `deadline` (reverts if `block.timestamp > deadline`) and `tipBps` (reverts if >10,000)
+2. Encodes the swap steps, gas snapshot, `tipBps`, and `minProfitOut` into the flash loan params
+3. Calls `POOL.flashLoanSimple()` on the Aave V3 lending pool
+4. Aave sends `flashloanAmount` of `flashloanToken` to this contract
+5. Aave then calls back into `executeOperation()`
 
 ## Aave Callback: `executeOperation()`
 
@@ -82,7 +95,7 @@ The `initiator` must be `address(this)` — the contract validates it received t
 Routes each swap step to the correct DEX based on the protocol enum:
 
 ```solidity
-function _executeSwap(SwapStep calldata step) internal {
+function _executeSwap(SwapStep memory step, uint256 index) internal {
     if (step.protocol == UNISWAP_V2) { ... }
     else if (step.protocol == UNISWAP_V3) { ... }
     else if (step.protocol == SUSHISWAP) { ... }
@@ -91,6 +104,8 @@ function _executeSwap(SwapStep calldata step) internal {
     else if (step.protocol == BANCOR_V3) { ... }
 }
 ```
+
+The `index` parameter identifies the hop position and is used in revert messages for debugging failed swaps.
 
 ### Protocol Constants
 

--- a/docs-site/architecture/smart-contract.md
+++ b/docs-site/architecture/smart-contract.md
@@ -1,0 +1,166 @@
+# Smart Contract
+
+The `AetherExecutor.sol` contract is the on-chain component that receives flash loans and executes multi-hop swaps. It's the final step in the arbitrage pipeline.
+
+## Overview
+
+- **Inherits:** `IFlashLoanSimpleReceiver` (Aave V3), `Ownable`, `ReentrancyGuard` (OpenZeppelin)
+- **Deployed on:** Ethereum Mainnet
+- **Build tool:** Foundry (`forge`)
+
+## Contract Flow
+
+```mermaid
+sequenceDiagram
+    participant EOA as Searcher EOA
+    participant EX as AetherExecutor
+    participant AAVE as Aave V3 Pool
+    participant DEX1 as DEX Pool 1
+    participant DEX2 as DEX Pool 2
+    participant DEXN as DEX Pool N
+
+    EOA->>EX: executeArb(steps, token, amount)
+    EX->>AAVE: flashLoanSimple(token, amount)
+    AAVE->>EX: Transfer loan amount
+    AAVE->>EX: executeOperation() callback
+
+    rect rgba(149, 128, 255, 0.08)
+        Note over EX,DEXN: Swap Loop
+        EX->>DEX1: _executeSwap(step[0])
+        DEX1-->>EX: tokens received
+        EX->>DEX2: _executeSwap(step[1])
+        DEX2-->>EX: tokens received
+        EX->>DEXN: _executeSwap(step[N])
+        DEXN-->>EX: tokens received
+    end
+
+    EX->>AAVE: Repay amount + 0.05% premium
+    EX->>EOA: Transfer profit
+```
+
+## Entry Point: `executeArb()`
+
+```solidity
+function executeArb(
+    SwapStep[] calldata steps,
+    address flashloanToken,
+    uint256 flashloanAmount
+) external onlyOwner nonReentrant
+```
+
+This is the main entry point, called by the searcher's EOA. It:
+
+1. Encodes the swap steps into the flash loan params
+2. Calls `POOL.flashLoanSimple()` on the Aave V3 lending pool
+3. Aave sends `flashloanAmount` of `flashloanToken` to this contract
+4. Aave then calls back into `executeOperation()`
+
+## Aave Callback: `executeOperation()`
+
+```solidity
+function executeOperation(
+    address asset,
+    uint256 amount,
+    uint256 premium,
+    address initiator,
+    bytes calldata params
+) external returns (bool)
+```
+
+Called by Aave after transferring the flash loan. This function:
+
+1. Decodes the swap steps from `params`
+2. Loops through each step, calling `_executeSwap()` for each
+3. After all swaps, calls `_repayAndDistribute()` to repay Aave and distribute profit
+
+::: warning
+The `initiator` must be `address(this)` — the contract validates it received the callback from a legitimate flash loan it initiated.
+:::
+
+## Swap Router: `_executeSwap()`
+
+Routes each swap step to the correct DEX based on the protocol enum:
+
+```solidity
+function _executeSwap(SwapStep calldata step) internal {
+    if (step.protocol == UNISWAP_V2) { ... }
+    else if (step.protocol == UNISWAP_V3) { ... }
+    else if (step.protocol == SUSHISWAP) { ... }
+    else if (step.protocol == CURVE) { ... }
+    else if (step.protocol == BALANCER_V2) { ... }
+    else if (step.protocol == BANCOR_V3) { ... }
+}
+```
+
+### Protocol Constants
+
+```solidity
+uint8 constant UNISWAP_V2 = 1;
+uint8 constant UNISWAP_V3 = 2;
+uint8 constant SUSHISWAP = 3;
+uint8 constant CURVE = 4;
+uint8 constant BALANCER_V2 = 5;
+uint8 constant BANCOR_V3 = 6;
+```
+
+### Slippage Protection
+
+Every swap step includes a `minAmountOut` field. If the actual output is less than this threshold, the swap reverts. Default slippage tolerance is 1%.
+
+### Token Transfers
+
+All token transfers use OpenZeppelin's `SafeERC20` to handle non-standard ERC20 implementations (tokens that don't return `bool` on transfer).
+
+## Profit Distribution: `_repayAndDistribute()`
+
+After all swaps complete:
+
+1. Approve Aave to pull back `amount + premium` (flash loan repayment + 0.05% fee)
+2. Calculate profit: `balance - amount - premium`
+3. Transfer profit to the contract `owner`
+
+If the final balance is less than `amount + premium`, the entire transaction reverts — this is the atomic safety guarantee.
+
+## Emergency Functions
+
+### `rescue()`
+
+```solidity
+function rescue(address token, uint256 amount) external onlyOwner
+```
+
+Emergency withdrawal of tokens stuck in the contract. Only callable by the owner (cold wallet). Used in incident response scenarios — see [Incident Response](/operations/incident-response).
+
+### `setApprovals()`
+
+```solidity
+function setApprovals(address token, address spender, uint256 amount) external onlyOwner
+```
+
+Sets ERC20 approvals for DEX routers. Pre-approving common tokens reduces gas costs per swap.
+
+## Security Model
+
+- **`onlyOwner`** on all state-changing functions — owner is the cold wallet, not the searcher hot wallet
+- **`nonReentrant`** (ReentrancyGuard) on `executeArb()` — prevents reentrancy attacks
+- **Deadline validation** — bundles target a specific block, stale executions are rejected
+- **Custom errors** — Gas-efficient error handling (cheaper than string revert reasons)
+- **No `selfdestruct`** — Contract is immutable once deployed
+- **Flash loan validation** — `executeOperation` verifies the callback came from a legitimate self-initiated flash loan
+
+## Testing
+
+Tests are in `contracts/test/AetherExecutor.t.sol` using Foundry's testing framework:
+
+```bash
+cd contracts && forge test
+```
+
+Tests cover:
+- Successful multi-hop arbitrage execution
+- Revert on unprofitable trades
+- Access control (`onlyOwner`)
+- Reentrancy protection
+- Slippage protection
+- Emergency rescue function
+- Each protocol's swap routing

--- a/docs-site/architecture/smart-contract.md
+++ b/docs-site/architecture/smart-contract.md
@@ -134,10 +134,10 @@ Emergency withdrawal of tokens stuck in the contract. Only callable by the owner
 ### `setApprovals()`
 
 ```solidity
-function setApprovals(address token, address spender, uint256 amount) external onlyOwner
+function setApprovals(address[] calldata tokens, address[] calldata spenders) external onlyOwner
 ```
 
-Sets ERC20 approvals for DEX routers. Pre-approving common tokens reduces gas costs per swap.
+Batch-sets max ERC20 approvals for DEX routers and the Aave pool. Both arrays must be the same length. Pre-approving common tokens eliminates per-swap approval overhead. Uses `forceApprove` with `type(uint256).max`.
 
 ## Security Model
 

--- a/docs-site/development/adding-a-dex.md
+++ b/docs-site/development/adding-a-dex.md
@@ -4,7 +4,7 @@ This guide walks through adding support for a new DEX protocol to Aether. The sy
 
 ## Overview
 
-Adding a new DEX requires changes in 6 files across 3 languages:
+Adding a new DEX requires changes in 5 files across 3 languages (steps 3 and 5 edit the same file):
 
 | Step | File | Language |
 |---|---|---|
@@ -142,7 +142,7 @@ In `contracts/src/AetherExecutor.sol`, add a routing case in `_executeSwap()`:
 ```solidity
 uint8 constant NEW_DEX = 7;
 
-function _executeSwap(SwapStep calldata step) internal {
+function _executeSwap(SwapStep memory step, uint256 index) internal {
     // ... existing cases ...
     else if (step.protocol == NEW_DEX) {
         // Protocol-specific swap logic

--- a/docs-site/development/adding-a-dex.md
+++ b/docs-site/development/adding-a-dex.md
@@ -12,7 +12,7 @@ Adding a new DEX requires changes in 6 files across 3 languages:
 | 2. Event decoding | `crates/ingestion/src/event_decoder.rs` | Rust |
 | 3. Protocol enum | `crates/common/src/types.rs` | Rust |
 | 4. Swap routing | `contracts/src/AetherExecutor.sol` | Solidity |
-| 5. Gas estimation | `crates/detector/src/gas.rs` | Rust |
+| 5. Gas estimation | `crates/common/src/types.rs` | Rust |
 | 6. Pool config | `config/pools.toml` | TOML |
 
 ## Step 1: Implement the Pool Trait
@@ -156,18 +156,20 @@ Add corresponding tests in `contracts/test/AetherExecutor.t.sol`.
 
 ## Step 5: Add Gas Estimation
 
-In `crates/detector/src/gas.rs`, add the base gas cost for the new protocol:
+In `crates/common/src/types.rs`, add a new arm to the `ProtocolType::base_gas()` method:
 
 ```rust
-pub fn base_gas(protocol: ProtocolType) -> u64 {
-    match protocol {
-        ProtocolType::UniswapV2 => 60_000,
-        ProtocolType::UniswapV3 => 100_000, // + 5000 per tick crossed
-        ProtocolType::SushiSwap => 60_000,
-        ProtocolType::Curve => 130_000,
-        ProtocolType::BalancerV2 => 120_000,
-        ProtocolType::BancorV3 => 150_000,
-        ProtocolType::NewDex => 80_000, // Measure with gas_profiler.py
+impl ProtocolType {
+    pub fn base_gas(&self) -> u64 {
+        match self {
+            ProtocolType::UniswapV2 => 60_000,
+            ProtocolType::UniswapV3 => 180_000, // + 5000 per tick crossed
+            ProtocolType::SushiSwap => 60_000,
+            ProtocolType::Curve => 130_000,
+            ProtocolType::BalancerV2 => 120_000,
+            ProtocolType::BancorV3 => 150_000,
+            ProtocolType::NewDex => 80_000, // Measure with gas_profiler.py
+        }
     }
 }
 ```

--- a/docs-site/development/adding-a-dex.md
+++ b/docs-site/development/adding-a-dex.md
@@ -1,0 +1,232 @@
+# Adding a DEX
+
+This guide walks through adding support for a new DEX protocol to Aether. The system is designed to make this straightforward — no changes to the detection or execution logic are needed.
+
+## Overview
+
+Adding a new DEX requires changes in 6 files across 3 languages:
+
+| Step | File | Language |
+|---|---|---|
+| 1. Pool implementation | `crates/pools/src/<new_dex>.rs` | Rust |
+| 2. Event decoding | `crates/ingestion/src/event_decoder.rs` | Rust |
+| 3. Protocol enum | `crates/common/src/types.rs` | Rust |
+| 4. Swap routing | `contracts/src/AetherExecutor.sol` | Solidity |
+| 5. Gas estimation | `crates/detector/src/gas.rs` | Rust |
+| 6. Pool config | `config/pools.toml` | TOML |
+
+## Step 1: Implement the Pool Trait
+
+Create `crates/pools/src/<new_dex>.rs` and implement the `Pool` trait:
+
+```rust
+use crate::Pool;
+use common::{ProtocolType, SwapStep};
+use alloy::primitives::{Address, Bytes, U256};
+
+pub struct NewDexPool {
+    address: Address,
+    token0: Address,
+    token1: Address,
+    fee_bps: u32,
+    // Protocol-specific state (reserves, weights, etc.)
+}
+
+impl Pool for NewDexPool {
+    fn protocol(&self) -> ProtocolType {
+        ProtocolType::NewDex
+    }
+
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn tokens(&self) -> (Address, Address) {
+        (self.token0, self.token1)
+    }
+
+    fn fee_bps(&self) -> u32 {
+        self.fee_bps
+    }
+
+    fn get_amount_out(&self, amount_in: U256, token_in: Address) -> U256 {
+        // CRITICAL: Must exactly replicate on-chain math
+        // Test against forked mainnet to verify
+        todo!()
+    }
+
+    fn get_amount_in(&self, amount_out: U256, token_out: Address) -> U256 {
+        todo!()
+    }
+
+    fn update_state(&mut self, event: &DecodedEvent) {
+        // Update internal state from on-chain events
+        todo!()
+    }
+
+    fn encode_swap(&self, step: &SwapStep) -> Bytes {
+        // ABI-encode the swap calldata for on-chain execution
+        todo!()
+    }
+
+    fn liquidity_depth(&self) -> U256 {
+        // Return a measure of pool liquidity (used for qualification)
+        todo!()
+    }
+}
+```
+
+::: warning Critical: Pricing Accuracy
+`get_amount_out()` and `get_amount_in()` **must exactly replicate on-chain math**. Any deviation causes simulation-to-execution mismatches → reverted bundles → wasted gas. Always test against forked mainnet state.
+:::
+
+Don't forget to register the module in `crates/pools/src/lib.rs`:
+
+```rust
+pub mod new_dex;
+```
+
+## Step 2: Add Event Decoding
+
+In `crates/ingestion/src/event_decoder.rs`, add the new protocol's event signatures:
+
+```rust
+alloy::sol! {
+    // Add the new DEX's swap event
+    event NewDexSwap(
+        address indexed sender,
+        uint256 amountIn,
+        uint256 amountOut,
+        address indexed to
+    );
+}
+```
+
+Then add a match arm in the event dispatcher to route these events to the pool update pipeline.
+
+## Step 3: Add Protocol Variant
+
+In `crates/common/src/types.rs`, add the new variant to the `ProtocolType` enum:
+
+```rust
+pub enum ProtocolType {
+    UniswapV2,
+    UniswapV3,
+    SushiSwap,
+    Curve,
+    BalancerV2,
+    BancorV3,
+    NewDex,  // Add here
+}
+```
+
+Also update the corresponding Protobuf enum in `proto/aether.proto`:
+
+```protobuf
+enum ProtocolType {
+    PROTOCOL_UNKNOWN = 0;
+    UNISWAP_V2 = 1;
+    UNISWAP_V3 = 2;
+    SUSHISWAP = 3;
+    CURVE = 4;
+    BALANCER_V2 = 5;
+    BANCOR_V3 = 6;
+    NEW_DEX = 7;  // Add here
+}
+```
+
+## Step 4: Add Swap Routing (Solidity)
+
+In `contracts/src/AetherExecutor.sol`, add a routing case in `_executeSwap()`:
+
+```solidity
+uint8 constant NEW_DEX = 7;
+
+function _executeSwap(SwapStep calldata step) internal {
+    // ... existing cases ...
+    else if (step.protocol == NEW_DEX) {
+        // Protocol-specific swap logic
+        // Use SafeERC20 for all token transfers
+        // Check minAmountOut for slippage protection
+    }
+}
+```
+
+Add corresponding tests in `contracts/test/AetherExecutor.t.sol`.
+
+## Step 5: Add Gas Estimation
+
+In `crates/detector/src/gas.rs`, add the base gas cost for the new protocol:
+
+```rust
+pub fn base_gas(protocol: ProtocolType) -> u64 {
+    match protocol {
+        ProtocolType::UniswapV2 => 60_000,
+        ProtocolType::UniswapV3 => 100_000, // + 5000 per tick crossed
+        ProtocolType::SushiSwap => 60_000,
+        ProtocolType::Curve => 130_000,
+        ProtocolType::BalancerV2 => 120_000,
+        ProtocolType::BancorV3 => 150_000,
+        ProtocolType::NewDex => 80_000, // Measure with gas_profiler.py
+    }
+}
+```
+
+::: tip Measuring Gas
+Use `scripts/gas_profiler.py` to measure actual gas usage on a forked mainnet. The estimate should be within 10% of actual usage.
+:::
+
+## Step 6: Add Pool Configuration
+
+Add pool entries to `config/pools.toml`:
+
+```toml
+[[pools]]
+protocol = "new_dex"
+address = "0x..."
+token0 = "0x..."
+token1 = "0x..."
+fee_bps = 30
+tier = "warm"  # Start as warm, promote to hot after validation
+```
+
+## Testing Checklist
+
+After implementing all steps:
+
+1. **Unit tests** — Verify pricing math against known on-chain values
+   ```bash
+   cargo test -p pools
+   ```
+
+2. **Integration test** — Verify the full pipeline detects opportunities involving the new DEX
+   ```bash
+   cargo test -p integration-tests
+   ```
+
+3. **Solidity tests** — Verify swap routing works for the new protocol
+   ```bash
+   cd contracts && forge test
+   ```
+
+4. **Gas profiling** — Measure actual gas costs
+   ```bash
+   python scripts/gas_profiler.py --protocol new_dex
+   ```
+
+5. **Mainnet fork test** — Run against forked mainnet to validate end-to-end
+   ```bash
+   ./scripts/staging_test.sh
+   ```
+
+## What You Don't Need to Change
+
+The following components work automatically with any new DEX:
+
+- **Bellman-Ford detection** — Operates on the price graph, protocol-agnostic
+- **Input optimization** — Ternary search works for any concave profit function
+- **EVM simulation** — Simulates whatever calldata is provided
+- **Bundle construction** — Wraps whatever calldata is provided
+- **Multi-builder submission** — Protocol-agnostic
+- **Risk management** — Monitors profits and gas, protocol-agnostic
+- **Monitoring** — Tracks all opportunities and executions

--- a/docs-site/development/contributing.md
+++ b/docs-site/development/contributing.md
@@ -1,0 +1,151 @@
+# Contributing
+
+Development guidelines, code style, and CI expectations for contributing to Aether.
+
+## Development Setup
+
+See [Getting Started](/guide/getting-started) for prerequisites and build instructions.
+
+## Rust Guidelines
+
+### Code Quality
+
+```bash
+# Run before every commit
+cargo clippy
+cargo test
+```
+
+### Hot Path Rules
+
+Code in the detection loop (`crates/detector/`, `crates/state/`) must follow these rules:
+
+- **No heap allocations** — Use arena allocators or stack-allocated buffers
+- **Use `#[inline]`** where beneficial for hot functions
+- **No `Box<dyn Trait>`** on the hot path — use enums or generics
+- **No `String` formatting** in the critical path — use pre-allocated buffers
+
+### ABI Decoding
+
+Always use the `alloy::sol!` macro for compile-time ABI code generation:
+
+```rust
+alloy::sol! {
+    event Sync(uint112 reserve0, uint112 reserve1);
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+}
+```
+
+Never manually parse ABI — it's error-prone and slower.
+
+### Pool Pricing
+
+Pool pricing functions (`get_amount_out`, `get_amount_in`) **must exactly replicate on-chain math**. Any deviation causes simulation-to-execution mismatches, which means reverted bundles. Test against forked mainnet state.
+
+### Production Builds
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+```
+
+LTO is enabled in the workspace `Cargo.toml` for release builds.
+
+## Go Guidelines
+
+### Runtime Settings
+
+Production settings:
+```
+GOMAXPROCS=2    # Limit OS threads
+GOGC=200        # Reduce GC frequency
+```
+
+### Context Propagation
+
+All goroutines **must** respect `context.Context` for cancellation:
+
+```go
+func (s *Submitter) Submit(ctx context.Context, bundle *Bundle) error {
+    select {
+    case <-ctx.Done():
+        return ctx.Err()
+    default:
+        // proceed
+    }
+}
+```
+
+### Deterministic Bundles
+
+Bundle construction must be deterministic — the same input must always produce the same bundle. This enables reproducible testing and debugging.
+
+## Solidity Guidelines
+
+### Build & Test
+
+```bash
+cd contracts
+forge build
+forge test
+```
+
+### Safety Rules
+
+- All external calls must use **`SafeERC20`** for token transfers
+- Every swap step must check **`minAmountOut`** for slippage protection (1% default)
+- **`onlyOwner`** on all state-changing functions
+- **`nonReentrant`** on entry points that handle value
+
+### Testing
+
+Write tests for:
+- Successful multi-hop execution
+- Revert on unprofitable trades
+- Access control enforcement
+- Edge cases (zero amounts, single-hop, max hops)
+
+## CI Pipeline
+
+The CI runs on every pull request with these jobs:
+
+### 1. Toolchain Verification
+Checks that Rust, Go, Foundry, and protoc are at the correct versions.
+
+### 2. Rust Checks
+```bash
+cargo clippy -- -D warnings
+cargo test
+```
+
+### 3. Go Checks
+```bash
+go vet ./...
+go test ./...
+```
+
+### 4. Solidity Checks
+```bash
+cd contracts && forge test
+```
+
+All four jobs must pass before merging.
+
+## Commit Style
+
+- Use conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
+- Keep commits focused — one logical change per commit
+- Write meaningful commit messages that explain *why*, not just *what*
+
+## Pull Requests
+
+- Keep PRs focused and reviewable (< 500 lines when possible)
+- Include test coverage for new functionality
+- Update documentation if changing public interfaces or behavior
+- Link related issues in the PR description

--- a/docs-site/development/testing.md
+++ b/docs-site/development/testing.md
@@ -166,7 +166,7 @@ Profile gas usage per protocol:
 python scripts/gas_profiler.py
 ```
 
-Outputs gas usage per swap type, helping calibrate the gas estimation model in `crates/detector/src/gas.rs`.
+Outputs gas usage per swap type, helping calibrate the per-protocol gas constants in `crates/common/src/types.rs` (`ProtocolType::base_gas()`).
 
 ## Backtesting
 

--- a/docs-site/development/testing.md
+++ b/docs-site/development/testing.md
@@ -1,0 +1,182 @@
+# Testing
+
+Aether's test strategy spans three languages and multiple test levels.
+
+## Quick Start
+
+```bash
+# Run everything
+./scripts/deploy.sh test
+
+# Or individually:
+cargo test           # Rust
+go test ./...        # Go
+cd contracts && forge test  # Solidity
+```
+
+## Rust Tests
+
+### Unit Tests
+
+Each crate has tests alongside the source code:
+
+```bash
+# All Rust tests
+cargo test
+
+# Specific crate
+cargo test -p detector
+cargo test -p pools
+cargo test -p simulator
+
+# Specific test
+cargo test -p detector bellman_ford::tests::detects_negative_cycle
+```
+
+Key test areas:
+- **`pools`** — Pricing math accuracy against known on-chain values
+- **`detector`** — Bellman-Ford cycle detection, optimizer convergence
+- **`simulator`** — EVM simulation results against forked state
+- **`state`** — Price graph construction, dirty bit tracking, MVCC correctness
+- **`ingestion`** — Event decoding for all supported protocols
+
+### Integration Tests
+
+The `crates/integration-tests/` crate runs end-to-end tests that exercise the full Rust pipeline:
+
+```bash
+cargo test -p integration-tests
+```
+
+These tests:
+- Set up a mock price graph with known arbitrage opportunities
+- Verify the detector finds them
+- Verify the simulator validates them
+- Check latency metrics
+
+### Linting
+
+```bash
+cargo clippy -- -D warnings
+```
+
+All clippy warnings are treated as errors in CI.
+
+## Go Tests
+
+```bash
+# All Go tests
+go test ./...
+
+# With verbose output
+go test -v ./...
+
+# Specific package
+go test -v ./cmd/executor/...
+go test -v ./cmd/risk/...
+
+# With race detection
+go test -race ./...
+```
+
+Key test areas:
+- **`cmd/executor`** — Bundle construction determinism, nonce management
+- **`cmd/risk`** — Circuit breaker state transitions, position limit enforcement
+- **`cmd/monitor`** — Metric registration, alert dispatch
+
+### Go Vet
+
+```bash
+go vet ./...
+```
+
+Run alongside tests to catch common issues.
+
+## Solidity Tests
+
+Uses Foundry's testing framework:
+
+```bash
+cd contracts
+
+# Run all tests
+forge test
+
+# With verbosity (show traces)
+forge test -vvv
+
+# Specific test
+forge test --match-test testExecuteArbSuccess
+
+# Gas report
+forge test --gas-report
+```
+
+Test file: `contracts/test/AetherExecutor.t.sol`
+
+Key test cases:
+- Successful multi-hop arbitrage execution
+- Revert on unprofitable trades (flash loan repayment failure)
+- Access control (`onlyOwner` enforcement)
+- Reentrancy protection
+- Slippage protection (`minAmountOut`)
+- Emergency `rescue()` function
+- Each protocol's swap routing
+
+### Fork Testing
+
+Test against forked Ethereum mainnet:
+
+```bash
+forge test --fork-url https://eth-mainnet.g.alchemy.com/v2/$ALCHEMY_API_KEY
+```
+
+## CI Pipeline
+
+The CI workflow (`.github/workflows/ci.yml`) runs on every pull request:
+
+| Job | What it runs | Must pass |
+|---|---|---|
+| Toolchain | Version checks (Rust, Go, Foundry, protoc) | Yes |
+| Rust | `cargo clippy`, `cargo test` | Yes |
+| Go | `go vet`, `go test` | Yes |
+| Solidity | `forge test` | Yes |
+
+All four jobs must pass before merging.
+
+## Staging Validation
+
+Before production deployment, run the staging test suite:
+
+```bash
+./scripts/staging_test.sh
+```
+
+This runs against a staging environment with:
+- Forked mainnet state
+- Real node connections (testnet or forked)
+- Full pipeline execution (detection → simulation → bundle construction)
+- No actual submission to builders
+
+## Gas Profiling
+
+Profile gas usage per protocol:
+
+```bash
+python scripts/gas_profiler.py
+```
+
+Outputs gas usage per swap type, helping calibrate the gas estimation model in `crates/detector/src/gas.rs`.
+
+## Backtesting
+
+Analyze historical arbitrage opportunities:
+
+```bash
+python scripts/backtest.py --from-block 18000000 --to-block 18001000
+```
+
+Useful for:
+- Validating detection accuracy against known historical opportunities
+- Measuring theoretical vs. actual profit
+- Benchmarking detection latency against historical data

--- a/docs-site/development/tooling.md
+++ b/docs-site/development/tooling.md
@@ -66,7 +66,7 @@ Outputs:
 - Gas usage per hop count (2-hop, 3-hop, etc.)
 - Comparison against the gas estimation model
 
-Use this to calibrate the gas estimates in `crates/detector/src/gas.rs`. Estimates should be within 10% of actual usage.
+Use this to calibrate the per-protocol gas constants in `crates/common/src/types.rs` (`ProtocolType::base_gas()`). Estimates should be within 10% of actual usage.
 
 ## `staging_test.sh` — Staging Validation
 

--- a/docs-site/development/tooling.md
+++ b/docs-site/development/tooling.md
@@ -1,0 +1,106 @@
+# Tooling & Scripts
+
+Utility scripts in the `scripts/` directory for building, testing, deploying, and analyzing Aether.
+
+## `deploy.sh` — Build, Test, Deploy
+
+The main automation script. Handles the complete lifecycle:
+
+```bash
+# Build all components (Rust, Go, Solidity)
+./scripts/deploy.sh build
+
+# Run all tests
+./scripts/deploy.sh test
+
+# Start local stack via Docker Compose
+./scripts/deploy.sh docker up
+./scripts/deploy.sh docker down
+
+# Deploy to environment
+./scripts/deploy.sh deploy staging
+./scripts/deploy.sh deploy production
+
+# Check deployment status
+./scripts/deploy.sh status production
+
+# Rollback to previous version
+./scripts/deploy.sh rollback production
+```
+
+### Build Targets
+
+| Command | What it builds |
+|---|---|
+| `deploy.sh build` | Rust (release + LTO), Go binary, Solidity contracts |
+| `deploy.sh build rust` | Rust core only |
+| `deploy.sh build go` | Go executor only |
+| `deploy.sh build sol` | Solidity contracts only |
+
+## `backtest.py` — Historical Analysis
+
+Analyzes historical blocks for arbitrage opportunities that Aether could have captured:
+
+```bash
+python scripts/backtest.py --from-block 18000000 --to-block 18001000
+```
+
+Use cases:
+- Validate detection accuracy against known historical opportunities
+- Measure theoretical profit vs. actual profit
+- Identify missed opportunities and their causes
+- Benchmark detection latency
+
+Requires an archive node endpoint for historical state access.
+
+## `gas_profiler.py` — Gas Usage Profiling
+
+Profiles actual gas usage per DEX protocol swap:
+
+```bash
+python scripts/gas_profiler.py
+```
+
+Outputs:
+- Gas usage per protocol (UniV2, UniV3, Curve, etc.)
+- Gas usage per hop count (2-hop, 3-hop, etc.)
+- Comparison against the gas estimation model
+
+Use this to calibrate the gas estimates in `crates/detector/src/gas.rs`. Estimates should be within 10% of actual usage.
+
+## `staging_test.sh` — Staging Validation
+
+End-to-end validation against a staging environment:
+
+```bash
+./scripts/staging_test.sh
+```
+
+Runs the full pipeline (detection → simulation → bundle construction) against forked mainnet state without submitting to actual builders. Use before production deployments.
+
+## `check_toolchain_versions.sh` — Version Verification
+
+Verifies all required toolchain versions match expectations:
+
+```bash
+./scripts/check_toolchain_versions.sh
+```
+
+Checks:
+- Rust version (1.94.1+)
+- Go version (1.26.1+)
+- Foundry (forge, cast, anvil) installation
+- Protobuf compiler (`protoc`) version
+- Docker and Docker Compose availability
+
+Run this on a new development machine or CI to verify the environment.
+
+## `test_integration.sh` — Integration Tests
+
+Runs the full integration test suite:
+
+```bash
+./scripts/test_integration.sh
+```
+
+Exercises the complete Rust pipeline end-to-end with test data, verifying detection accuracy and latency targets.

--- a/docs-site/guide/configuration.md
+++ b/docs-site/guide/configuration.md
@@ -1,0 +1,144 @@
+# Configuration
+
+All runtime configuration lives in the `config/` directory. This page provides an overview of each config file and how to modify them.
+
+## Config Files Overview
+
+| File | Purpose | Hot-Reload |
+|---|---|---|
+| `config/pools.toml` | Pool registry — monitored DEX pools | **Yes** (via `ControlService.ReloadConfig()`) |
+| `config/risk.yaml` | Risk parameters & circuit breaker thresholds | No (requires Go restart) |
+| `config/nodes.yaml` | Ethereum node provider endpoints (WS/IPC) | No (requires Rust restart) |
+| `config/builders.yaml` | Block builder API endpoints & auth | No (requires Go restart) |
+
+## Pool Registry (`pools.toml`)
+
+This is the most frequently modified config. It defines which DEX pools Aether monitors.
+
+```toml
+[[pools]]
+protocol = "uniswap_v2"
+address = "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"
+token0 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+token1 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+fee_bps = 30
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v3"
+address = "0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"
+token0 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+token1 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+fee_bps = 5
+tier = "hot"
+tick_spacing = 10
+```
+
+**Fields:**
+- `protocol` — One of: `uniswap_v2`, `uniswap_v3`, `sushiswap`, `curve`, `balancer_v2`, `bancor_v3`
+- `address` — Pool contract address
+- `token0`, `token1` — Token addresses in the pair
+- `fee_bps` — Pool fee in basis points (30 = 0.3%)
+- `tier` — `hot` (checked every block), `warm` (periodic), `cold` (on-demand)
+- `tick_spacing` — Required for Uniswap V3 pools
+
+### Hot Reload
+
+Pool config can be reloaded without restarting any services:
+
+```bash
+# Edit the config
+vim config/pools.toml
+
+# Trigger reload via gRPC
+grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig
+```
+
+## Risk Parameters (`risk.yaml`)
+
+Defines circuit breaker thresholds and position limits.
+
+```yaml
+circuit_breakers:
+  max_gas_gwei: 300
+  consecutive_reverts_pause: 10
+  revert_window_minutes: 10
+  daily_loss_halt_eth: 0.5
+  min_eth_balance: 0.1
+  max_node_latency_ms: 500
+  bundle_miss_rate_alert_pct: 80
+  bundle_miss_rate_window_minutes: 60
+  competitive_revert_alert_pct: 90
+
+position_limits:
+  max_single_trade_eth: 50.0
+  max_daily_volume_eth: 500.0
+  min_profit_eth: 0.001
+  min_tip_share_pct: 50
+  max_tip_share_pct: 95
+
+system:
+  initial_state: "running"
+  manual_reset_required_from_halted: true
+```
+
+::: warning
+Changes to `risk.yaml` require restarting the Go executor: `sudo systemctl restart aether-go`
+:::
+
+See [Risk Parameters Reference](/reference/risk-parameters) for detailed documentation of each field.
+
+## Node Providers (`nodes.yaml`)
+
+Configures Ethereum node connections.
+
+```yaml
+nodes:
+  - name: "alchemy-ws"
+    url: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+    type: "websocket"
+    priority: 1
+  - name: "local-reth"
+    url: "/tmp/reth.ipc"
+    type: "ipc"
+    priority: 0
+
+min_healthy_nodes: 2
+```
+
+- `type` — `websocket` or `ipc`
+- `priority` — Lower = preferred. IPC is fastest (same machine), WS is remote fallback.
+- `min_healthy_nodes` — System degrades if fewer than this many nodes are healthy.
+
+Environment variables (like `${ALCHEMY_API_KEY}`) are expanded at startup.
+
+## Block Builders (`builders.yaml`)
+
+Configures the block builders for bundle submission.
+
+```yaml
+builders:
+  - name: "flashbots"
+    url: "https://relay.flashbots.net"
+    enabled: true
+    timeout_ms: 2000
+    auth_type: "flashbots"
+  - name: "titan"
+    url: "https://rpc.titanbuilder.xyz"
+    enabled: true
+    timeout_ms: 2000
+    auth_type: "none"
+
+submission:
+  fan_out: true
+  max_retries: 2
+```
+
+- `fan_out: true` — Submit to all enabled builders simultaneously (recommended)
+- `auth_type` — `flashbots` (signed header), `api_key` (bearer token), or `none`
+
+## Next Steps
+
+- [Configuration Reference](/reference/configuration) — Full annotated reference for every config field
+- [Risk Parameters](/reference/risk-parameters) — Detailed circuit breaker documentation
+- [Runbook](/operations/runbook) — Operational procedures for config changes

--- a/docs-site/guide/getting-started.md
+++ b/docs-site/guide/getting-started.md
@@ -1,0 +1,148 @@
+# Getting Started
+
+This guide covers building, testing, and running Aether locally.
+
+## Prerequisites
+
+- **Rust** 1.94.1+ (via [rustup](https://rustup.rs/))
+- **Go** 1.26.1+
+- **Foundry** — [forge, cast, anvil](https://getfoundry.sh/)
+- **Protobuf compiler** (`protoc`)
+- **Docker & Docker Compose** (for local infrastructure)
+
+## Build
+
+### Rust Core
+
+```bash
+cargo build --release
+```
+
+For production builds with LTO and native CPU optimizations:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+```
+
+### Go Executor
+
+```bash
+go build -o bin/aether-executor ./cmd/executor
+```
+
+### Solidity Contracts
+
+```bash
+cd contracts && forge build
+```
+
+### All Components (via deploy script)
+
+```bash
+./scripts/deploy.sh build
+```
+
+## Test
+
+```bash
+# Rust tests
+cargo test
+
+# Go tests
+go test ./...
+
+# Solidity tests
+cd contracts && forge test
+
+# All tests at once
+./scripts/deploy.sh test
+```
+
+## Running
+
+### Option 1: Docker Compose (Recommended for local dev)
+
+Start the full stack with infrastructure services:
+
+```bash
+./scripts/deploy.sh docker up
+```
+
+This starts `aether-rust`, `aether-go`, and Prometheus.
+
+### Option 2: Manual Start
+
+```bash
+# 1. Start infrastructure (Prometheus)
+docker compose -f deploy/docker/docker-compose.yml up -d prometheus
+
+# 2. Start Rust core (gRPC server)
+cargo run --release --bin aether-grpc-server
+
+# 3. Start Go executor (in a separate terminal)
+go run ./cmd/executor
+```
+
+::: tip Start Order
+Always start the Rust core **before** the Go executor. The Go executor connects to the Rust gRPC server on startup.
+:::
+
+### Option 3: Production Deployment
+
+```bash
+# Deploy to staging
+./scripts/deploy.sh deploy staging
+
+# Deploy to production
+./scripts/deploy.sh deploy production
+
+# Check status
+./scripts/deploy.sh status production
+
+# Rollback if needed
+./scripts/deploy.sh rollback production
+```
+
+See [Deployment](/operations/deployment) for full production deployment instructions.
+
+## Verify It's Working
+
+Once running, check these endpoints:
+
+| Endpoint | URL | Purpose |
+|---|---|---|
+| Prometheus metrics | `http://localhost:9090/metrics` | Raw metrics |
+| Dashboard | `http://localhost:8080` | Operational dashboard |
+| gRPC health | `grpcurl -plaintext localhost:50051 aether.HealthService/Check` | Engine health |
+
+## Repository Structure
+
+```
+aether/
+├── Cargo.toml                    # Rust workspace root
+├── go.mod                        # Go module root
+├── proto/aether.proto            # Shared Protobuf schema
+├── crates/                       # Rust crates (7 crates)
+│   ├── ingestion/                # Data ingestion & node pool
+│   ├── pools/                    # DEX pool implementations
+│   ├── state/                    # State management & price graph
+│   ├── detector/                 # Arbitrage detection (Bellman-Ford)
+│   ├── simulator/                # EVM simulation (revm)
+│   ├── grpc-server/              # tonic gRPC server
+│   └── common/                   # Shared types & errors
+├── cmd/                          # Go services
+│   ├── executor/                 # Bundle construction & submission
+│   ├── risk/                     # Risk management & circuit breakers
+│   └── monitor/                  # Prometheus, dashboard, alerting
+├── contracts/                    # Solidity (Foundry)
+│   └── src/AetherExecutor.sol    # Flash loan executor
+├── config/                       # Runtime configuration
+├── deploy/                       # Docker, systemd, Ansible
+└── scripts/                      # Build, test, deploy automation
+```
+
+## Next Steps
+
+- [Configuration](/guide/configuration) — Configure pools, risk parameters, and node providers
+- [How It Works](/guide/how-it-works) — Understand the detection pipeline
+- [Contributing](/development/contributing) — Development guidelines and code style

--- a/docs-site/guide/how-it-works.md
+++ b/docs-site/guide/how-it-works.md
@@ -1,0 +1,158 @@
+# How It Works
+
+Aether's pipeline processes an Ethereum event from detection to bundle submission in under 15 milliseconds. This page walks through each step.
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph ETH["Ethereum Network"]
+        N1[Eth Nodes<br/>WS / IPC]
+    end
+
+    subgraph RUST["Rust Core — Latency-Critical"]
+        direction LR
+        I[Data Ingestion] --> P[Pool Registry]
+        P --> S[State Management]
+        S --> D[Detector<br/>Bellman-Ford]
+        D --> SIM[Simulator<br/>revm]
+    end
+
+    subgraph GO["Go Execution Layer — Coordination"]
+        direction LR
+        B[Bundle Constructor] --> SUB[Multi-Builder<br/>Submitter]
+        R[Risk Manager] -.-> B
+        M[Monitor<br/>Prometheus] -.-> R
+    end
+
+    subgraph CHAIN["On-Chain — Solidity"]
+        EX[AetherExecutor.sol<br/>Aave V3 Flash Loans → DEX Swaps]
+    end
+
+    N1 -->|"WebSocket events"| I
+    SIM -->|"gRPC over UDS ‹1μs"| B
+    SUB -->|"eth_sendBundle"| BLD[Block Builders<br/>Flashbots / Titan / Beaver / rsync]
+    BLD --> EX
+
+    style RUST fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style GO fill:#151a20,stroke:#5ce6c7,stroke-width:2px,color:#fff
+    style CHAIN fill:#1a1815,stroke:#f5a623,stroke-width:2px,color:#fff
+    style ETH fill:#15151c,stroke:#666,stroke-width:1px,color:#fff
+```
+
+## The Hot Path
+
+<Timeline>
+  <TimelineItem time="0 — 0.2ms" title="Event Ingestion">
+
+Aether maintains WebSocket connections to multiple Ethereum nodes. It subscribes to `newHeads`, `logs`, and `pendingTransactions`. Events are ABI-decoded at compile time via `alloy::sol!` — topic matching takes ~4 CPU cycles, full decode under 200ns per event.
+
+  </TimelineItem>
+  <TimelineItem time="0.2 — 0.5ms" title="State Update">
+
+Pool state is updated in the in-memory store (`DashMap`). The price graph is then refreshed — only edges affected by the update are recomputed using dirty bit tracking.
+
+  </TimelineItem>
+  <TimelineItem time="0.5 — 3ms" title="Arbitrage Detection">
+
+Bellman-Ford (SPFA variant) scans the dirty subgraph for negative weight cycles. When found, ternary search optimizes the input amount for maximum profit across ~100 iterations.
+
+  </TimelineItem>
+  <TimelineItem time="3 — 8ms" title="EVM Simulation">
+
+Each opportunity is simulated in a forked EVM via `revm`. The exact `AetherExecutor.executeArb()` calldata is executed against the latest block state to verify profitability.
+
+  </TimelineItem>
+  <TimelineItem time="8 — 8.5ms" title="gRPC Handoff">
+
+The validated arb is sent from Rust to Go over a Unix Domain Socket. Transport adds sub-microsecond latency — effectively a memory copy.
+
+  </TimelineItem>
+  <TimelineItem time="8.5 — 10ms" title="Bundle Construction">
+
+Go constructs a Flashbots bundle: an arb transaction calling `executeArb()` and a tip transaction sending 90% of profit to the builder's coinbase. Both are EIP-1559 and signed with the searcher key.
+
+  </TimelineItem>
+  <TimelineItem time="10 — 12ms" title="Multi-Builder Submission" color="green">
+
+The signed bundle is submitted simultaneously to all configured builders via goroutine fan-out — Flashbots, Titan, Beaver, and rsync.
+
+  </TimelineItem>
+</Timeline>
+
+## Price Graph Transform
+
+The detection engine uses a mathematical trick to convert arbitrage detection into a well-known graph problem.
+
+<Accordion>
+  <AccordionItem title="Why negative log edge weights?">
+
+Exchange rates are multiplicative — a profitable cycle means:
+
+`rate_1 × rate_2 × ... × rate_n > 1.0`
+
+By storing `-ln(rate)` as edge weights, this becomes additive:
+
+`-ln(rate_1) + -ln(rate_2) + ... + -ln(rate_n) < 0`
+
+A **negative sum** around a cycle means a profitable arbitrage. This is exactly what Bellman-Ford detects — negative weight cycles.
+
+  </AccordionItem>
+  <AccordionItem title="Why SPFA over standard Bellman-Ford?">
+
+Standard Bellman-Ford relaxes all edges V-1 times. SPFA uses a queue that only processes nodes whose distances were actually updated. For the sparse, partially-updated graphs typical in DEX arbitrage, this is 2-3x faster in practice.
+
+The SLF (Shortest-Label-First) optimization further reduces work by inserting shorter-distance nodes at the front of the deque.
+
+  </AccordionItem>
+  <AccordionItem title="How does input optimization work?">
+
+Once a profitable cycle is found, we need the optimal trade size. The profit function is concave for AMM-based DEXes (larger inputs hit diminishing returns from price impact).
+
+Ternary search converges on the maximum in ~60 iterations for U256 precision. This gives us the exact flash loan amount that maximizes net profit after gas and premiums.
+
+  </AccordionItem>
+</Accordion>
+
+## On-Chain Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant S as Searcher EOA
+    participant E as AetherExecutor
+    participant A as Aave V3 Pool
+    participant D1 as DEX 1
+    participant D2 as DEX 2
+
+    S->>E: executeArb(steps, token, amount)
+    E->>A: flashLoanSimple(token, amount)
+    A->>E: Transfer loan amount
+    A->>E: executeOperation() callback
+
+    rect rgba(149, 128, 255, 0.1)
+        Note over E,D2: Swap Sequence
+        E->>D1: swap(tokenA → tokenB)
+        D1-->>E: tokenB received
+        E->>D2: swap(tokenB → tokenA)
+        D2-->>E: tokenA received
+    end
+
+    E->>A: Repay loan + 0.05% premium
+    E->>S: Transfer profit
+```
+
+If at any point the trade is unprofitable, the transaction reverts — the flash loan is never taken, and no gas is spent (bundled transaction).
+
+## Simulation Safety
+
+::: warning Critical Invariant
+The simulation **must** use the same block state as the execution target. Stale simulations produce reverted bundles.
+:::
+
+The simulator forks the latest block state into a `CacheDB`, executes the exact calldata that will be submitted on-chain, and verifies the output. Only opportunities that pass simulation are forwarded to the Go executor.
+
+## Next Steps
+
+- [Getting Started](/guide/getting-started) — Build and run Aether
+- [Architecture Overview](/architecture/overview) — Detailed component breakdown
+- [Rust Core](/architecture/rust-core) — Deep dive into the detection engine

--- a/docs-site/guide/introduction.md
+++ b/docs-site/guide/introduction.md
@@ -1,0 +1,100 @@
+# Introduction
+
+Aether is a production-grade, cross-DEX arbitrage engine for Ethereum Mainnet. It detects and executes price discrepancies across decentralized exchanges in under 15 milliseconds, using flash loans to eliminate capital risk entirely.
+
+## What Problem Does Aether Solve?
+
+Decentralized exchanges on Ethereum often have different prices for the same token pair. When USDC/WETH trades at a different rate on Uniswap V2 vs. SushiSwap, there's a profit opportunity — buy where it's cheap, sell where it's expensive, pocket the difference.
+
+This is **MEV (Maximal Extractable Value) arbitrage**. Aether automates the entire pipeline:
+
+```mermaid
+graph LR
+    A["Detect<br/>price discrepancy"] --> B["Simulate<br/>on forked EVM"]
+    B --> C["Execute<br/>via flash loan"]
+    C --> D["Submit<br/>via Flashbots"]
+
+    style A fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style B fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style C fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style D fill:#151a20,stroke:#5ce6c7,stroke-width:2px,color:#fff
+```
+
+## Supported Protocols
+
+| Protocol | Type | Complexity |
+|---|---|---|
+| Uniswap V2 | Constant Product AMM | O(1) |
+| Uniswap V3 | Concentrated Liquidity | O(n_ticks) |
+| SushiSwap | Constant Product AMM | O(1) |
+| Curve | StableSwap (Newton's method) | O(iterations) |
+| Balancer V2 | Weighted Constant Product | O(1) |
+| Bancor V3 | Bonding Curve with BNT | O(1) |
+
+## Tech Stack
+
+| Layer | Language | Key Libraries |
+|---|---|---|
+| Data Ingestion & ABI Parsing | **Rust** | `tokio`, `alloy`, WebSocket |
+| Pool State Management | **Rust** | `DashMap`, arena allocators |
+| Arbitrage Detection | **Rust** | Bellman-Ford (SPFA), SIMD math |
+| EVM Simulation | **Rust** | `revm` (fork mode) |
+| Bundle Construction & Submission | **Go** | `go-ethereum`, `flashbotsrpc` |
+| Risk Management & Circuit Breakers | **Go** | Stateful controllers, `sync/atomic` |
+| Monitoring & API | **Go** | Prometheus, gRPC, `net/http` |
+| On-Chain Executor | **Solidity** | Aave V3 Flash Loans, OpenZeppelin |
+
+## Core Design Principles
+
+<Accordion>
+  <AccordionItem title="Zero-Copy Hot Path">
+
+Lock-free data structures, arena allocators, and zero-copy deserialization. No heap allocation on the hot path. Every nanosecond matters when competing for MEV.
+
+  </AccordionItem>
+  <AccordionItem title="Separation of Concerns">
+
+Rust handles all latency-critical work (event processing, detection, simulation). Go handles coordination (bundle building, submission, risk management, monitoring). Each language is used where it excels.
+
+  </AccordionItem>
+  <AccordionItem title="Fail-Safe by Default">
+
+Circuit breakers at every component. Gas too high? Auto-halt. Too many reverts? Auto-pause. Balance low? Auto-halt. The system protects itself without human intervention.
+
+  </AccordionItem>
+  <AccordionItem title="Atomic Execution">
+
+All arbitrage trades are flash loan-backed through Aave V3. If the trade isn't profitable after gas costs, the entire transaction reverts. Zero capital is ever at risk.
+
+  </AccordionItem>
+  <AccordionItem title="MEV-Aware Submission">
+
+Bundles are submitted through Flashbots Protect, MEV-Share, and direct builder APIs. Transactions never enter the public mempool, preventing frontrunning.
+
+  </AccordionItem>
+  <AccordionItem title="Extensible Pool Registry">
+
+Adding a new DEX protocol requires implementing a single Rust trait. Pool configuration is hot-reloadable via TOML — no restarts needed.
+
+  </AccordionItem>
+</Accordion>
+
+## Performance Targets
+
+| Metric | Target |
+|---|---|
+| Event decode + state update | <1ms |
+| Bellman-Ford detection | <3ms |
+| EVM simulation (revm) | <5ms |
+| gRPC Rust → Go | <1ms |
+| Bundle build + sign | <2ms |
+| **Total end-to-end** | **<15ms** |
+| Events processed per block | 10,000+ |
+| Pools monitored | 5,000+ |
+| Simulations per second | 200+ |
+
+## Next Steps
+
+- [How It Works](/guide/how-it-works) — Understand the 7-step hot path from event to submission
+- [Getting Started](/guide/getting-started) — Build and run Aether locally
+- [Architecture Overview](/architecture/overview) — Deep dive into the system design

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,0 +1,32 @@
+---
+layout: home
+
+hero:
+  name: Aether
+  text: Cross-DEX Arbitrage Engine
+  tagline: Sub-15ms opportunity detection across 6 DEX protocols on Ethereum Mainnet. Flash loan-backed execution with zero capital at risk.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: How It Works
+      link: /guide/how-it-works
+    - theme: alt
+      text: Architecture
+      link: /architecture/overview
+
+features:
+  - title: Sub-Millisecond Detection
+    details: Bellman-Ford negative cycle scan with SPFA optimization detects arbitrage in under 3ms across 5,000+ monitored pools.
+  - title: Zero Capital Risk
+    details: Every trade is flash loan-backed via Aave V3. Unprofitable transactions revert atomically on-chain. No capital ever at risk.
+  - title: 6 DEX Protocols
+    details: Uniswap V2/V3, SushiSwap, Curve, Balancer, and Bancor. Adding a new DEX is a single trait implementation.
+  - title: Rust + Go + Solidity
+    details: Rust for the latency-critical hot path. Go for coordination and monitoring. Solidity for on-chain settlement.
+  - title: Multi-Builder Submission
+    details: Simultaneous bundle submission to Flashbots, Titan, Beaver, and rsync builders for maximum inclusion probability.
+  - title: Full Observability
+    details: Prometheus metrics, Grafana dashboards, automated circuit breakers, and incident response playbooks.
+---

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -22,7 +22,7 @@ features:
   - title: Zero Capital Risk
     details: Every trade is flash loan-backed via Aave V3. Unprofitable transactions revert atomically on-chain. No capital ever at risk.
   - title: 6 DEX Protocols
-    details: Uniswap V2/V3, SushiSwap, Curve, Balancer, and Bancor. Adding a new DEX is a single trait implementation.
+    details: Uniswap V2/V3, SushiSwap, Curve, Balancer V2, and Bancor V3. Adding a new DEX is a single trait implementation.
   - title: Rust + Go + Solidity
     details: Rust for the latency-critical hot path. Go for coordination and monitoring. Solidity for on-chain settlement.
   - title: Multi-Builder Submission

--- a/docs-site/operations/deployment.md
+++ b/docs-site/operations/deployment.md
@@ -156,18 +156,14 @@ sysctl -w kernel.sched_rt_runtime_us=-1
 
 ## Ansible Provisioning
 
-Server provisioning playbooks are in `deploy/ansible/`:
+Server provisioning is managed via `deploy/ansible/`:
 
 ```bash
-# Provision a new server
-ansible-playbook -i inventory deploy/ansible/provision.yml
-
-# Deploy application
-ansible-playbook -i inventory deploy/ansible/deploy.yml
-
-# Update configuration only
-ansible-playbook -i inventory deploy/ansible/configure.yml
+# Run the provisioning and deployment playbook
+ansible-playbook -i deploy/ansible/inventory.yml deploy/ansible/playbook.yml
 ```
+
+The inventory file (`deploy/ansible/inventory.yml`) defines target hosts. The playbook (`deploy/ansible/playbook.yml`) handles server setup and application deployment.
 
 ## Network Security
 

--- a/docs-site/operations/deployment.md
+++ b/docs-site/operations/deployment.md
@@ -1,0 +1,198 @@
+# Deployment
+
+This page covers deploying Aether across different environments — from local development to production.
+
+## Local Development (Docker Compose)
+
+The fastest way to run the full stack locally:
+
+```bash
+./scripts/deploy.sh docker up
+```
+
+This starts:
+- **aether-rust** — Rust core (gRPC server)
+- **aether-go** — Go executor (bundle construction, risk, monitoring)
+- **Prometheus** — Metrics collection
+
+To stop:
+
+```bash
+./scripts/deploy.sh docker down
+```
+
+### Manual Docker Compose
+
+```bash
+# Start infrastructure only
+docker compose -f deploy/docker/docker-compose.yml up -d prometheus
+
+# Start Rust core
+cargo run --release --bin aether-grpc-server
+
+# Start Go executor (separate terminal)
+go run ./cmd/executor
+```
+
+## Production Deployment
+
+### Build
+
+```bash
+# Build all components
+./scripts/deploy.sh build
+
+# Or build individually:
+RUSTFLAGS="-C target-cpu=native" cargo build --release   # Rust (with LTO)
+go build -o bin/aether-executor ./cmd/executor            # Go
+cd contracts && forge build                               # Solidity
+```
+
+### Deploy
+
+```bash
+# Deploy to staging (runs tests first)
+./scripts/deploy.sh deploy staging
+
+# Deploy to production
+./scripts/deploy.sh deploy production
+
+# Check deployment status
+./scripts/deploy.sh status production
+
+# Rollback if issues
+./scripts/deploy.sh rollback production
+```
+
+### systemd Services
+
+Production runs as two systemd services:
+
+**`aether-rust.service`** — Rust core (gRPC server)
+```ini
+# deploy/systemd/aether-rust.service
+[Unit]
+Description=Aether Rust Core
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/aether/bin/aether-grpc-server
+WorkingDirectory=/opt/aether
+Nice=-20
+CPUAffinity=0 1 2 3
+IOSchedulingClass=realtime
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**`aether-go.service`** — Go executor
+```ini
+# deploy/systemd/aether-go.service
+[Unit]
+Description=Aether Go Executor
+After=aether-rust.service
+Requires=aether-rust.service
+
+[Service]
+Type=simple
+ExecStart=/opt/aether/bin/aether-executor
+WorkingDirectory=/opt/aether
+Environment=GOMAXPROCS=2 GOGC=200
+Nice=-15
+CPUAffinity=4 5
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+::: tip Start Order
+The Go executor depends on the Rust core. systemd handles this via `After=` and `Requires=` directives. For manual starts, always start Rust first, wait 2 seconds, then start Go.
+:::
+
+## Infrastructure Requirements
+
+### Hardware
+
+- **Server:** Bare metal, co-located at Equinix NY5 (same data center as major Ethereum node providers)
+- **CPU:** 6+ cores. Rust core pinned to CPU 0-3, Go executor pinned to CPU 4-5.
+- **Memory:** 4+ GB (Rust <2GB RSS, Go <512MB RSS)
+- **Storage:** SSD for logs and PostgreSQL
+
+### Kernel Tuning
+
+```bash
+# Network latency optimization
+sysctl -w net.ipv4.tcp_nodelay=1
+sysctl -w net.ipv4.tcp_low_latency=1
+
+# Memory optimization
+sysctl -w vm.swappiness=0
+
+# Huge pages (for Rust arena allocators)
+sysctl -w vm.nr_hugepages=1024
+
+# Allow realtime scheduling
+sysctl -w kernel.sched_rt_runtime_us=-1
+```
+
+### CPU Pinning
+
+| Component | CPUs | Nice | IO Scheduling |
+|---|---|---|---|
+| Rust core | 0-3 | -20 | Realtime |
+| Go executor | 4-5 | -15 | Best-effort |
+
+### Failover
+
+- Backup server with standby Reth node + Rust core + Go executor
+- Consul health checks for automatic failover
+- Standby server is always synced and ready to take over
+
+## Ansible Provisioning
+
+Server provisioning playbooks are in `deploy/ansible/`:
+
+```bash
+# Provision a new server
+ansible-playbook -i inventory deploy/ansible/provision.yml
+
+# Deploy application
+ansible-playbook -i inventory deploy/ansible/deploy.yml
+
+# Update configuration only
+ansible-playbook -i inventory deploy/ansible/configure.yml
+```
+
+## Network Security
+
+- **Firewall:** iptables rules allowing only necessary inbound/outbound traffic
+- **Admin access:** WireGuard VPN only
+- **gRPC:** mTLS if communicating over network (UDS is default for same-machine)
+- **Outbound:** Pinned to known IP ranges (Flashbots, builder endpoints, node providers)
+- **No arbitrary outbound traffic** — all connections are explicitly allowed
+
+## Verify Deployment
+
+After deployment, run the health check sequence:
+
+```bash
+# 1. Service status
+systemctl status aether-rust aether-go
+
+# 2. gRPC health
+grpcurl -plaintext localhost:50051 aether.HealthService/Check
+
+# 3. Metrics endpoint
+curl -s http://localhost:9090/metrics | head -20
+
+# 4. Dashboard
+curl -s http://localhost:8080/ | head -5
+```
+
+See [Runbook](/operations/runbook) for detailed operational procedures.

--- a/docs-site/operations/incident-response.md
+++ b/docs-site/operations/incident-response.md
@@ -74,7 +74,7 @@ sudo iptables -I OUTPUT -d 127.0.0.1 -j ACCEPT
 
 ## SEV2: All Ethereum Nodes Down
 
-**Detection:** `aether_node_healthy_count` = 0, system enters HALTED state.
+**Detection:** All node connections enter `Failed` state, system enters HALTED state.
 
 **Actions:**
 
@@ -165,7 +165,7 @@ sudo iptables -I OUTPUT -d 127.0.0.1 -j ACCEPT
    ```
 2. Check price graph size:
    ```bash
-   curl -s http://localhost:9090/metrics | grep aether_pools_monitored
+   curl -s http://localhost:9092/metrics | grep aether_blocks_processed_total
    ```
 3. If graph is too large, prune cold pools:
    ```bash

--- a/docs-site/operations/incident-response.md
+++ b/docs-site/operations/incident-response.md
@@ -196,11 +196,13 @@ sudo iptables -I OUTPUT -d 127.0.0.1 -j ACCEPT
 
 ### Alert Channels
 
-| Channel | Used For | Configuration |
+All alerts route through **Slack** with severity-based channel routing:
+
+| Channel | Severity | Configuration |
 |---|---|---|
-| PagerDuty | SEV1, SEV2 | `config/risk.yaml` → `alerting.pagerduty` |
-| Telegram | SEV2, SEV3 | `config/risk.yaml` → `alerting.telegram` |
-| Discord | All severities | `config/risk.yaml` → `alerting.discord` |
+| `#aether-alerts-sev1` | SEV1 | `config/risk.yaml` → `alerting.slack` |
+| `#aether-alerts-sev2` | SEV2 | `config/risk.yaml` → `alerting.slack` |
+| `#aether-alerts` | SEV3, SEV4 | `config/risk.yaml` → `alerting.slack` |
 
 ### Escalation Path
 

--- a/docs-site/operations/incident-response.md
+++ b/docs-site/operations/incident-response.md
@@ -1,0 +1,219 @@
+# Incident Response
+
+Playbooks for handling incidents affecting the Aether system.
+
+## Severity Levels
+
+| Level | Description | Response Time | Examples |
+|---|---|---|---|
+| **SEV1** | System halted, active loss of funds | Immediate | Private key compromise, contract exploit, unexpected fund drain |
+| **SEV2** | System halted, no loss | 15 min | Gas >300 gwei halt, balance <0.1 ETH, all nodes down |
+| **SEV3** | Degraded performance | 1 hour | Single node down, high revert rate, latency spike |
+| **SEV4** | Minor issue | Next business day | Dashboard down, log aggregation failure, non-critical alert |
+
+## SEV1: Private Key Compromise
+
+**Detection:** Unauthorized transactions from searcher wallet, unexpected balance changes.
+
+::: danger Immediate Actions (within 5 minutes)
+**1. HALT all services immediately**
+```bash
+sudo systemctl stop aether-go aether-rust
+```
+
+**2. Revoke contract permissions**
+```bash
+cast send <EXECUTOR_ADDRESS> "transferOwnership(address)" \
+    0x0000000000000000000000000000000000000001 \
+    --private-key <COLD_WALLET_KEY> --rpc-url <RPC_URL>
+```
+
+**3. Sweep remaining funds from searcher wallet**
+```bash
+cast send <COLD_WALLET> --value $(cast balance <SEARCHER_WALLET>) \
+    --private-key <SEARCHER_KEY> --rpc-url <RPC_URL>
+```
+
+**4. Rescue tokens from executor contract**
+```bash
+cast send <EXECUTOR_ADDRESS> "rescue(address,uint256)" <TOKEN> <AMOUNT> \
+    --private-key <COLD_WALLET_KEY> --rpc-url <RPC_URL>
+```
+
+**5. Block outbound network access**
+```bash
+sudo iptables -A OUTPUT -j DROP
+sudo iptables -I OUTPUT -d 127.0.0.1 -j ACCEPT
+```
+:::
+
+**Investigation:**
+- Review all transactions from searcher wallet: `cast logs --from-block <BLOCK> --address <SEARCHER>`
+- Check for unauthorized SSH access: `last -i`, `journalctl -u sshd`
+- Review process list for unexpected processes: `ps aux`
+- Check for modified binaries: `sha256sum /opt/aether/bin/*`
+
+**Recovery:**
+- Generate new searcher key pair
+- Deploy new AetherExecutor contract
+- Update all configuration with new addresses
+- Rotate all API keys (builder endpoints, node providers)
+- Restore from known-good backup
+
+## SEV1: Contract Exploit
+
+**Detection:** Unexpected token flows in/out of AetherExecutor, failed invariant checks.
+
+::: danger Immediate Actions
+1. Stop all services
+2. Rescue tokens from contract via `rescue()` (cold wallet only)
+3. Analyze the exploit transaction
+4. Deploy patched contract
+5. Update all references to new contract address
+:::
+
+## SEV2: All Ethereum Nodes Down
+
+**Detection:** `aether_node_healthy_count` = 0, system enters HALTED state.
+
+**Actions:**
+
+1. Check node provider status pages (Alchemy, QuickNode, Infura)
+2. Check local Reth/Geth node:
+   ```bash
+   curl -s -X POST -H "Content-Type: application/json" \
+       -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+       http://localhost:8545
+   ```
+3. Try alternative endpoints:
+   ```bash
+   vim /opt/aether/config/nodes.yaml
+   sudo systemctl restart aether-rust
+   ```
+4. If all providers are down, wait — likely a network-wide issue
+
+## SEV2: Gas Price Sustained Above 300 gwei
+
+**Detection:** `aether_gas_price_gwei` > 300 for >5 minutes, system auto-halts.
+
+**Actions:**
+
+1. This is **expected behavior** — the circuit breaker is protecting against unprofitable execution
+2. Monitor gas prices: `curl -s https://api.etherscan.io/api?module=gastracker&action=gasoracle`
+3. Resume when gas drops:
+   ```bash
+   grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+       -d '{"state": "RUNNING"}'
+   ```
+4. If gas is consistently high, consider adjusting threshold in `config/risk.yaml`
+
+## SEV2: Daily Loss Exceeds 0.5 ETH
+
+**Detection:** `aether_daily_pnl_eth` < -0.5, system auto-halts.
+
+::: warning Do NOT immediately resume — investigate first
+:::
+
+**Actions:**
+
+1. Check recent trades:
+   ```bash
+   psql -h localhost -U aether -d aether \
+       -c "SELECT * FROM trades WHERE created_at > NOW() - INTERVAL '24 hours'
+           ORDER BY created_at DESC;"
+   ```
+2. Analyze losing trades:
+   - Were simulations showing profit that didn't materialize?
+   - Is there a new MEV competitor front-running our bundles?
+   - Did pool state change between detection and execution?
+3. Check for systematic issues:
+   ```bash
+   journalctl -u aether-rust -u aether-go --since "24 hours ago" -p err
+   ```
+4. After root cause is identified and fixed:
+   ```bash
+   grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+       -d '{"state": "RUNNING"}'
+   ```
+
+## SEV3: High Revert Rate
+
+**Detection:** >3 consecutive reverts in 10 minutes, system enters PAUSED state.
+
+**Actions:**
+
+1. Check revert reasons:
+   ```bash
+   journalctl -u aether-rust --since "30 minutes ago" | grep -i "revert\|fail"
+   ```
+2. Common causes:
+   - **Stale state** — Usually self-resolving after a few blocks
+   - **MEV competition** — Check if competitors are extracting same opportunities
+   - **Pool state drift** — Verify pool reserve data matches on-chain
+3. System auto-resumes after 10-minute cooldown
+
+## SEV3: Detection Latency Spike
+
+**Detection:** `aether_detection_latency_ms` p99 > 10ms.
+
+**Actions:**
+
+1. Check CPU utilization:
+   ```bash
+   top -b -n1 | head -20
+   mpstat -P 0-3 1 5  # Rust core CPUs
+   ```
+2. Check price graph size:
+   ```bash
+   curl -s http://localhost:9090/metrics | grep aether_pools_monitored
+   ```
+3. If graph is too large, prune cold pools:
+   ```bash
+   vim /opt/aether/config/pools.toml
+   grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig
+   ```
+4. Check for memory pressure:
+   ```bash
+   free -h
+   cat /proc/$(pgrep aether-grpc)/status | grep -i "vmrss\|vmsize"
+   ```
+
+## SEV3: Single Node Provider Down
+
+**Detection:** Node enters `Degraded` or `Failed` state in health checks.
+
+**Actions:**
+
+1. System continues operating with remaining healthy nodes (min 2 required)
+2. Check provider status page
+3. If extended outage, add replacement provider:
+   ```bash
+   vim /opt/aether/config/nodes.yaml
+   sudo systemctl restart aether-rust
+   ```
+
+## Communication
+
+### Alert Channels
+
+| Channel | Used For | Configuration |
+|---|---|---|
+| PagerDuty | SEV1, SEV2 | `config/risk.yaml` → `alerting.pagerduty` |
+| Telegram | SEV2, SEV3 | `config/risk.yaml` → `alerting.telegram` |
+| Discord | All severities | `config/risk.yaml` → `alerting.discord` |
+
+### Escalation Path
+
+1. **Automated alert** fires via configured channels
+2. **On-call engineer** acknowledges within response time SLA
+3. **Follow playbook** for the specific incident type
+4. **Post-incident:** Write brief post-mortem, update playbooks if needed
+
+## Post-Incident Checklist
+
+- [ ] Root cause identified
+- [ ] Fix implemented and deployed
+- [ ] Monitoring/alerting updated if gaps found
+- [ ] Runbook/playbook updated with lessons learned
+- [ ] Affected users/stakeholders notified
+- [ ] Post-mortem document written (for SEV1/SEV2)

--- a/docs-site/operations/monitoring.md
+++ b/docs-site/operations/monitoring.md
@@ -1,0 +1,170 @@
+# Monitoring
+
+Aether exposes comprehensive metrics via Prometheus and provides built-in alerting through PagerDuty, Telegram, and Discord.
+
+## Prometheus Setup
+
+Metrics are exposed by the Go monitor service on `:9090/metrics`. Prometheus scrapes this endpoint at a 15-second interval.
+
+### Prometheus Configuration
+
+The included Prometheus config is at `deploy/docker/prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'aether'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:9090']
+```
+
+### Running Prometheus
+
+```bash
+# Via Docker Compose
+docker compose -f deploy/docker/docker-compose.yml up -d prometheus
+
+# Prometheus UI
+open http://localhost:9090
+```
+
+## Key Metrics
+
+### Counters
+
+| Metric | Description | Alert Threshold |
+|---|---|---|
+| `aether_opportunities_detected_total` | Arbitrage opportunities found | <10/min → warn |
+| `aether_bundles_submitted_total` | Bundles sent to builders | — |
+| `aether_bundles_included_total` | Bundles included on-chain | Inclusion rate <20% → alert |
+
+### Histograms
+
+| Metric | Description | Alert Threshold |
+|---|---|---|
+| `aether_detection_latency_ms` | Detection pipeline latency | p99 >10ms → warn |
+| `aether_simulation_latency_ms` | EVM simulation latency | p99 >50ms → warn |
+| `aether_end_to_end_latency_ms` | Full pipeline latency | p99 >100ms → alert |
+
+### Gauges
+
+| Metric | Description | Alert Threshold |
+|---|---|---|
+| `aether_gas_price_gwei` | Current gas price | >300 → halt |
+| `aether_daily_pnl_eth` | Daily profit/loss in ETH | <-0.5 ETH → halt |
+| `aether_eth_balance` | Searcher wallet balance | <0.1 ETH → halt |
+| `aether_pools_monitored` | Active pool count | — |
+| `aether_node_healthy_count` | Healthy node connections | <2 → degrade |
+
+## PromQL Queries
+
+### Opportunity Detection Rate
+
+```txt
+rate(aether_opportunities_detected_total[5m])
+```
+
+### Bundle Inclusion Rate
+
+```txt
+rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m])
+```
+
+### Detection Latency (p50, p99)
+
+```txt
+# p50
+histogram_quantile(0.5, rate(aether_detection_latency_ms_bucket[5m]))
+
+# p99
+histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
+```
+
+### End-to-End Latency p99
+
+```txt
+histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
+```
+
+### Daily PnL
+
+```txt
+aether_daily_pnl_eth
+```
+
+### Gas Price Trend
+
+```txt
+aether_gas_price_gwei
+```
+
+## Grafana Dashboards
+
+Grafana connects to Prometheus as a data source. Recommended dashboard panels:
+
+1. **System Overview** — Current state (Running/Degraded/Paused/Halted), uptime, active pools
+2. **Latency** — Detection, simulation, and end-to-end latency percentiles over time
+3. **Profitability** — Daily PnL, cumulative PnL, profit per trade
+4. **Bundles** — Submission rate, inclusion rate, miss rate
+5. **Gas** — Gas price trend, gas cost per trade
+6. **Infrastructure** — ETH balance, node health, CPU/memory usage
+
+## Alerting
+
+### Alert Rules
+
+Alerts are triggered by the Go monitor service based on metric thresholds:
+
+| Condition | Severity | Action |
+|---|---|---|
+| Gas price >300 gwei | SEV2 | System auto-halts |
+| 10+ consecutive reverts in 10 min | SEV3 | System auto-pauses |
+| Daily loss >0.5 ETH | SEV2 | System auto-halts |
+| ETH balance <0.1 ETH | SEV2 | System auto-halts |
+| Node latency >500ms | SEV3 | System degrades |
+| Bundle miss rate >80% in 1h | SEV3 | Alert dispatched |
+| Detection latency p99 >10ms | SEV3 | Alert dispatched |
+| Opportunities <10/min | SEV3 | Alert dispatched |
+
+### Alert Channels
+
+| Channel | Used For | Configuration |
+|---|---|---|
+| PagerDuty | SEV1, SEV2 | `config/risk.yaml → alerting.pagerduty` |
+| Telegram | SEV2, SEV3 | `config/risk.yaml → alerting.telegram` |
+| Discord | All severities | `config/risk.yaml → alerting.discord` |
+
+## Log Aggregation
+
+Logs are written to journald and can be aggregated with Loki for centralized search.
+
+### Useful Log Queries
+
+```bash
+# Recent errors from both services
+journalctl -u aether-rust -u aether-go --since "1 hour ago" -p err
+
+# Revert reasons
+journalctl -u aether-rust --since "1 hour ago" | grep -i "revert"
+
+# Bundle submission results
+journalctl -u aether-go --since "1 hour ago" | grep "bundle"
+
+# Node connection issues
+journalctl -u aether-rust --since "1 hour ago" | grep -i "reconnect\|disconnect\|timeout"
+```
+
+## Dashboard
+
+The built-in HTTP dashboard runs on `:8080`:
+
+```bash
+# Check dashboard is up
+curl -s http://localhost:8080/ | head -5
+```
+
+Provides at-a-glance view of:
+- System state and health
+- Recent opportunities and executions
+- Key performance metrics
+- Circuit breaker status

--- a/docs-site/operations/monitoring.md
+++ b/docs-site/operations/monitoring.md
@@ -1,18 +1,19 @@
 # Monitoring
 
-Aether exposes comprehensive metrics via Prometheus and provides built-in alerting through PagerDuty, Telegram, and Discord.
+Aether exposes metrics from two processes. The Rust engine serves histograms and counters on `:9092/metrics`. The Go executor serves metrics on `:9090/metrics` via the Prometheus client library. The Go monitor also serves simplified gauge-style metrics and an HTML dashboard.
 
 ## Prometheus Setup
 
-Metrics are exposed by the Go monitor service on `:9090/metrics`. Prometheus scrapes this endpoint at a 15-second interval.
-
-### Prometheus Configuration
-
-The included Prometheus config is at `deploy/docker/prometheus.yml`:
+Prometheus needs to scrape **both** endpoints:
 
 ```yaml
 scrape_configs:
-  - job_name: 'aether'
+  - job_name: 'aether-rust'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:9092']
+
+  - job_name: 'aether-go'
     scrape_interval: 15s
     static_configs:
       - targets: ['localhost:9090']
@@ -30,71 +31,69 @@ open http://localhost:9090
 
 ## Key Metrics
 
-### Counters
+### From Rust Engine (`:9092`)
 
-| Metric | Description | Alert Threshold |
+| Metric | Type | Description |
 |---|---|---|
-| `aether_opportunities_detected_total` | Arbitrage opportunities found | <10/min → warn |
-| `aether_bundles_submitted_total` | Bundles sent to builders | — |
-| `aether_bundles_included_total` | Bundles included on-chain | Inclusion rate <20% → alert |
+| `aether_detection_latency_ms` | Histogram | Bellman-Ford detection latency |
+| `aether_simulation_latency_ms` | Histogram | EVM simulation latency |
+| `aether_cycles_detected_total` | Counter | Negative cycles found |
+| `aether_simulations_run_total` | Counter | EVM simulations executed |
+| `aether_arbs_published_total` | Counter | Validated arbs sent to Go |
+| `aether_blocks_processed_total` | Counter | Blocks processed |
 
-### Histograms
+### From Go Executor (`:9090`)
 
-| Metric | Description | Alert Threshold |
+| Metric | Type | Description |
 |---|---|---|
-| `aether_detection_latency_ms` | Detection pipeline latency | p99 >10ms → warn |
-| `aether_simulation_latency_ms` | EVM simulation latency | p99 >50ms → warn |
-| `aether_end_to_end_latency_ms` | Full pipeline latency | p99 >100ms → alert |
+| `aether_executor_bundles_submitted_total` | Counter | Bundles submitted to builders |
+| `aether_executor_bundles_included_total` | Counter | Bundles accepted by builders |
+| `aether_executor_profit_wei_total` | Counter | Cumulative net profit (wei) |
+| `aether_executor_gas_spent_wei_total` | Counter | Cumulative gas spent (wei) |
+| `aether_executor_risk_rejections_total` | Counter | Arbs rejected by risk checks |
+| `aether_end_to_end_latency_ms` | Histogram | Detection to submission latency |
+| `aether_gas_price_gwei` | Gauge | Current gas price |
+| `aether_daily_pnl_eth` | Gauge | Daily profit/loss in ETH |
+| `aether_eth_balance` | Gauge | Searcher wallet balance |
 
-### Gauges
+### From Go Monitor (`:9090`)
 
-| Metric | Description | Alert Threshold |
+| Metric | Type | Description |
 |---|---|---|
-| `aether_gas_price_gwei` | Current gas price | >300 → halt |
-| `aether_daily_pnl_eth` | Daily profit/loss in ETH | <-0.5 ETH → halt |
-| `aether_eth_balance` | Searcher wallet balance | <0.1 ETH → halt |
-| `aether_pools_monitored` | Active pool count | — |
-| `aether_node_healthy_count` | Healthy node connections | <2 → degrade |
+| `aether_reverts_total{type="bug"}` | Counter | Bug-caused reverts |
+| `aether_reverts_total{type="competitive"}` | Counter | MEV competition reverts |
+
+See [Metrics Reference](/reference/metrics) for the complete list with bucket values and query examples.
 
 ## PromQL Queries
 
-### Opportunity Detection Rate
+### Detection Latency (from Rust histograms on `:9092`)
 
 ```txt
-rate(aether_opportunities_detected_total[5m])
-```
-
-### Bundle Inclusion Rate
-
-```txt
-rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m])
-```
-
-### Detection Latency (p50, p99)
-
-```txt
-# p50
-histogram_quantile(0.5, rate(aether_detection_latency_ms_bucket[5m]))
+# Average
+rate(aether_detection_latency_ms_sum[5m]) / rate(aether_detection_latency_ms_count[5m])
 
 # p99
 histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
 ```
 
-### End-to-End Latency p99
+### End-to-End Latency (from Go histogram on `:9090`)
 
 ```txt
+# p99
 histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
 ```
 
-### Daily PnL
+### Bundle Inclusion Rate
+
+```txt
+rate(aether_executor_bundles_included_total[5m]) / rate(aether_executor_bundles_submitted_total[5m]) * 100
+```
+
+### Daily PnL and Gas
 
 ```txt
 aether_daily_pnl_eth
-```
-
-### Gas Price Trend
-
-```txt
 aether_gas_price_gwei
 ```
 
@@ -102,37 +101,35 @@ aether_gas_price_gwei
 
 Grafana connects to Prometheus as a data source. Recommended dashboard panels:
 
-1. **System Overview** — Current state (Running/Degraded/Paused/Halted), uptime, active pools
-2. **Latency** — Detection, simulation, and end-to-end latency percentiles over time
-3. **Profitability** — Daily PnL, cumulative PnL, profit per trade
-4. **Bundles** — Submission rate, inclusion rate, miss rate
+1. **System Overview** — Current state, uptime, blocks processed
+2. **Latency** — Detection and simulation percentiles over time (source: Rust `:9092` histograms)
+3. **Profitability** — Daily PnL, cumulative profit, gas costs
+4. **Bundles** — Submission rate, inclusion rate, risk rejections
 5. **Gas** — Gas price trend, gas cost per trade
-6. **Infrastructure** — ETH balance, node health, CPU/memory usage
+6. **Infrastructure** — ETH balance, revert breakdown (bug vs competitive)
 
 ## Alerting
 
 ### Alert Rules
 
-Alerts are triggered by the Go monitor service based on metric thresholds:
+Alerts are triggered by the Go monitor/risk manager based on metric thresholds. See [Risk Parameters](/reference/risk-parameters) for the complete list.
 
 | Condition | Severity | Action |
 |---|---|---|
 | Gas price >300 gwei | SEV2 | System auto-halts |
-| 10+ consecutive reverts in 10 min | SEV3 | System auto-pauses |
+| 10+ bug reverts in 10 min | SEV3 | System auto-pauses |
 | Daily loss >0.5 ETH | SEV2 | System auto-halts |
 | ETH balance <0.1 ETH | SEV2 | System auto-halts |
 | Node latency >500ms | SEV3 | System degrades |
 | Bundle miss rate >80% in 1h | SEV3 | Alert dispatched |
-| Detection latency p99 >10ms | SEV3 | Alert dispatched |
-| Opportunities <10/min | SEV3 | Alert dispatched |
 
 ### Alert Channels
 
 | Channel | Used For | Configuration |
 |---|---|---|
-| PagerDuty | SEV1, SEV2 | `config/risk.yaml → alerting.pagerduty` |
-| Telegram | SEV2, SEV3 | `config/risk.yaml → alerting.telegram` |
-| Discord | All severities | `config/risk.yaml → alerting.discord` |
+| PagerDuty | SEV1, SEV2 | `config/risk.yaml` → `alerting.pagerduty` |
+| Telegram | SEV2, SEV3 | `config/risk.yaml` → `alerting.telegram` |
+| Discord | All severities | `config/risk.yaml` → `alerting.discord` |
 
 ## Log Aggregation
 
@@ -156,15 +153,12 @@ journalctl -u aether-rust --since "1 hour ago" | grep -i "reconnect\|disconnect\
 
 ## Dashboard
 
-The built-in HTTP dashboard runs on `:8080`:
+The built-in HTML dashboard runs on `:8080`, auto-refreshes every 5 seconds, and shows:
+
+- Pipeline stats (blocks, cycles, simulations, arbs, bundles)
+- Financials (daily PnL, gas price, ETH balance)
+- Latency (detection, simulation, executor, total pipeline)
 
 ```bash
-# Check dashboard is up
 curl -s http://localhost:8080/ | head -5
 ```
-
-Provides at-a-glance view of:
-- System state and health
-- Recent opportunities and executions
-- Key performance metrics
-- Circuit breaker status

--- a/docs-site/operations/monitoring.md
+++ b/docs-site/operations/monitoring.md
@@ -4,6 +4,10 @@ Aether exposes metrics from two processes. The Rust engine serves histograms and
 
 ## Prometheus Setup
 
+::: warning Port Collision
+Both the Go executor (`cmd/executor/`) and Go monitor (`cmd/monitor/`) default to `:9090` for their metrics server. If running both services on the same host, set `METRICS_PORT=9091` on one of them to avoid a `ListenAndServe` bind failure.
+:::
+
 Prometheus needs to scrape **both** endpoints:
 
 ```yaml
@@ -125,11 +129,13 @@ Alerts are triggered by the Go monitor/risk manager based on metric thresholds. 
 
 ### Alert Channels
 
-| Channel | Used For | Configuration |
+All alerts route through a single **Slack webhook** with severity-based channel routing:
+
+| Channel | Severity | Configuration |
 |---|---|---|
-| PagerDuty | SEV1, SEV2 | `config/risk.yaml` → `alerting.pagerduty` |
-| Telegram | SEV2, SEV3 | `config/risk.yaml` → `alerting.telegram` |
-| Discord | All severities | `config/risk.yaml` → `alerting.discord` |
+| `#aether-alerts-sev1` | SEV1 | `config/risk.yaml` → `alerting.slack` |
+| `#aether-alerts-sev2` | SEV2 | `config/risk.yaml` → `alerting.slack` |
+| `#aether-alerts` | SEV3, SEV4 | `config/risk.yaml` → `alerting.slack` |
 
 ## Log Aggregation
 

--- a/docs-site/operations/runbook.md
+++ b/docs-site/operations/runbook.md
@@ -219,28 +219,31 @@ curl -s -X POST -H "Content-Type: application/json" \
 
 ### Key Metrics to Watch
 
-| Metric | Normal Range | Action if Abnormal |
-|---|---|---|
-| `aether_opportunities_detected_total` rate | >10/min | Check node connectivity |
-| `aether_bundles_included_total` rate | >20% inclusion | Check builder endpoints |
-| `aether_detection_latency_ms` p99 | <10ms | Check CPU load, price graph size |
-| `aether_simulation_latency_ms` p99 | <50ms | Check RPC latency |
-| `aether_end_to_end_latency_ms` p99 | <100ms | Check all components |
-| `aether_gas_price_gwei` | <100 gwei | System auto-halts at 300 |
-| `aether_daily_pnl_eth` | >0 | Review strategy |
-| `aether_eth_balance` | >0.1 ETH | Top up searcher wallet |
+| Metric | Source | Normal Range | Action if Abnormal |
+|---|---|---|---|
+| `aether_arbs_published_total` rate | Rust `:9092` | >10/min | Check node connectivity |
+| `aether_executor_bundles_included_total` rate | Go `:9090` | >20% inclusion | Check builder endpoints |
+| `aether_detection_latency_ms` avg | Rust `:9092` | <10ms | Check CPU load, graph size |
+| `aether_simulation_latency_ms` avg | Rust `:9092` | <50ms | Check RPC latency |
+| `aether_end_to_end_latency_ms` p99 | Go `:9090` | <100ms | Check all components |
+| `aether_gas_price_gwei` | Go `:9090` | <100 gwei | System auto-halts at 300 |
+| `aether_daily_pnl_eth` | Go `:9090` | >0 | Review strategy |
+| `aether_eth_balance` | Go `:9090` | >0.1 ETH | Top up searcher wallet |
 
 ### Useful PromQL Queries
 
 ```txt
-# Opportunity detection rate (5min window)
-rate(aether_opportunities_detected_total[5m])
+# Arbs published per minute (Rust engine)
+rate(aether_arbs_published_total[5m]) * 60
 
-# Bundle inclusion rate
-rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m])
+# Bundle inclusion rate (Go executor)
+rate(aether_executor_bundles_included_total[5m]) / rate(aether_executor_bundles_submitted_total[5m])
 
-# Detection latency p99
-histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
+# Detection latency average (Rust histogram)
+rate(aether_detection_latency_ms_sum[5m]) / rate(aether_detection_latency_ms_count[5m])
+
+# End-to-end latency p99 (Go histogram)
+histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
 
 # Daily PnL
 aether_daily_pnl_eth

--- a/docs-site/operations/runbook.md
+++ b/docs-site/operations/runbook.md
@@ -1,0 +1,288 @@
+# Runbook
+
+Operational procedures for managing Aether in production.
+
+## Quick Reference
+
+| Action | Command |
+|---|---|
+| Start services | `sudo systemctl start aether-rust aether-go` |
+| Stop services | `sudo systemctl stop aether-go aether-rust` |
+| Restart all | `sudo systemctl restart aether-rust && sleep 2 && sudo systemctl restart aether-go` |
+| View logs | `journalctl -u aether-rust -u aether-go -f` |
+| Check status | `systemctl status aether-rust aether-go` |
+| Dashboard | `http://<host>:8080` |
+| Metrics | `http://<host>:9090/metrics` |
+
+## Service Management
+
+### Starting the System
+
+Always start Rust core before Go executor:
+
+```bash
+sudo systemctl start aether-rust
+# Wait for gRPC server to be ready
+sleep 2
+sudo systemctl start aether-go
+```
+
+### Stopping the System
+
+Stop Go executor first to prevent in-flight bundle submissions:
+
+```bash
+sudo systemctl stop aether-go
+# Wait for pending bundles to complete
+sleep 3
+sudo systemctl stop aether-rust
+```
+
+### Graceful Restart
+
+```bash
+# Stop Go first
+sudo systemctl stop aether-go
+sleep 2
+
+# Restart Rust core
+sudo systemctl restart aether-rust
+sleep 2
+
+# Start Go executor
+sudo systemctl start aether-go
+```
+
+::: warning Service Dependency
+`aether-go` depends on `aether-rust`. Always start Rust first, stop Go first.
+:::
+
+## Configuration Changes
+
+### Hot Reload Pool Config
+
+Pool configuration can be reloaded without restarting any service:
+
+```bash
+# Edit pool config
+vim /opt/aether/config/pools.toml
+
+# Trigger reload via gRPC
+grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig
+```
+
+### Risk Parameter Changes
+
+Risk parameters require Go executor restart:
+
+```bash
+vim /opt/aether/config/risk.yaml
+sudo systemctl restart aether-go
+```
+
+### Node Provider Changes
+
+Node config requires Rust core restart:
+
+```bash
+vim /opt/aether/config/nodes.yaml
+sudo systemctl restart aether-rust
+```
+
+## System States
+
+The risk manager operates a state machine:
+
+| State | Meaning | Automatic Recovery |
+|---|---|---|
+| **Running** | Normal operation | N/A |
+| **Degraded** | Reduced functionality (e.g., node latency) | Yes — returns to Running when condition clears |
+| **Paused** | Arb detection paused (e.g., consecutive reverts) | Yes — after cooldown period (10 min default) |
+| **Halted** | All operations stopped | **No** — requires manual intervention |
+
+### Manual State Reset
+
+To resume from Halted state:
+
+```bash
+# Check why system halted
+journalctl -u aether-go --since "1 hour ago" | grep -i "halt"
+
+# Fix the underlying issue, then:
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+```
+
+## Common Operational Scenarios
+
+### High Gas Price
+
+**Symptom:** System auto-halts when gas >300 gwei.
+
+```bash
+# Check current gas
+curl -s http://localhost:9090/metrics | grep aether_gas_price_gwei
+
+# Wait for gas to drop, then resume
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+```
+
+### Low ETH Balance
+
+**Symptom:** System halts when searcher balance <0.1 ETH.
+
+```bash
+# Check balance
+curl -s http://localhost:9090/metrics | grep aether_eth_balance
+
+# Top up the searcher wallet, then resume
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+```
+
+### Node Connectivity Issues
+
+**Symptom:** Degraded state, no new opportunities detected.
+
+```bash
+# Check node health
+journalctl -u aether-rust --since "10 minutes ago" | grep -i "node\|connect"
+
+# Verify node endpoints
+curl -s -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    http://localhost:8545
+
+# If persistent, update node config
+vim /opt/aether/config/nodes.yaml
+sudo systemctl restart aether-rust
+```
+
+### Consecutive Reverts
+
+**Symptom:** System pauses after consecutive reverts in 10 minutes.
+
+```bash
+# Check revert reasons
+journalctl -u aether-rust --since "30 minutes ago" | grep -i "revert"
+```
+
+Common causes:
+1. **Stale state** (block reorg) — usually self-resolving
+2. **MEV competition** — someone else extracting the same arb
+3. **Pool state changed** between detection and execution
+
+System auto-resumes after cooldown. To force resume:
+
+```bash
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+```
+
+### Deployment
+
+```bash
+# Build, test, deploy
+./scripts/deploy.sh build
+./scripts/deploy.sh test
+./scripts/deploy.sh deploy prod
+
+# Rollback if issues
+./scripts/deploy.sh rollback prod
+```
+
+## Health Checks
+
+### Manual Health Check Sequence
+
+```bash
+# 1. Service status
+systemctl status aether-rust aether-go
+
+# 2. gRPC health
+grpcurl -plaintext localhost:50051 aether.HealthService/Check
+
+# 3. Metrics endpoint
+curl -s http://localhost:9090/metrics | head -20
+
+# 4. Dashboard
+curl -s http://localhost:8080/ | head -5
+
+# 5. Node connectivity
+curl -s -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+    http://localhost:8545
+```
+
+## Monitoring
+
+### Key Metrics to Watch
+
+| Metric | Normal Range | Action if Abnormal |
+|---|---|---|
+| `aether_opportunities_detected_total` rate | >10/min | Check node connectivity |
+| `aether_bundles_included_total` rate | >20% inclusion | Check builder endpoints |
+| `aether_detection_latency_ms` p99 | <10ms | Check CPU load, price graph size |
+| `aether_simulation_latency_ms` p99 | <50ms | Check RPC latency |
+| `aether_end_to_end_latency_ms` p99 | <100ms | Check all components |
+| `aether_gas_price_gwei` | <100 gwei | System auto-halts at 300 |
+| `aether_daily_pnl_eth` | >0 | Review strategy |
+| `aether_eth_balance` | >0.1 ETH | Top up searcher wallet |
+
+### Useful PromQL Queries
+
+```txt
+# Opportunity detection rate (5min window)
+rate(aether_opportunities_detected_total[5m])
+
+# Bundle inclusion rate
+rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m])
+
+# Detection latency p99
+histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
+
+# Daily PnL
+aether_daily_pnl_eth
+
+# Gas price trend
+aether_gas_price_gwei
+```
+
+### Log Analysis
+
+```bash
+# Recent errors
+journalctl -u aether-rust -u aether-go --since "1 hour ago" -p err
+
+# Search for revert reasons
+journalctl -u aether-rust --since "1 hour ago" | grep -i "revert"
+
+# Bundle submission results
+journalctl -u aether-go --since "1 hour ago" | grep "bundle"
+
+# Node connection issues
+journalctl -u aether-rust --since "1 hour ago" | grep -i "reconnect\|disconnect\|timeout"
+```
+
+## Maintenance
+
+### Log Rotation
+
+Logs are managed by journald. Configure retention:
+
+```bash
+# /etc/systemd/journald.conf
+SystemMaxUse=2G
+MaxRetentionSec=7d
+```
+
+### Profit Sweep
+
+Profits are automatically swept from the searcher wallet to the cold wallet every 100 blocks. To check:
+
+```bash
+curl -s http://localhost:9090/metrics | grep aether_eth_balance
+```
+
+Ensure the cold wallet address is configured in `risk.yaml`.

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1,0 +1,3935 @@
+{
+  "name": "aether-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aether-docs",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mermaid": "^11.14.0",
+        "vitepress": "^1.6.4",
+        "vitepress-plugin-mermaid": "^2.0.17"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.1.tgz",
+      "integrity": "sha512-Xxk4l00pYI+jE0PNw8y0MvsQWh5278WRtZQav8/BMMi3HKi2xmeuqe11WJ3y8/6nuBHdv39w76OpJb09TMfAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.1.tgz",
+      "integrity": "sha512-4peZlPXMwTOey9q1rQKMdCnwZb/E95/1e+7KujXpLLSh0FawJzg//U2NM+r4AiJy4+naT2MTBhj0K30yshnVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.1.tgz",
+      "integrity": "sha512-i+aWHHG8NZvGFHtPeMZkxL2Loc6Fm7iaRo15lYSMx8gFL+at9vgdWxhka7mD1fqxkrxXsQstUBCIsSY8FvkEOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.1.tgz",
+      "integrity": "sha512-Hw52Fwapyk/7hMSV/fI4+s3H9MGZEUcRh4VphyXLAk2oLYdndVUkc6KBi0zwHSzwPAr+ZBwFPe2x6naUt9mZGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.1.tgz",
+      "integrity": "sha512-Bn/wtwhJ7p1OD/6pY+Zzn+zlu2N/SJnH46md/PAbvqIzmjVuwjNwD4y0vV5Ov8naeukXdd7UU9v550+v8+mtlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.1.tgz",
+      "integrity": "sha512-0V4Tu0RWR8YxkgI9EPVOZHGE4K5pEIhkLNN0CTkP/rnPsqaaSQpNMYW3/mGWdiKOWbX0iVmwLB9QESk3H0jS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.1.tgz",
+      "integrity": "sha512-jofcWNYMXJDDr87Z2eivlWY6o71Zn7F7aOvQCXSDAo9QTlyf7BhXEsZymLUvF0O1yU9Q9wvrjAWn8uVHYnAvgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.1.tgz",
+      "integrity": "sha512-OteRb8WubcmEvU0YlMJwCXs3Q6xrdkb0v50/qZBJP1TF0CvujFZQM++9BjEkTER/Jr9wbPHvjSFKnbMta0b4dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.1.tgz",
+      "integrity": "sha512-0GmfSgDQK6oiIVXnJvGxtNFOfosBspRTR7csCOYCTL1P8QtxX2vDCIKwTM7xdSAEbJaZ43QlWg25q0Qdsndz8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.1.tgz",
+      "integrity": "sha512-ySuigKEe4YjYV3si8NVk9BHQpFj/1B+ON7DhhvTvbrZJseHQQloxzq0yHwKmznSdlO6C956fx4pcfOKkZClsyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.1.tgz",
+      "integrity": "sha512-Cp8T/B0gVmjFlzzp6eP47hwKh5FGyeqQp1N48/ANDdvdiQkPqLyFHQVDwLBH0LddfIPQE+yqmZIgmKc82haF4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.1.tgz",
+      "integrity": "sha512-XKdGGLikfrlK66ZSXh/vWcXZZ8Vg3byDFbJD8pwEvN1FoBRGxhxya476IY2ohoTymLa4qB5LBRlIa+2TLHx3Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.1.tgz",
+      "integrity": "sha512-mBAU6WyVsDwhHyGM+nodt1/oebHxgvuLlOAoMGbj/1i6LygDHZWDgL1t5JEs37x9Aywv7ZGhqbM1GsfZ54sU6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.1.tgz",
+      "integrity": "sha512-qmo1LXrNKLHvJE6mdQbLnsZAoZvj7VyF2ft4xmbSGWI2WWm87fx/CjUX4kEExt4y0a6T6nEts6ofpUfH5TEE1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.78",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.78.tgz",
+      "integrity": "sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
+      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^6.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.0.0",
+        "khroma": "^2.0.0",
+        "non-layered-tidy-tree-layout": "^2.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "vue": "3.5.32"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.1.tgz",
+      "integrity": "sha512-/bwdue1/8LWELn/DBalGRfuLsXBLXULJo/yOeavJtDu8rBwxIzC6/Rz9Jg19S21VkJvRuZO1k8CZXBMS73mYbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.16.1",
+        "@algolia/client-abtesting": "5.50.1",
+        "@algolia/client-analytics": "5.50.1",
+        "@algolia/client-common": "5.50.1",
+        "@algolia/client-insights": "5.50.1",
+        "@algolia/client-personalization": "5.50.1",
+        "@algolia/client-query-suggestions": "5.50.1",
+        "@algolia/client-search": "5.50.1",
+        "@algolia/ingestion": "1.50.1",
+        "@algolia/monitoring": "1.50.1",
+        "@algolia/recommend": "5.50.1",
+        "@algolia/requester-browser-xhr": "5.50.1",
+        "@algolia/requester-fetch": "5.50.1",
+        "@algolia/requester-node-http": "5.50.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress-plugin-mermaid": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
+      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@mermaid-js/mermaid-mindmap": "^9.3.0"
+      },
+      "peerDependencies": {
+        "mermaid": "10 || 11",
+        "vitepress": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aether-docs",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "mermaid": "^11.14.0",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-mermaid": "^2.0.17"
+  }
+}

--- a/docs-site/reference/api.md
+++ b/docs-site/reference/api.md
@@ -1,0 +1,260 @@
+# gRPC API Reference
+
+Complete API reference for Aether's gRPC services, defined in `proto/aether.proto`.
+
+## Connection
+
+```
+Socket: /tmp/aether.sock (Unix Domain Socket)
+Fallback: localhost:50051 (TCP)
+```
+
+All examples use `grpcurl` with TCP for readability. In production, UDS is the default transport.
+
+## Services
+
+### ArbService
+
+#### `SubmitArb`
+
+Submit a validated arbitrage opportunity for execution.
+
+```protobuf
+rpc SubmitArb(ValidatedArb) returns (SubmitArbResponse);
+```
+
+**Request:** `ValidatedArb` (see [Messages](#validatedarb))
+
+**Response:**
+
+| Field | Type | Description |
+|---|---|---|
+| `accepted` | bool | Whether the arb was accepted for execution |
+| `bundle_hash` | string | Bundle hash (if accepted) |
+| `error` | string | Error message (if rejected) |
+
+**Example:**
+
+```bash
+grpcurl -plaintext localhost:50051 aether.ArbService/SubmitArb \
+    -d '{
+        "id": "arb-001",
+        "block_number": 18000000,
+        "net_profit_wei": "AAAAAAA=",
+        "total_gas": 250000
+    }'
+```
+
+#### `StreamArbs`
+
+Subscribe to a server-side stream of validated arbitrage opportunities.
+
+```protobuf
+rpc StreamArbs(StreamArbsRequest) returns (stream ValidatedArb);
+```
+
+**Request:**
+
+| Field | Type | Description |
+|---|---|---|
+| `min_profit_eth` | double | Minimum net profit filter (ETH). Only opportunities above this threshold are streamed. |
+
+**Response:** Stream of `ValidatedArb` messages.
+
+**Example:**
+
+```bash
+# Stream all opportunities with >0.01 ETH profit
+grpcurl -plaintext localhost:50051 aether.ArbService/StreamArbs \
+    -d '{"min_profit_eth": 0.01}'
+```
+
+---
+
+### HealthService
+
+#### `Check`
+
+Check the health of the Rust detection engine.
+
+```protobuf
+rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+```
+
+**Request:** Empty (no fields).
+
+**Response:**
+
+| Field | Type | Description |
+|---|---|---|
+| `healthy` | bool | Overall health status |
+| `status` | string | Human-readable status message |
+| `uptime_seconds` | int64 | Seconds since engine start |
+| `last_block` | uint64 | Last processed block number |
+| `active_pools` | uint32 | Number of actively monitored pools |
+
+**Example:**
+
+```bash
+grpcurl -plaintext localhost:50051 aether.HealthService/Check
+```
+
+**Sample response:**
+
+```json
+{
+  "healthy": true,
+  "status": "running",
+  "uptimeSeconds": "3600",
+  "lastBlock": "18000000",
+  "activePools": 4200
+}
+```
+
+---
+
+### ControlService
+
+#### `SetState`
+
+Set the system state (pause/resume detection).
+
+```protobuf
+rpc SetState(SetStateRequest) returns (SetStateResponse);
+```
+
+**Request:**
+
+| Field | Type | Description |
+|---|---|---|
+| `state` | SystemState | Target state |
+| `reason` | string | Optional reason for the state change |
+
+**Response:**
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | bool | Whether the state change succeeded |
+| `previous_state` | SystemState | State before the change |
+
+**Examples:**
+
+```bash
+# Pause detection
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "PAUSED", "reason": "manual maintenance"}'
+
+# Resume detection
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+
+# Emergency halt
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "HALTED", "reason": "investigating anomaly"}'
+```
+
+#### `ReloadConfig`
+
+Hot-reload the pool configuration from `pools.toml`.
+
+```protobuf
+rpc ReloadConfig(ReloadConfigRequest) returns (ReloadConfigResponse);
+```
+
+**Request:**
+
+| Field | Type | Description |
+|---|---|---|
+| `config_path` | string | Optional custom config path (defaults to `config/pools.toml`) |
+
+**Response:**
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | bool | Whether the reload succeeded |
+| `pools_loaded` | uint32 | Number of pools loaded from config |
+| `error` | string | Error message (if failed) |
+
+**Example:**
+
+```bash
+# Reload default config
+grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig
+
+# Reload from custom path
+grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig \
+    -d '{"config_path": "/opt/aether/config/pools-staging.toml"}'
+```
+
+## Enums
+
+### ProtocolType
+
+| Value | Number | Description |
+|---|---|---|
+| `PROTOCOL_UNKNOWN` | 0 | Unknown/unset |
+| `UNISWAP_V2` | 1 | Uniswap V2 (constant product) |
+| `UNISWAP_V3` | 2 | Uniswap V3 (concentrated liquidity) |
+| `SUSHISWAP` | 3 | SushiSwap (constant product) |
+| `CURVE` | 4 | Curve Finance (StableSwap) |
+| `BALANCER_V2` | 5 | Balancer V2 (weighted pools) |
+| `BANCOR_V3` | 6 | Bancor V3 (bonding curve) |
+
+### SystemState
+
+| Value | Number | Description |
+|---|---|---|
+| `STATE_UNKNOWN` | 0 | Unknown/unset |
+| `RUNNING` | 1 | Normal operation |
+| `DEGRADED` | 2 | Reduced functionality |
+| `PAUSED` | 3 | Detection paused |
+| `HALTED` | 4 | All operations stopped |
+
+## Messages
+
+### ValidatedArb
+
+A simulation-verified arbitrage opportunity ready for execution.
+
+| Field | Number | Type | Description |
+|---|---|---|---|
+| `id` | 1 | string | Unique opportunity identifier |
+| `hops` | 2 | repeated ArbHop | Hop sequence from detection |
+| `total_profit_wei` | 3 | bytes | Gross profit (big-endian U256) |
+| `total_gas` | 4 | uint64 | Estimated total gas usage |
+| `gas_cost_wei` | 5 | bytes | Gas cost (big-endian U256) |
+| `net_profit_wei` | 6 | bytes | Net profit after gas + premium |
+| `block_number` | 7 | uint64 | Target execution block |
+| `timestamp_ns` | 8 | int64 | Detection timestamp (ns since epoch) |
+| `flashloan_token` | 9 | bytes | Token address to borrow |
+| `flashloan_amount` | 10 | bytes | Amount to borrow (big-endian U256) |
+| `steps` | 11 | repeated SwapStep | Execution steps with calldata |
+| `calldata` | 12 | bytes | Pre-built AetherExecutor calldata |
+
+### ArbHop
+
+A single hop in the detected arbitrage path.
+
+| Field | Number | Type | Description |
+|---|---|---|---|
+| `protocol` | 1 | ProtocolType | DEX protocol |
+| `pool_address` | 2 | bytes | Pool contract address (20 bytes) |
+| `token_in` | 3 | bytes | Input token address |
+| `token_out` | 4 | bytes | Output token address |
+| `amount_in` | 5 | bytes | Input amount (big-endian U256) |
+| `expected_out` | 6 | bytes | Expected output amount |
+| `estimated_gas` | 7 | uint64 | Estimated gas for this hop |
+
+### SwapStep
+
+A single swap step for on-chain execution.
+
+| Field | Number | Type | Description |
+|---|---|---|---|
+| `protocol` | 1 | ProtocolType | DEX protocol |
+| `pool_address` | 2 | bytes | Pool contract address |
+| `token_in` | 3 | bytes | Input token address |
+| `token_out` | 4 | bytes | Output token address |
+| `amount_in` | 5 | bytes | Input amount |
+| `min_amount_out` | 6 | bytes | Minimum output (slippage protection) |
+| `calldata` | 7 | bytes | Protocol-specific swap calldata |

--- a/docs-site/reference/configuration.md
+++ b/docs-site/reference/configuration.md
@@ -1,0 +1,216 @@
+# Configuration Reference
+
+Complete reference for all Aether configuration files.
+
+## `config/pools.toml`
+
+**Hot-reloadable:** Yes (via `grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig`)
+
+Defines the DEX pools that Aether monitors for arbitrage opportunities.
+
+### Pool Entry
+
+```toml
+[[pools]]
+protocol = "uniswap_v2"
+address = "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"
+token0 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+token1 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+fee_bps = 30
+tier = "hot"
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `protocol` | string | Yes | Protocol identifier (see below) |
+| `address` | string | Yes | Pool contract address (checksummed) |
+| `token0` | string | Yes | First token address |
+| `token1` | string | Yes | Second token address |
+| `fee_bps` | integer | Yes | Pool fee in basis points (30 = 0.3%) |
+| `tier` | string | Yes | Update frequency tier |
+| `tick_spacing` | integer | UniV3 only | Tick spacing for Uniswap V3 pools |
+
+### Protocol Values
+
+| Value | Protocol |
+|---|---|
+| `uniswap_v2` | Uniswap V2 |
+| `uniswap_v3` | Uniswap V3 |
+| `sushiswap` | SushiSwap |
+| `curve` | Curve Finance |
+| `balancer_v2` | Balancer V2 |
+| `bancor_v3` | Bancor V3 |
+
+### Tier Values
+
+| Value | Update Frequency | Use For |
+|---|---|---|
+| `hot` | Every block | High-liquidity, frequently-traded pools |
+| `warm` | Every N blocks | Medium-activity pools |
+| `cold` | On-demand | Low-activity pools, checked only when graph suggests opportunity |
+
+### Pool Qualification Criteria
+
+Pools must meet these thresholds to be added:
+- Liquidity >$10,000
+- 24h volume >$1,000
+- Age >100 blocks
+- Rug-pull score <0.3
+
+---
+
+## `config/risk.yaml`
+
+**Hot-reloadable:** No (requires `sudo systemctl restart aether-go`)
+
+### Circuit Breakers
+
+```yaml
+circuit_breakers:
+  max_gas_gwei: 300
+  consecutive_reverts_pause: 10
+  revert_window_minutes: 10
+  daily_loss_halt_eth: 0.5
+  min_eth_balance: 0.1
+  max_node_latency_ms: 500
+  bundle_miss_rate_alert_pct: 80
+  bundle_miss_rate_window_minutes: 60
+  competitive_revert_alert_pct: 90
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_gas_gwei` | integer | 300 | Gas price threshold → HALT |
+| `consecutive_reverts_pause` | integer | 10 | Bug revert count → PAUSE |
+| `revert_window_minutes` | integer | 10 | Window for counting reverts |
+| `daily_loss_halt_eth` | float | 0.5 | Daily loss threshold → HALT |
+| `min_eth_balance` | float | 0.1 | Min searcher balance → HALT |
+| `max_node_latency_ms` | integer | 500 | Node latency threshold → DEGRADE |
+| `bundle_miss_rate_alert_pct` | integer | 80 | Bundle miss rate → ALERT |
+| `bundle_miss_rate_window_minutes` | integer | 60 | Window for miss rate calculation |
+| `competitive_revert_alert_pct` | integer | 90 | Competitive revert rate → ALERT |
+
+::: tip
+Only bug reverts count toward `consecutive_reverts_pause`. Competitive/MEV reverts (where another searcher captured the same opportunity) are excluded.
+:::
+
+### Position Limits
+
+```yaml
+position_limits:
+  max_single_trade_eth: 50.0
+  max_daily_volume_eth: 500.0
+  min_profit_eth: 0.001
+  min_tip_share_pct: 50
+  max_tip_share_pct: 95
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_single_trade_eth` | float | 50.0 | Maximum ETH value per trade |
+| `max_daily_volume_eth` | float | 500.0 | Maximum daily trading volume |
+| `min_profit_eth` | float | 0.001 | Minimum net profit to execute |
+| `min_tip_share_pct` | integer | 50 | Minimum % of profit sent to builder |
+| `max_tip_share_pct` | integer | 95 | Maximum % of profit sent to builder |
+
+### System
+
+```yaml
+system:
+  initial_state: "running"
+  manual_reset_required_from_halted: true
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `initial_state` | string | `running` | State on startup (`running`, `paused`) |
+| `manual_reset_required_from_halted` | boolean | true | Require manual intervention to exit HALTED |
+
+---
+
+## `config/nodes.yaml`
+
+**Hot-reloadable:** No (requires `sudo systemctl restart aether-rust`)
+
+```yaml
+nodes:
+  - name: "alchemy-ws"
+    url: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+    type: "websocket"
+    priority: 1
+  - name: "local-reth"
+    url: "/tmp/reth.ipc"
+    type: "ipc"
+    priority: 0
+
+min_healthy_nodes: 2
+```
+
+### Node Entry
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Human-readable identifier |
+| `url` | string | Yes | Connection URL (WS URL or IPC path) |
+| `type` | string | Yes | `websocket` or `ipc` |
+| `priority` | integer | Yes | Lower = preferred (0 is highest priority) |
+
+### Global Settings
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `min_healthy_nodes` | integer | 2 | Minimum healthy nodes before degrading |
+
+### Environment Variables
+
+URLs support `${VAR_NAME}` syntax for environment variable expansion. Variables are expanded at startup.
+
+---
+
+## `config/builders.yaml`
+
+**Hot-reloadable:** No (requires `sudo systemctl restart aether-go`)
+
+```yaml
+builders:
+  - name: "flashbots"
+    url: "https://relay.flashbots.net"
+    enabled: true
+    timeout_ms: 2000
+    auth_type: "flashbots"
+  - name: "titan"
+    url: "https://rpc.titanbuilder.xyz"
+    enabled: true
+    timeout_ms: 2000
+    auth_type: "none"
+
+submission:
+  fan_out: true
+  max_retries: 2
+```
+
+### Builder Entry
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Human-readable identifier |
+| `url` | string | Yes | Builder API endpoint URL |
+| `enabled` | boolean | Yes | Whether to submit to this builder |
+| `timeout_ms` | integer | Yes | Request timeout in milliseconds |
+| `auth_type` | string | Yes | Authentication type (see below) |
+| `auth_key` | string | No | API key (for `api_key` auth type) |
+
+### Auth Types
+
+| Value | Description |
+|---|---|
+| `flashbots` | Flashbots-style signed header (uses searcher private key) |
+| `api_key` | Bearer token authentication (set via `auth_key` field) |
+| `none` | No authentication |
+
+### Submission Settings
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `fan_out` | boolean | true | Submit to all enabled builders simultaneously |
+| `max_retries` | integer | 2 | Max retry attempts per builder per bundle |

--- a/docs-site/reference/metrics.md
+++ b/docs-site/reference/metrics.md
@@ -1,78 +1,120 @@
 # Metrics Reference
 
-Complete reference for all Prometheus metrics exposed by Aether on `:9090/metrics`.
+Aether exposes metrics from two processes. The Rust engine serves real Prometheus histograms and counters on `:9092/metrics`. The Go executor serves metrics via the Prometheus client library on `:9090/metrics`. The Go monitor service also exposes simplified gauge-style metrics on `:9090/metrics`.
 
-## Counters
+## Rust Engine Metrics (`:9092`)
 
-| Metric | Description | Labels |
+### Histograms
+
+| Metric | Description | Buckets (ms) |
 |---|---|---|
-| `aether_opportunities_detected_total` | Total arbitrage opportunities detected | — |
-| `aether_bundles_submitted_total` | Total bundles submitted to builders | `builder` |
-| `aether_bundles_included_total` | Total bundles included on-chain | `builder` |
-| `aether_bundles_reverted_total` | Total bundles that reverted on-chain | `reason` |
-| `aether_events_processed_total` | Total events decoded and processed | `event_type` |
-| `aether_simulations_total` | Total EVM simulations executed | `result` (success/revert/halt) |
+| `aether_detection_latency_ms` | Bellman-Ford detection latency | 0.1, 0.5, 1, 3, 5, 10, 50 |
+| `aether_simulation_latency_ms` | EVM simulation latency | 0.5, 1, 2, 5, 10, 25, 50, 75, 100, 250, 500 |
 
-## Histograms
+These are real Prometheus histograms that emit `_bucket`, `_sum`, and `_count` series. You can compute percentiles and averages from them.
 
-| Metric | Description | Buckets |
+### Counters
+
+| Metric | Description |
+|---|---|
+| `aether_cycles_detected_total` | Total negative cycles detected by Bellman-Ford |
+| `aether_simulations_run_total` | Total EVM simulations executed |
+| `aether_arbs_published_total` | Total validated arbs published to Go via gRPC |
+| `aether_blocks_processed_total` | Total blocks processed |
+
+## Go Executor Metrics (`:9090`)
+
+### Counters
+
+| Metric | Description |
+|---|---|
+| `aether_executor_bundles_submitted_total` | Bundles submitted for builder fan-out |
+| `aether_executor_bundles_included_total` | Bundles with at least one builder acceptance |
+| `aether_executor_profit_wei_total` | Cumulative estimated net profit (wei) |
+| `aether_executor_gas_spent_wei_total` | Cumulative estimated gas spent (wei) |
+| `aether_executor_risk_rejections_total` | Arbs rejected by preflight risk checks |
+
+### Histogram
+
+| Metric | Description | Buckets (ms) |
 |---|---|---|
-| `aether_detection_latency_ms` | Time from event to opportunity detection | 0.5, 1, 2, 3, 5, 10, 20 |
-| `aether_simulation_latency_ms` | Time for EVM simulation | 1, 2, 5, 10, 20, 50, 100 |
-| `aether_end_to_end_latency_ms` | Full pipeline: event to bundle submission | 5, 10, 15, 20, 50, 100, 200 |
-| `aether_submission_latency_ms` | Time to submit bundle to builders | 10, 50, 100, 500, 1000, 2000 |
+| `aether_end_to_end_latency_ms` | Arb detection to bundle submission | 10, 50, 75, 100, 250, 500, 1000, 2000, 5000 |
 
-## Gauges
+This is a real Prometheus histogram (emits `_bucket`, `_sum`, `_count`).
+
+### Gauges
 
 | Metric | Description | Unit |
 |---|---|---|
-| `aether_gas_price_gwei` | Current gas price | gwei |
-| `aether_daily_pnl_eth` | Daily profit/loss | ETH |
+| `aether_gas_price_gwei` | Current gas oracle base fee | gwei |
+| `aether_daily_pnl_eth` | Daily profit minus gas costs (resets at UTC midnight) | ETH |
 | `aether_eth_balance` | Searcher wallet balance | ETH |
-| `aether_pools_monitored` | Number of actively monitored pools | count |
-| `aether_node_healthy_count` | Number of healthy node connections | count |
-| `aether_system_state` | Current system state (1=Running, 2=Degraded, 3=Paused, 4=Halted) | enum |
+
+## Go Monitor Metrics (`:9090`)
+
+The monitor service also emits simplified metrics (stored as last-value gauges, not histograms):
+
+| Metric | Prometheus Type | Description |
+|---|---|---|
+| `aether_opportunities_detected_total` | counter | Total arbitrage opportunities detected |
+| `aether_bundles_submitted_total` | counter | Total bundles submitted |
+| `aether_bundles_included_total` | counter | Total bundles included on-chain |
+| `aether_reverts_total{type="bug"}` | counter | Reverts caused by bugs |
+| `aether_reverts_total{type="competitive"}` | counter | Reverts from MEV competition |
+| `aether_gas_price_gwei` | gauge | Current gas price |
+| `aether_detection_latency_ms` | gauge | Last detection latency (not a histogram) |
+| `aether_simulation_latency_ms` | gauge | Last simulation latency (not a histogram) |
+| `aether_end_to_end_latency_ms` | gauge | Last end-to-end latency (not a histogram) |
+| `aether_eth_balance` | gauge | Searcher wallet balance |
+
+::: warning Monitor vs. Engine Metrics
+The Rust engine emits `aether_detection_latency_ms` and `aether_simulation_latency_ms` as **real Prometheus histograms** (with `_bucket`, `_sum`, `_count`). The Go monitor emits metrics with the same names but as **gauges** storing only the last observed value. Use the Rust engine endpoint (`:9092`) for accurate percentile queries. The monitor gauges are for the dashboard display only.
+:::
 
 ## Alert Thresholds
 
-| Metric | Condition | Severity | Action |
-|---|---|---|---|
-| `aether_opportunities_detected_total` | rate <10/min | Warn | Check node connectivity |
-| `aether_bundles_included_total` | inclusion rate <20% | Alert | Check builder endpoints |
-| `aether_detection_latency_ms` | p99 >10ms | Warn | Check CPU, graph size |
-| `aether_simulation_latency_ms` | p99 >50ms | Warn | Check RPC latency |
-| `aether_end_to_end_latency_ms` | p99 >100ms | Alert | Check all components |
-| `aether_gas_price_gwei` | >300 | SEV2 | System auto-halts |
-| `aether_daily_pnl_eth` | <-0.5 | SEV2 | System auto-halts |
-| `aether_eth_balance` | <0.1 | SEV2 | System auto-halts |
+These are documented in [Risk Parameters](/reference/risk-parameters) and configured in `config/risk.yaml`. Key thresholds:
 
-## Common PromQL Queries
+| Condition | Severity | Action |
+|---|---|---|
+| Gas price >300 gwei | SEV2 | System auto-halts |
+| Daily loss >0.5 ETH | SEV2 | System auto-halts |
+| ETH balance <0.1 ETH | SEV2 | System auto-halts |
+| 10+ consecutive bug reverts in 10 min | SEV3 | System auto-pauses |
+| Node latency >500ms | SEV3 | System degrades |
+| Bundle miss rate >80% in 1h | SEV3 | Alert dispatched |
+| Competitive revert rate >90% | SEV3 | Alert dispatched |
 
-### Detection Rate
+## PromQL Queries
+
+### Detection Latency (Rust engine histograms)
 
 ```txt
-# Opportunities per minute (5min window)
-rate(aether_opportunities_detected_total[5m]) * 60
+# Average detection latency (from histogram sum/count)
+rate(aether_detection_latency_ms_sum[5m]) / rate(aether_detection_latency_ms_count[5m])
+
+# Detection latency p99
+histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
+```
+
+::: tip
+These queries target the Rust engine's real histograms on `:9092`. They will return empty if pointed at the monitor's gauge-style metrics on `:9090`.
+:::
+
+### End-to-End Latency (Go executor histogram)
+
+```txt
+# Average end-to-end latency
+rate(aether_end_to_end_latency_ms_sum[5m]) / rate(aether_end_to_end_latency_ms_count[5m])
+
+# End-to-end latency p99
+histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
 ```
 
 ### Bundle Inclusion Rate
 
 ```txt
-# Inclusion percentage
-rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m]) * 100
-```
-
-### Latency Percentiles
-
-```txt
-# Detection p50
-histogram_quantile(0.5, rate(aether_detection_latency_ms_bucket[5m]))
-
-# Detection p99
-histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
-
-# End-to-end p99
-histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
+rate(aether_executor_bundles_included_total[5m]) / rate(aether_executor_bundles_submitted_total[5m]) * 100
 ```
 
 ### Profitability
@@ -81,16 +123,22 @@ histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
 # Daily PnL
 aether_daily_pnl_eth
 
-# Gas cost trend
+# Gas price
 aether_gas_price_gwei
+
+# Cumulative profit
+aether_executor_profit_wei_total
 ```
 
-### Per-Builder Performance
+### Pipeline Throughput
 
 ```txt
-# Submissions per builder
-rate(aether_bundles_submitted_total[5m]) by (builder)
+# Blocks per minute
+rate(aether_blocks_processed_total[5m]) * 60
 
-# Inclusion rate per builder
-rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m]) by (builder)
+# Cycles detected per minute
+rate(aether_cycles_detected_total[5m]) * 60
+
+# Arbs published per minute
+rate(aether_arbs_published_total[5m]) * 60
 ```

--- a/docs-site/reference/metrics.md
+++ b/docs-site/reference/metrics.md
@@ -1,0 +1,96 @@
+# Metrics Reference
+
+Complete reference for all Prometheus metrics exposed by Aether on `:9090/metrics`.
+
+## Counters
+
+| Metric | Description | Labels |
+|---|---|---|
+| `aether_opportunities_detected_total` | Total arbitrage opportunities detected | — |
+| `aether_bundles_submitted_total` | Total bundles submitted to builders | `builder` |
+| `aether_bundles_included_total` | Total bundles included on-chain | `builder` |
+| `aether_bundles_reverted_total` | Total bundles that reverted on-chain | `reason` |
+| `aether_events_processed_total` | Total events decoded and processed | `event_type` |
+| `aether_simulations_total` | Total EVM simulations executed | `result` (success/revert/halt) |
+
+## Histograms
+
+| Metric | Description | Buckets |
+|---|---|---|
+| `aether_detection_latency_ms` | Time from event to opportunity detection | 0.5, 1, 2, 3, 5, 10, 20 |
+| `aether_simulation_latency_ms` | Time for EVM simulation | 1, 2, 5, 10, 20, 50, 100 |
+| `aether_end_to_end_latency_ms` | Full pipeline: event to bundle submission | 5, 10, 15, 20, 50, 100, 200 |
+| `aether_submission_latency_ms` | Time to submit bundle to builders | 10, 50, 100, 500, 1000, 2000 |
+
+## Gauges
+
+| Metric | Description | Unit |
+|---|---|---|
+| `aether_gas_price_gwei` | Current gas price | gwei |
+| `aether_daily_pnl_eth` | Daily profit/loss | ETH |
+| `aether_eth_balance` | Searcher wallet balance | ETH |
+| `aether_pools_monitored` | Number of actively monitored pools | count |
+| `aether_node_healthy_count` | Number of healthy node connections | count |
+| `aether_system_state` | Current system state (1=Running, 2=Degraded, 3=Paused, 4=Halted) | enum |
+
+## Alert Thresholds
+
+| Metric | Condition | Severity | Action |
+|---|---|---|---|
+| `aether_opportunities_detected_total` | rate <10/min | Warn | Check node connectivity |
+| `aether_bundles_included_total` | inclusion rate <20% | Alert | Check builder endpoints |
+| `aether_detection_latency_ms` | p99 >10ms | Warn | Check CPU, graph size |
+| `aether_simulation_latency_ms` | p99 >50ms | Warn | Check RPC latency |
+| `aether_end_to_end_latency_ms` | p99 >100ms | Alert | Check all components |
+| `aether_gas_price_gwei` | >300 | SEV2 | System auto-halts |
+| `aether_daily_pnl_eth` | <-0.5 | SEV2 | System auto-halts |
+| `aether_eth_balance` | <0.1 | SEV2 | System auto-halts |
+
+## Common PromQL Queries
+
+### Detection Rate
+
+```txt
+# Opportunities per minute (5min window)
+rate(aether_opportunities_detected_total[5m]) * 60
+```
+
+### Bundle Inclusion Rate
+
+```txt
+# Inclusion percentage
+rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m]) * 100
+```
+
+### Latency Percentiles
+
+```txt
+# Detection p50
+histogram_quantile(0.5, rate(aether_detection_latency_ms_bucket[5m]))
+
+# Detection p99
+histogram_quantile(0.99, rate(aether_detection_latency_ms_bucket[5m]))
+
+# End-to-end p99
+histogram_quantile(0.99, rate(aether_end_to_end_latency_ms_bucket[5m]))
+```
+
+### Profitability
+
+```txt
+# Daily PnL
+aether_daily_pnl_eth
+
+# Gas cost trend
+aether_gas_price_gwei
+```
+
+### Per-Builder Performance
+
+```txt
+# Submissions per builder
+rate(aether_bundles_submitted_total[5m]) by (builder)
+
+# Inclusion rate per builder
+rate(aether_bundles_included_total[5m]) / rate(aether_bundles_submitted_total[5m]) by (builder)
+```

--- a/docs-site/reference/metrics.md
+++ b/docs-site/reference/metrics.md
@@ -22,6 +22,10 @@ These are real Prometheus histograms that emit `_bucket`, `_sum`, and `_count` s
 | `aether_arbs_published_total` | Total validated arbs published to Go via gRPC |
 | `aether_blocks_processed_total` | Total blocks processed |
 
+::: warning Port Collision
+Both the Go executor (`cmd/executor/`) and Go monitor (`cmd/monitor/`) default to `:9090` for their metrics server. If running both services on the same host, set `METRICS_PORT=9091` on one of them to avoid a `ListenAndServe` bind failure.
+:::
+
 ## Go Executor Metrics (`:9090`)
 
 ### Counters

--- a/docs-site/reference/risk-parameters.md
+++ b/docs-site/reference/risk-parameters.md
@@ -1,0 +1,149 @@
+# Risk Parameters
+
+Detailed documentation of Aether's risk management system — circuit breakers, position limits, and system state machine.
+
+## System State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running
+    Running --> Degraded: node latency > 500ms
+    Degraded --> Running: condition clears
+    Running --> Paused: consecutive reverts
+    Paused --> Running: 10min cooldown
+    Running --> Halted: gas / loss / balance breaker
+    Degraded --> Halted: gas / loss / balance breaker
+    Halted --> Running: manual reset only
+```
+
+| State | Description | Entry Conditions | Recovery |
+|---|---|---|---|
+| **Running** | Normal operation | Startup, manual reset | — |
+| **Degraded** | Reduced functionality | Node latency >500ms | Automatic when condition clears |
+| **Paused** | Detection stopped | Consecutive reverts | Automatic after 10-minute cooldown |
+| **Halted** | All operations stopped | Gas >300 gwei, daily loss, low balance | **Manual reset required** |
+
+### Manual State Reset
+
+```bash
+# Resume from any non-Running state
+grpcurl -plaintext localhost:50051 aether.ControlService/SetState \
+    -d '{"state": "RUNNING"}'
+```
+
+::: danger
+Only resume from HALTED after investigating and fixing the root cause. Resuming blindly can result in further losses.
+:::
+
+## Circuit Breakers
+
+### Gas Price Breaker
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 300 gwei | `circuit_breakers.max_gas_gwei` |
+| Action | **HALT** | — |
+| Recovery | Manual reset after gas drops | — |
+
+**Rationale:** At 300+ gwei, gas costs consume most or all of the arbitrage profit. Executing trades at these gas prices is almost certainly unprofitable.
+
+### Consecutive Reverts Breaker
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 10 reverts | `circuit_breakers.consecutive_reverts_pause` |
+| Window | 10 minutes | `circuit_breakers.revert_window_minutes` |
+| Action | **PAUSE** | — |
+| Recovery | Automatic after 10-minute cooldown | — |
+
+**Rationale:** Multiple consecutive reverts suggest a systematic issue (stale state, aggressive competition, or a bug). Pausing prevents further wasted gas while the issue resolves or is investigated.
+
+::: tip
+Only **bug reverts** count toward this threshold. Competitive/MEV reverts (where another searcher captured the same opportunity first) are excluded and tracked separately via `competitive_revert_alert_pct`.
+:::
+
+### Daily Loss Breaker
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 0.5 ETH loss | `circuit_breakers.daily_loss_halt_eth` |
+| Action | **HALT** | — |
+| Recovery | Manual reset after investigation | — |
+
+**Rationale:** A daily loss exceeding 0.5 ETH indicates something is fundamentally wrong — either the strategy is losing money, or there's a bug causing failed trades with gas costs.
+
+### Balance Breaker
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 0.1 ETH | `circuit_breakers.min_eth_balance` |
+| Action | **HALT** | — |
+| Recovery | Manual reset after topping up wallet | — |
+
+**Rationale:** The searcher wallet needs ETH for gas. If balance drops below 0.1 ETH, there's not enough gas budget for safe operation.
+
+### Node Latency Breaker
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 500ms | `circuit_breakers.max_node_latency_ms` |
+| Action | **DEGRADE** | — |
+| Recovery | Automatic when latency drops | — |
+
+**Rationale:** High node latency means stale state data, leading to inaccurate detection and reverted trades.
+
+### Bundle Miss Rate Alert
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 80% miss rate | `circuit_breakers.bundle_miss_rate_alert_pct` |
+| Window | 60 minutes | `circuit_breakers.bundle_miss_rate_window_minutes` |
+| Action | **ALERT** | — |
+
+**Rationale:** If >80% of bundles aren't being included, something is wrong with builder connectivity, tip calculation, or bundle construction.
+
+### Competitive Revert Alert
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Threshold | 90% | `circuit_breakers.competitive_revert_alert_pct` |
+| Action | **ALERT** | — |
+
+**Rationale:** If 90%+ of reverts are competitive (another searcher captured the opportunity), Aether is consistently too slow. Indicates need for latency optimization.
+
+## Position Limits
+
+### Max Single Trade
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Limit | 50 ETH | `position_limits.max_single_trade_eth` |
+
+Maximum flash loan amount per trade. Caps exposure to any single arbitrage opportunity.
+
+### Max Daily Volume
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Limit | 500 ETH | `position_limits.max_daily_volume_eth` |
+
+Cumulative trading volume cap per 24-hour period. Prevents runaway trading in edge cases.
+
+### Min Profit
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Limit | 0.001 ETH | `position_limits.min_profit_eth` |
+
+Minimum net profit (after gas + flash loan premium) required to execute a trade. Filters out dust-level opportunities that aren't worth the execution risk.
+
+### Tip Share Range
+
+| Parameter | Value | Config Key |
+|---|---|---|
+| Minimum | 50% | `position_limits.min_tip_share_pct` |
+| Maximum | 95% | `position_limits.max_tip_share_pct` |
+
+Percentage of profit sent to the block builder as a tip. Higher tips increase inclusion probability but reduce profit. The range ensures:
+- **Min 50%:** Builders have sufficient incentive to include the bundle
+- **Max 95%:** Aether retains at least 5% of profit


### PR DESCRIPTION
## Summary

- Add a complete 22-page VitePress documentation site in `docs-site/`
- Custom theme with Space Grotesk font, purple brand colors, animated components (accordion, timeline, cards), and mermaid flowcharts replacing ASCII art
- GitHub Actions workflow for auto-deploy to GitHub Pages on push to `main`
- Five documentation sections: Guide, Architecture, Operations, Development, Reference

## Pages

| Section | Pages |
|---|---|
| Guide | Introduction, How It Works, Getting Started, Configuration |
| Architecture | Overview, Rust Core, Go Services, Smart Contract, gRPC Protocol, Design Decisions |
| Operations | Deployment, Runbook, Incident Response, Monitoring |
| Development | Contributing, Adding a DEX, Testing, Tooling |
| Reference | Configuration, Metrics, Risk Parameters, gRPC API |

## Deployment

After merging, enable GitHub Pages (Settings > Pages > Source: GitHub Actions) or import to Vercel with root directory `docs-site/`.

## Test plan

- [ ] `cd docs-site && npm ci && npm run dev` — verify all pages render locally
- [ ] `npm run build` — verify static build succeeds with no errors
- [ ] Check mermaid diagrams render on Introduction, How It Works, Architecture Overview, Smart Contract, Go Services, Risk Parameters pages
- [ ] Check accordion/timeline components work on Introduction, How It Works, Architecture Overview pages
- [ ] Verify local search indexes all pages