### PR TITLE
fix(executor): replace production stubs with on-chain validation (#66)

### DIFF
--- a/cmd/executor/integration_test.go
+++ b/cmd/executor/integration_test.go
@@ -112,8 +112,10 @@ func TestConsumeArbStream(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
+	lb := NewLiveBalance()
+	lb.Set(0.5)
 	consumeArbStream(ctx, client, bundler, submitter, rm,
-		"0x0000000000000000000000000000000000000000", 0.5)
+		"0x0000000000000000000000000000000000000000", lb)
 
 	// Verify bundle tracking was updated
 	missRate := rm.BundleMissRate()
@@ -218,8 +220,10 @@ func TestGracefulShutdown(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
+		lb := NewLiveBalance()
+		lb.Set(0.5)
 		consumeArbStream(ctx, client, bundler, submitter, rm,
-			"0x0000000000000000000000000000000000000000", 0.5)
+			"0x0000000000000000000000000000000000000000", lb)
 		close(done)
 	}()
 

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -233,7 +233,8 @@ func main() {
 	// and bytecode checks.
 	if txSigner != nil {
 		if err := fetchAndStoreBalance(ctx, ethClient, txSigner.Address(), liveBalance); err != nil {
-			log.Fatalf("FATAL: initial eth_getBalance failed: %v", redactRPCError(err, rpcURL))
+			log.Fatalf("FATAL: initial eth_getBalance(%s) failed: %v",
+				txSigner.Address().Hex(), redactRPCError(err, rpcURL))
 		}
 		wg.Add(1)
 		go func() {

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -95,19 +95,14 @@ func main() {
 	// Executor on-chain parameters (contract address, expected chain ID) are
 	// required: the service refuses to start without them. This prevents the
 	// old fail-open behaviour where a zero-address stub silently routed
-	// bundles to nowhere.
+	// bundles to nowhere. Deployments inject the address via
+	// ${AETHER_EXECUTOR_ADDRESS} which executor.yaml expands at load time —
+	// ExpandEnv runs inside LoadExecutorConfig before validation, so no
+	// separate post-load override path is needed.
 	execPath := config.ConfigPath("executor.yaml")
 	execCfg, err := config.LoadExecutorConfig(execPath)
 	if err != nil {
 		log.Fatalf("FATAL: executor config (%s) missing or invalid: %v", execPath, err)
-	}
-	// AETHER_EXECUTOR_ADDRESS env var overrides the yaml value so deployments
-	// can inject the deployed address without editing the file in-tree.
-	if envAddr := os.Getenv("AETHER_EXECUTOR_ADDRESS"); envAddr != "" {
-		execCfg.ExecutorAddress = envAddr
-	}
-	if err := config.ValidateExecutorConfig(execCfg); err != nil {
-		log.Fatalf("FATAL: executor config invalid after env override: %v", err)
 	}
 	log.Printf("Config: executor_address=%s expected_chain_id=%d",
 		execCfg.ExecutorAddress, execCfg.ExpectedChainID)
@@ -119,10 +114,11 @@ func main() {
 		log.Fatalf("FATAL: ETH_RPC_URL not set — required for chain-id / bytecode / balance checks")
 	}
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer dialCancel()
 	ethClient, err := ethclient.DialContext(dialCtx, rpcURL)
-	dialCancel()
 	if err != nil {
-		log.Fatalf("FATAL: failed to connect to ETH_RPC_URL: %v", err)
+		log.Fatalf("FATAL: failed to connect to ETH_RPC_URL (%s): %v",
+			redactRPCURL(rpcURL), redactRPCError(err, rpcURL))
 	}
 	log.Printf("Connected to Ethereum node")
 
@@ -130,10 +126,10 @@ func main() {
 	// executor.yaml. A mismatch here typically means someone pointed a
 	// mainnet config at a testnet RPC (or vice versa) — refuse to start.
 	chainCtx, chainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer chainCancel()
 	chainID, err := ethClient.ChainID(chainCtx)
-	chainCancel()
 	if err != nil {
-		log.Fatalf("FATAL: eth_chainId failed: %v", err)
+		log.Fatalf("FATAL: eth_chainId failed: %v", redactRPCError(err, rpcURL))
 	}
 	if chainID.Int64() != execCfg.ExpectedChainID {
 		log.Fatalf("FATAL: chain-id mismatch — node reports %d, config expects %d",
@@ -144,10 +140,11 @@ func main() {
 	// Verify the configured executor contract actually exists on-chain. A
 	// zero-bytecode result means we'd be sending bundles to a non-contract.
 	codeCtx, codeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer codeCancel()
 	code, err := ethClient.CodeAt(codeCtx, common.HexToAddress(execCfg.ExecutorAddress), nil)
-	codeCancel()
 	if err != nil {
-		log.Fatalf("FATAL: eth_getCode(%s) failed: %v", execCfg.ExecutorAddress, err)
+		log.Fatalf("FATAL: eth_getCode(%s) failed: %v",
+			execCfg.ExecutorAddress, redactRPCError(err, rpcURL))
 	}
 	if len(code) == 0 {
 		log.Fatalf("FATAL: executor address %s has no bytecode on chain %d",
@@ -228,16 +225,20 @@ func main() {
 		gasOracle.UpdateLoop(ctx, 12*time.Second)
 	}()
 
-	// Start ETH balance watcher. Perform one synchronous fetch first so the
-	// first arb does not see a zero balance and get rejected incorrectly.
+	// Start ETH balance watcher. The initial fetch is synchronous and fatal
+	// on failure: LiveBalance starts at zero, and risk.PreflightCheck rejects
+	// anything below MinETHBalance, so a transient startup blip would
+	// silently kill every arb for up to 30s until balanceWatchLoop's first
+	// tick. This matches the fatal-on-startup pattern of the dial, chain-ID,
+	// and bytecode checks.
 	if txSigner != nil {
 		if err := fetchAndStoreBalance(ctx, ethClient, txSigner.Address(), liveBalance); err != nil {
-			log.Printf("WARNING: initial eth_getBalance failed: %v", err)
+			log.Fatalf("FATAL: initial eth_getBalance failed: %v", redactRPCError(err, rpcURL))
 		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			balanceWatchLoop(ctx, ethClient, txSigner.Address(), 30*time.Second, liveBalance)
+			balanceWatchLoop(ctx, ethClient, txSigner.Address(), 30*time.Second, liveBalance, rpcURL)
 		}()
 	}
 

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/aether-arb/aether/internal/config"
@@ -21,23 +22,20 @@ import (
 )
 
 // Config holds executor service configuration.
+// ChainID, ExecutorAddr, and the live ETH balance are no longer carried here —
+// they are resolved against the connected node at startup (see main) and the
+// balance is updated continuously by balanceWatchLoop.
 type Config struct {
 	GRPCAddress    string
 	BuilderConfigs []BuilderConfig
-	ChainID        int64
 	MaxGasGwei     float64
-	ExecutorAddr   string  // On-chain AetherExecutor contract address
-	EthBalance     float64 // Current ETH balance of searcher wallet (simulated)
 }
 
 func defaultConfig() Config {
 	return Config{
 		GRPCAddress:    "localhost:50051",
 		BuilderConfigs: defaultBuilderConfigs(),
-		ChainID:        1,
 		MaxGasGwei:     300.0,
-		ExecutorAddr:   "0x0000000000000000000000000000000000000000",
-		EthBalance:     0.5,
 	}
 }
 
@@ -94,6 +92,70 @@ func main() {
 
 	cfg := loadConfig()
 
+	// Executor on-chain parameters (contract address, expected chain ID) are
+	// required: the service refuses to start without them. This prevents the
+	// old fail-open behaviour where a zero-address stub silently routed
+	// bundles to nowhere.
+	execPath := config.ConfigPath("executor.yaml")
+	execCfg, err := config.LoadExecutorConfig(execPath)
+	if err != nil {
+		log.Fatalf("FATAL: executor config (%s) missing or invalid: %v", execPath, err)
+	}
+	// AETHER_EXECUTOR_ADDRESS env var overrides the yaml value so deployments
+	// can inject the deployed address without editing the file in-tree.
+	if envAddr := os.Getenv("AETHER_EXECUTOR_ADDRESS"); envAddr != "" {
+		execCfg.ExecutorAddress = envAddr
+	}
+	if err := config.ValidateExecutorConfig(execCfg); err != nil {
+		log.Fatalf("FATAL: executor config invalid after env override: %v", err)
+	}
+	log.Printf("Config: executor_address=%s expected_chain_id=%d",
+		execCfg.ExecutorAddress, execCfg.ExpectedChainID)
+
+	// ETH_RPC_URL is now required — the chain-ID check, bytecode check, and
+	// live balance polling all need a node connection.
+	rpcURL := os.Getenv("ETH_RPC_URL")
+	if rpcURL == "" {
+		log.Fatalf("FATAL: ETH_RPC_URL not set — required for chain-id / bytecode / balance checks")
+	}
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ethClient, err := ethclient.DialContext(dialCtx, rpcURL)
+	dialCancel()
+	if err != nil {
+		log.Fatalf("FATAL: failed to connect to ETH_RPC_URL: %v", err)
+	}
+	log.Printf("Connected to Ethereum node")
+
+	// Cross-check chain ID: the node must agree with the expected chain in
+	// executor.yaml. A mismatch here typically means someone pointed a
+	// mainnet config at a testnet RPC (or vice versa) — refuse to start.
+	chainCtx, chainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	chainID, err := ethClient.ChainID(chainCtx)
+	chainCancel()
+	if err != nil {
+		log.Fatalf("FATAL: eth_chainId failed: %v", err)
+	}
+	if chainID.Int64() != execCfg.ExpectedChainID {
+		log.Fatalf("FATAL: chain-id mismatch — node reports %d, config expects %d",
+			chainID.Int64(), execCfg.ExpectedChainID)
+	}
+	log.Printf("Chain ID verified: %d", chainID.Int64())
+
+	// Verify the configured executor contract actually exists on-chain. A
+	// zero-bytecode result means we'd be sending bundles to a non-contract.
+	codeCtx, codeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	code, err := ethClient.CodeAt(codeCtx, common.HexToAddress(execCfg.ExecutorAddress), nil)
+	codeCancel()
+	if err != nil {
+		log.Fatalf("FATAL: eth_getCode(%s) failed: %v", execCfg.ExecutorAddress, err)
+	}
+	if len(code) == 0 {
+		log.Fatalf("FATAL: executor address %s has no bytecode on chain %d",
+			execCfg.ExecutorAddress, chainID.Int64())
+	}
+	log.Printf("Executor contract verified on-chain: %s (%d bytes of code)",
+		execCfg.ExecutorAddress, len(code))
+
 	// Load searcher private key for transaction signing and bundle submission.
 	searcherKey := os.Getenv("SEARCHER_KEY")
 
@@ -106,7 +168,7 @@ func main() {
 	var txSigner *TransactionSigner
 	if searcherKey != "" {
 		var signerErr error
-		txSigner, signerErr = NewTransactionSigner(searcherKey, cfg.ChainID)
+		txSigner, signerErr = NewTransactionSigner(searcherKey, chainID.Int64())
 		if signerErr != nil {
 			log.Fatalf("Failed to load SEARCHER_KEY: %v", signerErr)
 		}
@@ -117,22 +179,6 @@ func main() {
 
 	os.Unsetenv("SEARCHER_KEY")
 
-	// Connect to Ethereum node for nonce sync.
-	var ethClient *ethclient.Client
-	if rpcURL := os.Getenv("ETH_RPC_URL"); rpcURL != "" {
-		dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer dialCancel()
-		var err error
-		ethClient, err = ethclient.DialContext(dialCtx, rpcURL)
-		if err != nil {
-			log.Printf("WARNING: failed to connect to ETH_RPC_URL: %v", err)
-		} else {
-			log.Printf("Connected to Ethereum node for nonce sync")
-		}
-	} else {
-		log.Println("WARNING: ETH_RPC_URL not set — nonce manager will not sync on-chain nonce")
-	}
-
 	// Setup graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -141,27 +187,27 @@ func main() {
 	nonceManager := NewNonceManager(0)
 	if txSigner != nil {
 		nonceManager.SetSyncSource(txSigner.Address(), ethClient)
-		if ethClient != nil {
-			if err := nonceManager.SyncFromChain(ctx); err != nil {
-				log.Printf("WARNING: failed to sync nonce for %s: %v", txSigner.Address().Hex(), err)
-			}
-		} else {
-			log.Printf("WARNING: ETH_RPC_URL not set — nonce manager will not sync on-chain nonce for %s", txSigner.Address().Hex())
+		if err := nonceManager.SyncFromChain(ctx); err != nil {
+			log.Printf("WARNING: failed to sync nonce for %s: %v", txSigner.Address().Hex(), err)
 		}
 	} else {
 		log.Printf("WARNING: SEARCHER_KEY not set — nonce manager will use initial nonce 0")
 	}
 
 	gasOracle := NewGasOracle(cfg.MaxGasGwei)
-	if ethClient != nil {
-		gasOracle.SetClient(ethClient)
-		// Fetch real gas prices before first arb evaluation.
-		if _, err := gasOracle.FetchOnce(ctx); err != nil {
-			log.Printf("WARNING: initial gas oracle fetch failed: %v", err)
-		}
+	gasOracle.SetClient(ethClient)
+	if _, err := gasOracle.FetchOnce(ctx); err != nil {
+		log.Printf("WARNING: initial gas oracle fetch failed: %v", err)
 	}
-	bundler := NewBundleConstructor(nonceManager, gasOracle, txSigner, cfg.ChainID)
+	bundler := NewBundleConstructor(nonceManager, gasOracle, txSigner, chainID.Int64())
 	riskMgr := risk.NewRiskManager(loadRiskConfig())
+
+	// Live searcher ETH balance, written by balanceWatchLoop and read by
+	// consumeArbStream → processArb → risk.PreflightCheck. When no searcher
+	// key is configured there is no address to query, so the live balance
+	// stays at zero and preflight will reject every arb — correct behaviour
+	// for a misconfigured deployment.
+	liveBalance := NewLiveBalance()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -182,12 +228,16 @@ func main() {
 		gasOracle.UpdateLoop(ctx, 12*time.Second)
 	}()
 
-	// Start ETH balance watcher
-	if ethClient != nil && txSigner != nil {
+	// Start ETH balance watcher. Perform one synchronous fetch first so the
+	// first arb does not see a zero balance and get rejected incorrectly.
+	if txSigner != nil {
+		if err := fetchAndStoreBalance(ctx, ethClient, txSigner.Address(), liveBalance); err != nil {
+			log.Printf("WARNING: initial eth_getBalance failed: %v", err)
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			balanceWatchLoop(ctx, ethClient, txSigner.Address(), 30*time.Second)
+			balanceWatchLoop(ctx, ethClient, txSigner.Address(), 30*time.Second, liveBalance)
 		}()
 	}
 
@@ -214,7 +264,7 @@ func main() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			consumeArbStream(ctx, grpcClient, bundler, submitter, riskMgr, cfg.ExecutorAddr, cfg.EthBalance)
+			consumeArbStream(ctx, grpcClient, bundler, submitter, riskMgr, execCfg.ExecutorAddress, liveBalance)
 		}()
 	}
 
@@ -331,7 +381,7 @@ func looksLikeRevert(errMsg string) bool {
 // processes validated arbitrage opportunities as they arrive. On stream
 // errors it reconnects with a backoff delay. The function exits when ctx
 // is cancelled.
-func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *BundleConstructor, submitter *Submitter, rm *risk.RiskManager, executorAddr string, ethBalance float64) {
+func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *BundleConstructor, submitter *Submitter, rm *risk.RiskManager, executorAddr string, liveBalance *LiveBalance) {
 	const (
 		minProfitETH   = 0.001 // Minimum profit threshold in ETH
 		reconnectDelay = 5 * time.Second
@@ -368,7 +418,7 @@ func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *B
 			log.Printf("Received arb: id=%s hops=%d gas=%d block=%d",
 				arb.Id, len(arb.Hops), arb.TotalGas, arb.BlockNumber)
 
-			submitted, err := processArb(ctx, arb, receivedAt, rm, bundler, submitter, executorAddr, ethBalance)
+			submitted, err := processArb(ctx, arb, receivedAt, rm, bundler, submitter, executorAddr, liveBalance.Get())
 			switch {
 			case err != nil:
 				log.Printf("Error processing arb %s: %v", arb.Id, err)

--- a/cmd/executor/metrics.go
+++ b/cmd/executor/metrics.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -199,7 +200,52 @@ func addPnl(profitWei *big.Int, gasCostWei float64) {
 
 // --- ETH balance watcher ---
 
-func balanceWatchLoop(ctx context.Context, client *ethclient.Client, addr common.Address, interval time.Duration) {
+// LiveBalance holds the most recent searcher ETH balance in a lock-free
+// readable form. balanceWatchLoop writes it on every successful poll;
+// processArb reads it on every inbound arb to feed the risk manager.
+//
+// Stored as the IEEE-754 bit representation of a float64 inside an
+// atomic.Uint64 so Get/Set are single atomic ops with no mutex contention on
+// the hot path.
+type LiveBalance struct {
+	bits atomic.Uint64
+}
+
+func NewLiveBalance() *LiveBalance {
+	return &LiveBalance{}
+}
+
+func (b *LiveBalance) Get() float64 {
+	return math.Float64frombits(b.bits.Load())
+}
+
+func (b *LiveBalance) Set(v float64) {
+	b.bits.Store(math.Float64bits(v))
+}
+
+// fetchAndStoreBalance does a single eth_getBalance call, updates both the
+// Prometheus gauge and the shared LiveBalance, and returns any error from
+// the RPC. Used at startup to seed the balance before the first arb and
+// inside balanceWatchLoop to refresh it periodically.
+func fetchAndStoreBalance(ctx context.Context, client *ethclient.Client, addr common.Address, live *LiveBalance) error {
+	fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	bal, err := client.BalanceAt(fetchCtx, addr, nil)
+	if err != nil {
+		return err
+	}
+	ethVal, _ := new(big.Float).Quo(
+		new(big.Float).SetInt(bal),
+		new(big.Float).SetFloat64(1e18),
+	).Float64()
+	ethBalanceGauge.Set(ethVal)
+	if live != nil {
+		live.Set(ethVal)
+	}
+	return nil
+}
+
+func balanceWatchLoop(ctx context.Context, client *ethclient.Client, addr common.Address, interval time.Duration, live *LiveBalance) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -207,18 +253,9 @@ func balanceWatchLoop(ctx context.Context, client *ethclient.Client, addr common
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			bal, err := client.BalanceAt(fetchCtx, addr, nil)
-			cancel()
-			if err != nil {
+			if err := fetchAndStoreBalance(ctx, client, addr, live); err != nil {
 				log.Printf("WARNING: eth_getBalance failed: %v", err)
-				continue
 			}
-			ethVal, _ := new(big.Float).Quo(
-				new(big.Float).SetInt(bal),
-				new(big.Float).SetFloat64(1e18),
-			).Float64()
-			ethBalanceGauge.Set(ethVal)
 		}
 	}
 }

--- a/cmd/executor/metrics.go
+++ b/cmd/executor/metrics.go
@@ -245,7 +245,10 @@ func fetchAndStoreBalance(ctx context.Context, client *ethclient.Client, addr co
 	return nil
 }
 
-func balanceWatchLoop(ctx context.Context, client *ethclient.Client, addr common.Address, interval time.Duration, live *LiveBalance) {
+// balanceWatchLoop periodically refreshes the searcher's ETH balance. rpcURL
+// is used only to strip the embedded API key from logged errors (Alchemy /
+// QuickNode / Infura all put the key in the URL path).
+func balanceWatchLoop(ctx context.Context, client *ethclient.Client, addr common.Address, interval time.Duration, live *LiveBalance, rpcURL string) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -254,7 +257,7 @@ func balanceWatchLoop(ctx context.Context, client *ethclient.Client, addr common
 			return
 		case <-ticker.C:
 			if err := fetchAndStoreBalance(ctx, client, addr, live); err != nil {
-				log.Printf("WARNING: eth_getBalance failed: %v", err)
+				log.Printf("WARNING: eth_getBalance failed: %v", redactRPCError(err, rpcURL))
 			}
 		}
 	}

--- a/cmd/executor/metrics_test.go
+++ b/cmd/executor/metrics_test.go
@@ -7,12 +7,105 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+// LiveBalance is read on the arb hot path and written by balanceWatchLoop.
+// These tests pin the atomic-float64 contract — round-trip correctness for
+// edge values and race-free concurrent Get/Set — so a future refactor that
+// silently replaces the atomic.Uint64 with a plain float64 (which would
+// tear reads under contention) fails loudly.
+
+func TestLiveBalance_ZeroValue(t *testing.T) {
+	lb := NewLiveBalance()
+	if got := lb.Get(); got != 0 {
+		t.Fatalf("fresh LiveBalance.Get() = %v, want 0", got)
+	}
+}
+
+func TestLiveBalance_SetGetRoundTrip(t *testing.T) {
+	cases := []float64{
+		0,
+		1,
+		0.5,
+		1e18,
+		1e-18,
+		math.MaxFloat64,
+		math.SmallestNonzeroFloat64,
+	}
+	lb := NewLiveBalance()
+	for _, v := range cases {
+		lb.Set(v)
+		if got := lb.Get(); got != v {
+			t.Errorf("round-trip %v: got %v", v, got)
+		}
+	}
+}
+
+func TestLiveBalance_OverwritesPreviousValue(t *testing.T) {
+	lb := NewLiveBalance()
+	lb.Set(3.14)
+	lb.Set(2.71)
+	if got := lb.Get(); got != 2.71 {
+		t.Fatalf("after two Sets, Get() = %v, want 2.71", got)
+	}
+}
+
+func TestLiveBalance_ConcurrentSetGet(t *testing.T) {
+	// The contract is: Get always returns a value that was passed to Set by
+	// some goroutine. Float64 tearing (observing a bit pattern that was
+	// never written) must not happen.
+	lb := NewLiveBalance()
+	const writers = 8
+	const readers = 8
+	const iters = 10_000
+
+	// Valid write values. Every observed read must match one of these.
+	values := []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}
+	valid := make(map[float64]struct{}, len(values)+1)
+	for _, v := range values {
+		valid[v] = struct{}{}
+	}
+	valid[0] = struct{}{} // zero-value is also valid (never-written state)
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := 0; w < writers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				lb.Set(values[(id+i)%len(values)])
+			}
+		}(w)
+	}
+
+	var tearCount int64
+	var tearMu sync.Mutex
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				v := lb.Get()
+				if _, ok := valid[v]; !ok {
+					tearMu.Lock()
+					tearCount++
+					tearMu.Unlock()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	if tearCount != 0 {
+		t.Fatalf("observed %d torn reads out of %d, atomic contract broken", tearCount, readers*iters)
+	}
+}
 
 func TestMetricsEndpoint_ContainsRequiredMetrics(t *testing.T) {
 	server := httptest.NewServer(promhttp.Handler())

--- a/cmd/executor/rpc_redact.go
+++ b/cmd/executor/rpc_redact.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// redactRPCURL returns a safe-to-log form of an RPC URL by keeping only the
+// scheme + host and replacing any path / query / fragment with a single
+// [REDACTED] marker. Provider URL formats vary — Alchemy puts the key as
+// the last path segment, Infura as well, QuickNode puts it as an
+// intermediate segment between slashes — so masking anything past the host
+// is the only shape that doesn't leak secrets on at least one provider.
+//
+// Falls back to a bare [REDACTED] when the URL is unparseable or has no
+// host. The result is assembled manually rather than via url.URL.String()
+// because the latter percent-encodes "[" / "]" (produces %5BREDACTED%5D),
+// which is unreadable in logs.
+func redactRPCURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "[REDACTED]"
+	}
+	var b strings.Builder
+	if u.Scheme != "" {
+		b.WriteString(u.Scheme)
+		b.WriteString("://")
+	}
+	b.WriteString(u.Host)
+	if u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		b.WriteString("/[REDACTED]")
+	}
+	return b.String()
+}
+
+// redactRPCError returns a new error whose message has every occurrence of
+// rpcURL replaced with its redacted form. Go-ethereum wraps HTTP failures as
+// `Post "<url>": <cause>`, so this keeps the cause visible while stripping
+// the embedded API key from logs, journald, Loki, and alert payloads.
+//
+// Returns nil if err is nil, and the original error unchanged if rpcURL is
+// empty.
+func redactRPCError(err error, rpcURL string) error {
+	if err == nil {
+		return nil
+	}
+	if rpcURL == "" {
+		return err
+	}
+	msg := err.Error()
+	redacted := redactRPCURL(rpcURL)
+	stripped := strings.ReplaceAll(msg, rpcURL, redacted)
+	if stripped == msg {
+		return err
+	}
+	return errors.New(stripped)
+}

--- a/cmd/executor/rpc_redact_test.go
+++ b/cmd/executor/rpc_redact_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRedactRPCURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, in, want string
+	}{
+		{"empty", "", ""},
+		{
+			"alchemy",
+			"https://eth-mainnet.g.alchemy.com/v2/abc123XYZsecret",
+			"https://eth-mainnet.g.alchemy.com/[REDACTED]",
+		},
+		{
+			"quicknode — key is intermediate path segment",
+			"https://example.quiknode.pro/abc123XYZsecret/",
+			"https://example.quiknode.pro/[REDACTED]",
+		},
+		{
+			"infura",
+			"https://mainnet.infura.io/v3/projectidsecret",
+			"https://mainnet.infura.io/[REDACTED]",
+		},
+		{
+			"no path",
+			"https://host.example",
+			"https://host.example",
+		},
+		{
+			"localhost with trailing slash",
+			"http://localhost:8545/",
+			"http://localhost:8545/[REDACTED]",
+		},
+		{
+			"query string is masked",
+			"https://host.example/path?apikey=secret",
+			"https://host.example/[REDACTED]",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := redactRPCURL(tc.in)
+			if got != tc.want {
+				t.Errorf("redactRPCURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if tc.in != "" && strings.Contains(got, "secret") {
+				t.Errorf("secret leaked into %q", got)
+			}
+		})
+	}
+}
+
+func TestRedactRPCError(t *testing.T) {
+	t.Parallel()
+
+	rpcURL := "https://eth-mainnet.g.alchemy.com/v2/ALCHEMYKEY123"
+
+	t.Run("nil err passes through", func(t *testing.T) {
+		t.Parallel()
+		if redactRPCError(nil, rpcURL) != nil {
+			t.Fatal("expected nil, got non-nil")
+		}
+	})
+
+	t.Run("empty url returns original", func(t *testing.T) {
+		t.Parallel()
+		orig := errors.New("boom")
+		if got := redactRPCError(orig, ""); got != orig {
+			t.Errorf("expected identity, got %v", got)
+		}
+	})
+
+	t.Run("go-ethereum wrapped Post error is redacted", func(t *testing.T) {
+		t.Parallel()
+		wrapped := fmt.Errorf("Post %q: connection refused", rpcURL)
+		got := redactRPCError(wrapped, rpcURL)
+		if got == nil {
+			t.Fatal("expected non-nil")
+		}
+		if strings.Contains(got.Error(), "ALCHEMYKEY123") {
+			t.Fatalf("api key leaked: %q", got.Error())
+		}
+		if !strings.Contains(got.Error(), "[REDACTED]") {
+			t.Errorf("redaction marker missing: %q", got.Error())
+		}
+		if !strings.Contains(got.Error(), "connection refused") {
+			t.Errorf("underlying cause dropped: %q", got.Error())
+		}
+	})
+
+	t.Run("error without url is passed through", func(t *testing.T) {
+		t.Parallel()
+		orig := errors.New("context deadline exceeded")
+		got := redactRPCError(orig, rpcURL)
+		if got.Error() != orig.Error() {
+			t.Errorf("expected %q, got %q", orig.Error(), got.Error())
+		}
+	})
+}

--- a/config/executor.yaml
+++ b/config/executor.yaml
@@ -9,8 +9,9 @@
 #   fails fast on mismatch (prevents mainnet bundles from being sent to a
 #   testnet RPC, or vice versa).
 #
-# Both fields support ${ENV_VAR} expansion. AETHER_EXECUTOR_ADDRESS is the
-# conventional override for the address.
+# Both fields support ${ENV_VAR} substitution at load time. In practice the
+# address is sourced from the AETHER_EXECUTOR_ADDRESS env var via the
+# ${...} placeholder below, not via a post-load override path.
 
 executor_address: ${AETHER_EXECUTOR_ADDRESS}
 expected_chain_id: 1

--- a/config/executor.yaml
+++ b/config/executor.yaml
@@ -1,0 +1,16 @@
+# Aether executor on-chain parameters.
+#
+# executor_address — deployed AetherExecutor contract. MUST be the real
+#   deployment for the target chain. Startup fails if this address has no
+#   bytecode on-chain (eth_getCode == 0x).
+#
+# expected_chain_id — the chain the executor was deployed on. Startup
+#   cross-checks this against eth_chainId reported by ETH_RPC_URL and
+#   fails fast on mismatch (prevents mainnet bundles from being sent to a
+#   testnet RPC, or vice versa).
+#
+# Both fields support ${ENV_VAR} expansion. AETHER_EXECUTOR_ADDRESS is the
+# conventional override for the address.
+
+executor_address: ${AETHER_EXECUTOR_ADDRESS}
+expected_chain_id: 1

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -263,6 +263,10 @@ func LoadExecutorConfig(path string) (ExecutorFileConfig, error) {
 		return cfg, fmt.Errorf("parse executor config %s: %w", path, err)
 	}
 
+	// Normalize whitespace before validation so downstream consumers and log
+	// sites see the clean address without padding.
+	cfg.ExecutorAddress = strings.TrimSpace(cfg.ExecutorAddress)
+
 	if err := ValidateExecutorConfig(cfg); err != nil {
 		return cfg, fmt.Errorf("validate executor config: %w", err)
 	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -224,6 +224,61 @@ type NodesFileConfig struct {
 	MinHealthyNodes int         `yaml:"min_healthy_nodes"`
 }
 
+// ---------------------------------------------------------------------------
+// Executor config (config/executor.yaml)
+// ---------------------------------------------------------------------------
+
+// ExecutorFileConfig maps the executor.yaml file structure.
+type ExecutorFileConfig struct {
+	ExecutorAddress string `yaml:"executor_address"`
+	ExpectedChainID int64  `yaml:"expected_chain_id"`
+}
+
+// LoadExecutorConfig reads and parses an executor YAML config file.
+// Environment variables in ${VAR} format are expanded before parsing,
+// so AETHER_EXECUTOR_ADDRESS can be injected via the yaml itself.
+func LoadExecutorConfig(path string) (ExecutorFileConfig, error) {
+	var cfg ExecutorFileConfig
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, fmt.Errorf("read executor config %s: %w", path, err)
+	}
+
+	data = expandEnvVars(data)
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parse executor config %s: %w", path, err)
+	}
+
+	if err := ValidateExecutorConfig(cfg); err != nil {
+		return cfg, fmt.Errorf("validate executor config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// ValidateExecutorConfig ensures required fields are present and well-formed.
+// Address syntax is validated here; on-chain bytecode check happens at runtime
+// against the connected Ethereum node.
+func ValidateExecutorConfig(cfg ExecutorFileConfig) error {
+	if cfg.ExecutorAddress == "" {
+		return fmt.Errorf("executor_address must not be empty")
+	}
+	addr := cfg.ExecutorAddress
+	if len(addr) != 42 || addr[:2] != "0x" {
+		return fmt.Errorf("executor_address must be a 0x-prefixed 20-byte hex string, got %q", addr)
+	}
+	zero := "0x0000000000000000000000000000000000000000"
+	if addr == zero {
+		return fmt.Errorf("executor_address must not be the zero address")
+	}
+	if cfg.ExpectedChainID <= 0 {
+		return fmt.Errorf("expected_chain_id must be > 0, got %d", cfg.ExpectedChainID)
+	}
+	return nil
+}
+
 // expandEnvVars replaces ${VAR} patterns in the input with their
 // corresponding environment variable values. Unset variables are
 // replaced with an empty string.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -4,12 +4,24 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"gopkg.in/yaml.v3"
 )
+
+// decodeStrictYAML unmarshals YAML with unknown-key rejection enabled so typos
+// like `expected_chainid:` surface as a decoder error instead of silently
+// leaving the typed field at its zero value.
+func decodeStrictYAML(data []byte, out any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(out)
+}
 
 // ConfigDir returns the config directory path.
 // Uses AETHER_CONFIG_DIR env var, falls back to "./config".
@@ -247,7 +259,7 @@ func LoadExecutorConfig(path string) (ExecutorFileConfig, error) {
 
 	data = expandEnvVars(data)
 
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := decodeStrictYAML(data, &cfg); err != nil {
 		return cfg, fmt.Errorf("parse executor config %s: %w", path, err)
 	}
 
@@ -262,15 +274,18 @@ func LoadExecutorConfig(path string) (ExecutorFileConfig, error) {
 // Address syntax is validated here; on-chain bytecode check happens at runtime
 // against the connected Ethereum node.
 func ValidateExecutorConfig(cfg ExecutorFileConfig) error {
-	if cfg.ExecutorAddress == "" {
+	addr := strings.TrimSpace(cfg.ExecutorAddress)
+	if addr == "" {
 		return fmt.Errorf("executor_address must not be empty")
 	}
-	addr := cfg.ExecutorAddress
-	if len(addr) != 42 || addr[:2] != "0x" {
+	// Require the 0x prefix explicitly; common.IsHexAddress accepts bare 40-
+	// char hex too, but the YAML contract here is always 0x-prefixed.
+	// IsHexAddress catches wrong length and non-hex characters — defense-in-
+	// depth on top of the runtime eth_getCode check.
+	if !strings.HasPrefix(addr, "0x") || !common.IsHexAddress(addr) {
 		return fmt.Errorf("executor_address must be a 0x-prefixed 20-byte hex string, got %q", addr)
 	}
-	zero := "0x0000000000000000000000000000000000000000"
-	if addr == zero {
+	if common.HexToAddress(addr) == (common.Address{}) {
 		return fmt.Errorf("executor_address must not be the zero address")
 	}
 	if cfg.ExpectedChainID <= 0 {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -560,9 +560,13 @@ func TestValidateExecutorConfig_Errors(t *testing.T) {
 		errSub string
 	}{
 		{"empty address", ExecutorFileConfig{"", 1}, "executor_address must not be empty"},
+		{"whitespace-only address", ExecutorFileConfig{"   ", 1}, "executor_address must not be empty"},
 		{"zero address", ExecutorFileConfig{"0x0000000000000000000000000000000000000000", 1}, "must not be the zero address"},
 		{"missing 0x prefix", ExecutorFileConfig{"1111111111111111111111111111111111111111", 1}, "0x-prefixed"},
 		{"too short", ExecutorFileConfig{"0x1234", 1}, "0x-prefixed"},
+		// Defense-in-depth: reject non-hex digits that the old length-only
+		// check accepted and common.HexToAddress silently coerced to zero.
+		{"non-hex chars", ExecutorFileConfig{"0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ", 1}, "0x-prefixed"},
 		{"zero chain id", ExecutorFileConfig{"0x1111111111111111111111111111111111111111", 0}, "expected_chain_id must be > 0"},
 		{"negative chain id", ExecutorFileConfig{"0x1111111111111111111111111111111111111111", -1}, "expected_chain_id must be > 0"},
 	}
@@ -603,6 +607,70 @@ func TestLoadExecutorConfig_MissingFile(t *testing.T) {
 	_, err := LoadExecutorConfig("/nonexistent/executor.yaml")
 	if err == nil {
 		t.Fatal("expected error for missing file")
+	}
+}
+
+// When the yaml references an env var that is unset, ExpandEnv substitutes
+// an empty string and validation must reject it. Prevents a silent "this
+// looks like a valid yaml, why are bundles going nowhere" bug in prod.
+func TestLoadExecutorConfig_EnvUnset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "executor.yaml")
+	body := "executor_address: ${TEST_AETHER_UNSET_VAR}\nexpected_chain_id: 1\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Make sure the var really is unset for this test — Setenv+Unsetenv
+	// instead of a bare Unsetenv so t.Cleanup restores any prior value.
+	t.Setenv("TEST_AETHER_UNSET_VAR", "")
+	os.Unsetenv("TEST_AETHER_UNSET_VAR")
+
+	_, err := LoadExecutorConfig(path)
+	if err == nil {
+		t.Fatal("expected error when env var is unset")
+	}
+	if !strings.Contains(err.Error(), "executor_address must not be empty") {
+		t.Errorf("error %q does not point at the empty-address case", err.Error())
+	}
+}
+
+// Env var expands to the zero address — must be rejected, not treated as a
+// deployed contract address.
+func TestLoadExecutorConfig_EnvIsZeroAddress(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "executor.yaml")
+	body := "executor_address: ${TEST_AETHER_ZERO_ADDR}\nexpected_chain_id: 1\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("TEST_AETHER_ZERO_ADDR", "0x0000000000000000000000000000000000000000")
+
+	_, err := LoadExecutorConfig(path)
+	if err == nil {
+		t.Fatal("expected error for zero-address env expansion")
+	}
+	if !strings.Contains(err.Error(), "must not be the zero address") {
+		t.Errorf("error %q does not point at the zero-address case", err.Error())
+	}
+}
+
+// Strict YAML decoding rejects unknown keys so typos (e.g. `expected_chainid:`)
+// surface as a decoder error instead of silently leaving the field at zero
+// and tripping the generic `> 0` validator with a misleading message.
+func TestLoadExecutorConfig_RejectsUnknownKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "executor.yaml")
+	body := "executor_address: 0x1111111111111111111111111111111111111111\nexpected_chainid: 1\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := LoadExecutorConfig(path)
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	if !strings.Contains(err.Error(), "expected_chainid") {
+		t.Errorf("error %q does not name the offending key", err.Error())
 	}
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -535,3 +536,73 @@ func validRiskFileConfig() RiskFileConfig {
 	cfg.PositionLimits.MaxTipSharePct = 95
 	return cfg
 }
+
+// ---------------------------------------------------------------------------
+// Executor config
+// ---------------------------------------------------------------------------
+
+func TestValidateExecutorConfig_Valid(t *testing.T) {
+	t.Parallel()
+	cfg := ExecutorFileConfig{
+		ExecutorAddress: "0x1111111111111111111111111111111111111111",
+		ExpectedChainID: 1,
+	}
+	if err := ValidateExecutorConfig(cfg); err != nil {
+		t.Fatalf("expected valid, got error: %v", err)
+	}
+}
+
+func TestValidateExecutorConfig_Errors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		cfg    ExecutorFileConfig
+		errSub string
+	}{
+		{"empty address", ExecutorFileConfig{"", 1}, "executor_address must not be empty"},
+		{"zero address", ExecutorFileConfig{"0x0000000000000000000000000000000000000000", 1}, "must not be the zero address"},
+		{"missing 0x prefix", ExecutorFileConfig{"1111111111111111111111111111111111111111", 1}, "0x-prefixed"},
+		{"too short", ExecutorFileConfig{"0x1234", 1}, "0x-prefixed"},
+		{"zero chain id", ExecutorFileConfig{"0x1111111111111111111111111111111111111111", 0}, "expected_chain_id must be > 0"},
+		{"negative chain id", ExecutorFileConfig{"0x1111111111111111111111111111111111111111", -1}, "expected_chain_id must be > 0"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateExecutorConfig(tc.cfg)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.errSub)
+			}
+			if !strings.Contains(err.Error(), tc.errSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errSub)
+			}
+		})
+	}
+}
+
+func TestLoadExecutorConfig_EnvExpansion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "executor.yaml")
+	body := "executor_address: ${TEST_AETHER_EXEC_ADDR}\nexpected_chain_id: 1\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("TEST_AETHER_EXEC_ADDR", "0x2222222222222222222222222222222222222222")
+	cfg, err := LoadExecutorConfig(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.ExecutorAddress != "0x2222222222222222222222222222222222222222" {
+		t.Errorf("env expansion failed: got %q", cfg.ExecutorAddress)
+	}
+}
+
+func TestLoadExecutorConfig_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := LoadExecutorConfig("/nonexistent/executor.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+


### PR DESCRIPTION
## Summary

Closes #66. Removes the three hardcoded stubs in `cmd/executor/main.go:37-40` that silently faked production state, and wires each one to real on-chain data with fail-fast startup validation.

- **ExecutorAddr** `"0x0000…"` → loaded from new `config/executor.yaml` (with `AETHER_EXECUTOR_ADDRESS` env override), verified against `eth_getCode != 0x` at startup.
- **EthBalance** `0.5` → replaced with a lock-free `LiveBalance` refreshed every 30s by `balanceWatchLoop` and read by `processArb` on every inbound arb, so the risk manager's `<0.1 ETH halt` finally sees real data.
- **ChainID** `1` → `expected_chain_id` in `executor.yaml`, cross-checked against `eth_chainId` at startup.
- **`ETH_RPC_URL`** is now required — all three checks above need it.

## Files Changed

| File | Change |
|---|---|
| `config/executor.yaml` | **new** — `executor_address` (supports `${AETHER_EXECUTOR_ADDRESS}` expansion) and `expected_chain_id` |
| `internal/config/loader.go` | new `ExecutorFileConfig`, `LoadExecutorConfig`, `ValidateExecutorConfig` |
| `internal/config/loader_test.go` | 4 new tests: valid config, 6 invalid cases, env expansion, missing file |
| `cmd/executor/main.go` | drop stubs; load executor.yaml; require `ETH_RPC_URL`; verify chain ID and executor bytecode; wire live balance into arb stream |
| `cmd/executor/metrics.go` | new `LiveBalance` (atomic float64 via `math.Float64bits`); refactor `balanceWatchLoop` to write it; extract `fetchAndStoreBalance` for shared use at startup and in the loop |
| `cmd/executor/integration_test.go` | update call sites to pass `*LiveBalance` instead of `float64` |

## Acceptance Criteria

| Criterion | Status | Evidence |
|---|---|---|
| Starting without `AETHER_EXECUTOR_ADDRESS` or `config/executor.yaml` exits with error | ✅ | Smoke: `FATAL: executor config (...): executor_address must not be empty` (yaml uses `${AETHER_EXECUTOR_ADDRESS}`; empty expansion → reject) |
| Starting with a zero address exits with error | ✅ | Smoke: `FATAL: ... executor_address must not be the zero address` |
| ETH balance updates in Prometheus (`aether_eth_balance` gauge) | ✅ (see note below) | `fetchAndStoreBalance` writes `ethBalanceGauge.Set(ethVal)` on every tick; called at startup and every 30s by `balanceWatchLoop` |
| Chain ID mismatch at startup exits with error | ✅ | `main.go` calls `ethClient.ChainID(ctx)`, compares to `execCfg.ExpectedChainID`, `log.Fatalf("FATAL: chain-id mismatch — node reports %d, config expects %d", ...)` |
| `go test ./cmd/executor/... -race` passes | ✅ | `ok github.com/aether-arb/aether/cmd/executor 9.725s` |
| No remaining `"0x0"` or `0.5` stubs in `main.go` | ✅ | `grep -nE '0x0{40}\|EthBalance:\s*0\.5\|ChainID:\s*1' cmd/executor/main.go` → no matches |

### Note on "every block" phrasing in the issue

The issue's acceptance criterion says "ETH balance updates **every block**". This PR ships a 30-second timer rather than a strict per-block refresh. Reason: the Go executor has no WebSocket subscription today — `ethclient.SubscribeNewHead` requires `ws://`/`wss://`/IPC, and all existing RPC usage in `cmd/executor/` is request/response. Adding WS wiring is real work beyond "remove stubs."

**Two follow-up approaches for strict per-block** (not in this PR):

1. **WebSocket subscription** — require `ETH_RPC_URL` (or a new `ETH_WS_URL`) to be a WS endpoint; call `SubscribeNewHead` and refresh balance on each head.
2. **Piggyback on the arb stream** — every `ArbOpportunity` already carries `arb.BlockNumber`; refresh balance whenever the block advances. Zero new infrastructure.

Happy to ship whichever the reviewer prefers as a follow-up, or widen this PR if you'd rather do it now.

## Test plan

- [x] `go test ./... -race -count=1` — all packages green (`cmd/executor` 9.7s under race)
- [x] `cargo test --workspace --release` — 0 failed across all crates
- [x] `forge test` — 38 passed, 0 failed, 2 skipped
- [x] `go vet ./...`, `go build ./...` — clean
- [x] Fail-fast smoke tests:
  - [x] no `ETH_RPC_URL` → `FATAL: ETH_RPC_URL not set — required for chain-id / bytecode / balance checks`
  - [x] no `AETHER_EXECUTOR_ADDRESS` → `FATAL: ... executor_address must not be empty`
  - [x] zero address env override → `FATAL: ... must not be the zero address`
  - [x] unreachable RPC → `FATAL: eth_chainId failed: ...`
- [ ] Production dry-run against a mainnet RPC with a real deployed `AetherExecutor` — pending deploy