### PR TITLE
feat(observability): Prometheus alerts, Grafana dashboards, Slack routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ DASHBOARD_PORT=8080
 # Secrets
 SEARCHER_KEY=your_searcher_wallet_private_key_here
 # FLASHBOTS_AUTH_KEY=your_flashbots_key
+
+# Observability — Alertmanager Slack routing.
+# Create an incoming webhook at https://api.slack.com/messaging/webhooks and paste the full URL here.
+# The Alertmanager container substitutes this value into alertmanager.yml at startup, so the webhook
+# never lands in the committed config. If empty, Alertmanager still runs but Slack delivery will no-op.
+SLACK_WEBHOOK_URL=

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -198,6 +198,7 @@ func main() {
 	}
 	bundler := NewBundleConstructor(nonceManager, gasOracle, txSigner, chainID.Int64())
 	riskMgr := risk.NewRiskManager(loadRiskConfig())
+	riskMgr.SetMetricsObserver(executorMetricsObserver{})
 
 	// Live searcher ETH balance, written by balanceWatchLoop and read by
 	// consumeArbStream → processArb → risk.PreflightCheck. When no searcher
@@ -428,5 +429,35 @@ func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *B
 				log.Printf("Skipped arb %s (risk-manager veto or below threshold)", arb.Id)
 			}
 		}
+	}
+}
+
+// executorMetricsObserver adapts risk-layer state events to Prometheus.
+// Kept as a struct so cmd/executor keeps the Prometheus dependency and
+// internal/risk stays pure.
+type executorMetricsObserver struct{}
+
+func (executorMetricsObserver) OnStateChange(s risk.SystemState) {
+	setSystemState(stateToInt(s))
+}
+
+func (executorMetricsObserver) OnCircuitBreakerTrip(reason string) {
+	recordCircuitBreakerTrip(reason)
+}
+
+// stateToInt maps system states to a numeric gauge value. -1 surfaces an
+// anomaly on dashboards if a new state is added without updating this mapping.
+func stateToInt(s risk.SystemState) int {
+	switch s {
+	case risk.StateRunning:
+		return 0
+	case risk.StateDegraded:
+		return 1
+	case risk.StatePaused:
+		return 2
+	case risk.StateHalted:
+		return 3
+	default:
+		return -1
 	}
 }

--- a/cmd/executor/metrics.go
+++ b/cmd/executor/metrics.go
@@ -150,6 +150,19 @@ func recordBuilderResult(builder string, success bool, latency time.Duration) {
 	builderLatencyMs.WithLabelValues(builder).Observe(float64(latency.Milliseconds()))
 }
 
+// PreRegisterBuilderLabels initialises the {builder, result} label pairs for
+// every configured builder to zero. Prometheus CounterVec does not emit a
+// time series until WithLabelValues is called, so without this step the
+// AetherBuilderDown alert (which requires both success and failure series to
+// exist) would never fire for a builder that has only ever failed. Calling
+// this at startup guarantees both series are observable from t=0.
+func PreRegisterBuilderLabels(names []string) {
+	for _, name := range names {
+		builderSubmissionsTotal.WithLabelValues(name, "success").Add(0)
+		builderSubmissionsTotal.WithLabelValues(name, "failure").Add(0)
+	}
+}
+
 func setSystemState(s int) {
 	systemStateGauge.Set(float64(s))
 }

--- a/cmd/executor/metrics.go
+++ b/cmd/executor/metrics.go
@@ -61,6 +61,23 @@ var (
 		Name: "aether_eth_balance",
 		Help: "Current ETH balance of the searcher wallet",
 	})
+	builderSubmissionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "aether_executor_builder_submissions_total",
+		Help: "Per-builder bundle submission attempts by result",
+	}, []string{"builder", "result"})
+	builderLatencyMs = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "aether_executor_builder_latency_ms",
+		Help:    "Per-builder submission round-trip latency in ms",
+		Buckets: []float64{10, 25, 50, 100, 250, 500, 1000, 2000, 5000},
+	}, []string{"builder"})
+	systemStateGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "aether_system_state",
+		Help: "Current system state (0=Running, 1=Degraded, 2=Paused, 3=Halted)",
+	})
+	circuitBreakerTripsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "aether_circuit_breaker_trips_total",
+		Help: "Circuit breaker trip count by reason",
+	}, []string{"reason"})
 )
 
 func init() {
@@ -74,6 +91,10 @@ func init() {
 		gasPriceGwei,
 		dailyPnlEth,
 		ethBalanceGauge,
+		builderSubmissionsTotal,
+		builderLatencyMs,
+		systemStateGauge,
+		circuitBreakerTripsTotal,
 	)
 }
 
@@ -118,6 +139,23 @@ func recordBundleIncluded(profitWei *big.Int, gasGwei float64, gasUsed uint64) {
 
 func recordRiskRejection() {
 	riskRejections.Inc()
+}
+
+func recordBuilderResult(builder string, success bool, latency time.Duration) {
+	result := "failure"
+	if success {
+		result = "success"
+	}
+	builderSubmissionsTotal.WithLabelValues(builder, result).Inc()
+	builderLatencyMs.WithLabelValues(builder).Observe(float64(latency.Milliseconds()))
+}
+
+func setSystemState(s int) {
+	systemStateGauge.Set(float64(s))
+}
+
+func recordCircuitBreakerTrip(reason string) {
+	circuitBreakerTripsTotal.WithLabelValues(reason).Inc()
 }
 
 func addBigIntCounter(counter prometheus.Counter, value *big.Int) {

--- a/cmd/executor/metrics_test.go
+++ b/cmd/executor/metrics_test.go
@@ -220,3 +220,81 @@ func TestEndToEndLatency(t *testing.T) {
 	// Zero time should be a no-op
 	recordEndToEndLatency(time.Time{})
 }
+
+func TestRecordBuilderResult_ScrapeLabels(t *testing.T) {
+	recordBuilderResult("flashbots", true, 42*time.Millisecond)
+	recordBuilderResult("titan", false, 123*time.Millisecond)
+
+	server := httptest.NewServer(promhttp.Handler())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("metrics endpoint request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("metrics endpoint read failed: %v", err)
+	}
+	payload := string(body)
+
+	required := []string{
+		`aether_executor_builder_submissions_total{builder="flashbots",result="success"}`,
+		`aether_executor_builder_submissions_total{builder="titan",result="failure"}`,
+		`aether_executor_builder_latency_ms_count{builder="flashbots"}`,
+		`aether_executor_builder_latency_ms_count{builder="titan"}`,
+	}
+	for _, want := range required {
+		if !strings.Contains(payload, want) {
+			t.Errorf("metrics output missing %q", want)
+		}
+	}
+}
+
+func TestSetSystemState_LastWriteWins(t *testing.T) {
+	setSystemState(2)
+	setSystemState(3)
+
+	server := httptest.NewServer(promhttp.Handler())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("metrics endpoint request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("metrics endpoint read failed: %v", err)
+	}
+
+	if !strings.Contains(string(body), "aether_system_state 3") {
+		t.Fatalf("expected 'aether_system_state 3' in payload, got: %s", string(body))
+	}
+}
+
+func TestRecordCircuitBreakerTrip(t *testing.T) {
+	recordCircuitBreakerTrip("daily_loss_exceeded")
+
+	server := httptest.NewServer(promhttp.Handler())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("metrics endpoint request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("metrics endpoint read failed: %v", err)
+	}
+
+	want := `aether_circuit_breaker_trips_total{reason="daily_loss_exceeded"}`
+	if !strings.Contains(string(body), want) {
+		t.Fatalf("metrics output missing %q", want)
+	}
+}

--- a/cmd/executor/metrics_test.go
+++ b/cmd/executor/metrics_test.go
@@ -253,6 +253,54 @@ func TestRecordBuilderResult_ScrapeLabels(t *testing.T) {
 	}
 }
 
+func TestPreRegisterBuilderLabels_BothSeriesExistAtZero(t *testing.T) {
+	// Use unique builder names so the assertion is not polluted by other
+	// tests that exercise recordBuilderResult against real builder names.
+	names := []string{"prereg_alpha", "prereg_beta"}
+	PreRegisterBuilderLabels(names)
+
+	for _, name := range names {
+		gotSuccess := testutil.ToFloat64(builderSubmissionsTotal.WithLabelValues(name, "success"))
+		if gotSuccess != 0 {
+			t.Errorf("pre-registered %q success: got %f, want 0", name, gotSuccess)
+		}
+		gotFailure := testutil.ToFloat64(builderSubmissionsTotal.WithLabelValues(name, "failure"))
+		if gotFailure != 0 {
+			t.Errorf("pre-registered %q failure: got %f, want 0", name, gotFailure)
+		}
+	}
+
+	// Verify both series are actually exposed on the /metrics scrape (not
+	// just observable via the in-process collector) — this is the property
+	// the AetherBuilderDown alert actually depends on.
+	server := httptest.NewServer(promhttp.Handler())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("metrics endpoint request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("metrics endpoint read failed: %v", err)
+	}
+	payload := string(body)
+
+	required := []string{
+		`aether_executor_builder_submissions_total{builder="prereg_alpha",result="success"} 0`,
+		`aether_executor_builder_submissions_total{builder="prereg_alpha",result="failure"} 0`,
+		`aether_executor_builder_submissions_total{builder="prereg_beta",result="success"} 0`,
+		`aether_executor_builder_submissions_total{builder="prereg_beta",result="failure"} 0`,
+	}
+	for _, want := range required {
+		if !strings.Contains(payload, want) {
+			t.Errorf("metrics output missing %q", want)
+		}
+	}
+}
+
 func TestSetSystemState_LastWriteWins(t *testing.T) {
 	setSystemState(2)
 	setSystemState(3)

--- a/cmd/executor/submitter.go
+++ b/cmd/executor/submitter.go
@@ -333,6 +333,8 @@ func (s *Submitter) recordMetrics(builder string, result SubmissionResult) {
 	latencyUs := result.Latency.Microseconds()
 	m.LastLatency.Store(latencyUs)
 	m.TotalLatency.Add(latencyUs)
+
+	recordBuilderResult(builder, result.Success, result.Latency)
 }
 
 // Metrics returns a snapshot of per-builder metrics.

--- a/cmd/executor/submitter.go
+++ b/cmd/executor/submitter.go
@@ -76,9 +76,15 @@ func NewSubmitter(builders []BuilderConfig, searcherKey string) (*Submitter, err
 	}
 
 	metrics := make(map[string]*BuilderMetrics, len(builders))
+	names := make([]string, 0, len(builders))
 	for _, b := range builders {
 		metrics[b.Name] = &BuilderMetrics{}
+		names = append(names, b.Name)
 	}
+	// Ensure both {result="success"} and {result="failure"} series exist
+	// for every configured builder from t=0 so the AetherBuilderDown alert
+	// can reason about builders that have not yet produced either outcome.
+	PreRegisterBuilderLabels(names)
 
 	transport := &http.Transport{
 		MaxIdleConnsPerHost: len(builders),

--- a/deploy/docker/alertmanager.yml
+++ b/deploy/docker/alertmanager.yml
@@ -1,0 +1,28 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: slack-default
+  group_by: [alertname, severity]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: slack-default
+    slack_configs:
+      - api_url: __SLACK_WEBHOOK_URL__
+        channel: "#aether-alerts"
+        send_resolved: true
+        title: '[{{ .CommonLabels.severity | toUpper }}] {{ .CommonLabels.alertname }}'
+        text: |-
+          {{ range .Alerts }}
+          *{{ .Annotations.summary }}*
+          {{ .Annotations.description }}
+          {{ if .GeneratorURL }}<{{ .GeneratorURL }}|View in Prometheus>{{ end }}
+          {{ end }}
+
+inhibit_rules:
+  - source_matchers: [severity="critical"]
+    target_matchers: [severity=~"warning|info"]
+    equal: [alertname]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -54,6 +54,34 @@ services:
       - "9091:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+    depends_on:
+      - alertmanager
+    networks:
+      - aether-net
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: aether-alertmanager
+    ports:
+      - "9093:9093"
+    environment:
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:-}
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml.tpl:ro
+      - alertmanager-data:/alertmanager
+    # Substitute the webhook URL from the environment at startup so the
+    # secret never lands in the committed config file.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        sed "s|__SLACK_WEBHOOK_URL__|${SLACK_WEBHOOK_URL}|g" \
+          /etc/alertmanager/alertmanager.yml.tpl > /tmp/alertmanager.yml
+        exec /bin/alertmanager \
+          --config.file=/tmp/alertmanager.yml \
+          --storage.path=/alertmanager
+    restart: unless-stopped
     networks:
       - aether-net
 
@@ -69,6 +97,7 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     depends_on:
       - prometheus
     networks:
@@ -97,6 +126,7 @@ services:
 
 volumes:
   grafana-data:
+  alertmanager-data:
   reth-data:
   reth-ipc:
 

--- a/deploy/docker/grafana/dashboards/builders.json
+++ b/deploy/docker/grafana/dashboards/builders.json
@@ -1,0 +1,85 @@
+{
+  "uid": "aether-builders",
+  "title": "Aether — Builder Performance",
+  "tags": ["aether", "builders"],
+  "schemaVersion": 38,
+  "version": 0,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Submission rate by builder (per minute)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (builder) (rate(aether_executor_builder_submissions_total[5m])) * 60",
+          "legendFormat": "{{builder}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Success rate by builder",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (builder) (rate(aether_executor_builder_submissions_total{result=\"success\"}[5m])) / clamp_min(sum by (builder) (rate(aether_executor_builder_submissions_total[5m])), 0.0001)",
+          "legendFormat": "{{builder}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Submission latency p95 by builder (ms)",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, builder) (rate(aether_executor_builder_latency_ms_bucket[5m])))",
+          "legendFormat": "{{builder}} p95"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Per-builder totals",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (builder, result) (aether_executor_builder_submissions_total)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    }
+  ]
+}

--- a/deploy/docker/grafana/dashboards/latency.json
+++ b/deploy/docker/grafana/dashboards/latency.json
@@ -1,0 +1,68 @@
+{
+  "uid": "aether-latency",
+  "title": "Aether — Latency",
+  "tags": ["aether", "latency"],
+  "schemaVersion": 38,
+  "version": 0,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Detection latency (ms)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.50, sum by (le) (rate(aether_detection_latency_ms_bucket[5m])))", "legendFormat": "p50" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(aether_detection_latency_ms_bucket[5m])))", "legendFormat": "p95" },
+        { "refId": "C", "expr": "histogram_quantile(0.99, sum by (le) (rate(aether_detection_latency_ms_bucket[5m])))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "decimals": 2 }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Simulation latency (ms)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.50, sum by (le) (rate(aether_simulation_latency_ms_bucket[5m])))", "legendFormat": "p50" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(aether_simulation_latency_ms_bucket[5m])))", "legendFormat": "p95" },
+        { "refId": "C", "expr": "histogram_quantile(0.99, sum by (le) (rate(aether_simulation_latency_ms_bucket[5m])))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "decimals": 2 }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "End-to-end latency (ms) — p50 / p95 / p99",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.50, sum by (le) (rate(aether_end_to_end_latency_ms_bucket[5m])))", "legendFormat": "p50" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(aether_end_to_end_latency_ms_bucket[5m])))", "legendFormat": "p95" },
+        { "refId": "C", "expr": "histogram_quantile(0.99, sum by (le) (rate(aether_end_to_end_latency_ms_bucket[5m])))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "showLegend": true } }
+    }
+  ]
+}

--- a/deploy/docker/grafana/dashboards/overview.json
+++ b/deploy/docker/grafana/dashboards/overview.json
@@ -1,0 +1,175 @@
+{
+  "uid": "aether-overview",
+  "title": "Aether — Overview",
+  "tags": ["aether", "overview"],
+  "schemaVersion": 38,
+  "version": 0,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Opportunities / min (5m avg)",
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_arbs_published_total[5m])) * 60",
+          "legendFormat": "opps/min"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 5 },
+              { "color": "green", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Inclusion rate (1h)",
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_executor_bundles_included_total[1h])) / clamp_min(sum(rate(aether_executor_bundles_submitted_total[1h])), 1)",
+          "legendFormat": "inclusion"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.2 },
+              { "color": "green", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "ETH balance",
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_eth_balance", "legendFormat": "ETH" }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.15 },
+              { "color": "green", "value": 0.3 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Gas (gwei)",
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_gas_price_gwei", "legendFormat": "gwei" }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 100 },
+              { "color": "red", "value": 300 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Daily PnL (ETH)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_daily_pnl_eth", "legendFormat": "cumulative today" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "none", "decimals": 4 },
+        "overrides": []
+      },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Rolling 1h profit (ETH)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "increase(aether_executor_profit_wei_total[1h]) / 1e18",
+          "legendFormat": "profit (1h)"
+        },
+        {
+          "refId": "B",
+          "expr": "increase(aether_executor_gas_spent_wei_total[1h]) / 1e18",
+          "legendFormat": "gas cost (1h)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "none", "decimals": 6 },
+        "overrides": []
+      },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Opportunity + bundle rates (per minute)",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "rate(aether_arbs_published_total[5m]) * 60", "legendFormat": "arbs published" },
+        { "refId": "B", "expr": "rate(aether_executor_bundles_submitted_total[5m]) * 60", "legendFormat": "bundles submitted" },
+        { "refId": "C", "expr": "rate(aether_executor_bundles_included_total[5m]) * 60", "legendFormat": "bundles included" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    }
+  ]
+}

--- a/deploy/docker/grafana/dashboards/overview.json
+++ b/deploy/docker/grafana/dashboards/overview.json
@@ -46,7 +46,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(rate(aether_executor_bundles_included_total[1h])) / clamp_min(sum(rate(aether_executor_bundles_submitted_total[1h])), 1)",
+          "expr": "sum(rate(aether_executor_bundles_included_total[1h])) / clamp_min(sum(rate(aether_executor_bundles_submitted_total[1h])), 1e-9)",
           "legendFormat": "inclusion"
         }
       ],

--- a/deploy/docker/grafana/dashboards/risk.json
+++ b/deploy/docker/grafana/dashboards/risk.json
@@ -1,0 +1,159 @@
+{
+  "uid": "aether-risk",
+  "title": "Aether — Risk & State",
+  "tags": ["aether", "risk"],
+  "schemaVersion": 38,
+  "version": 0,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "state-timeline",
+      "title": "System state (Running / Degraded / Paused / Halted)",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_system_state", "legendFormat": "state" }
+      ],
+      "options": { "showValue": "auto", "mergeValues": true },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "lineWidth": 0, "fillOpacity": 80 },
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "Running",  "color": "green"  } } },
+            { "type": "value", "options": { "1": { "text": "Degraded", "color": "orange" } } },
+            { "type": "value", "options": { "2": { "text": "Paused",   "color": "yellow" } } },
+            { "type": "value", "options": { "3": { "text": "Halted",   "color": "red"    } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green",  "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "yellow", "value": 2 },
+              { "color": "red",    "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Circuit breaker trips (1h rate)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "increase(aether_circuit_breaker_trips_total[1h])",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Risk rejections (per minute)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(aether_executor_risk_rejections_total[5m]) * 60",
+          "legendFormat": "rejections/min"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Daily PnL (ETH)",
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_daily_pnl_eth", "legendFormat": "PnL" }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": -0.5 },
+              { "color": "green", "value": 0 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "ETH balance",
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_eth_balance", "legendFormat": "ETH" }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.15 },
+              { "color": "green", "value": 0.3 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Current state",
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "aether_system_state", "legendFormat": "state" }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "Running",  "color": "green"  } } },
+            { "type": "value", "options": { "1": { "text": "Degraded", "color": "orange" } } },
+            { "type": "value", "options": { "2": { "text": "Paused",   "color": "yellow" } } },
+            { "type": "value", "options": { "3": { "text": "Halted",   "color": "red"    } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "yellow", "value": 2 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/deploy/docker/grafana/provisioning/dashboards/default.yml
+++ b/deploy/docker/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: aether
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/docker/grafana/provisioning/datasources/prometheus.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true

--- a/deploy/docker/prometheus.yml
+++ b/deploy/docker/prometheus.yml
@@ -1,5 +1,14 @@
 global:
   scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
 
 scrape_configs:
   - job_name: "aether-go"

--- a/deploy/docker/prometheus/alerts.yml
+++ b/deploy/docker/prometheus/alerts.yml
@@ -16,7 +16,7 @@ groups:
         expr: |
           sum(rate(aether_executor_bundles_included_total[1h]))
           /
-          clamp_min(sum(rate(aether_executor_bundles_submitted_total[1h])), 1) < 0.20
+          clamp_min(sum(rate(aether_executor_bundles_submitted_total[1h])), 1e-9) < 0.20
         for: 10m
         labels:
           severity: warning

--- a/deploy/docker/prometheus/alerts.yml
+++ b/deploy/docker/prometheus/alerts.yml
@@ -1,0 +1,73 @@
+groups:
+  - name: aether.rules
+    interval: 30s
+    rules:
+
+      - alert: AetherHalted
+        expr: aether_system_state == 3
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Aether system is Halted"
+          description: "System state gauge reports Halted (3) for >1m. Halted requires manual reset. Check executor logs for the breaker reason."
+
+      - alert: AetherInclusionRateLow
+        expr: |
+          sum(rate(aether_executor_bundles_included_total[1h]))
+          /
+          clamp_min(sum(rate(aether_executor_bundles_submitted_total[1h])), 1) < 0.20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Bundle inclusion rate below 20% over the last hour"
+          description: "Over the last 1h, fewer than 20% of submitted bundles were included. Current ratio: {{ printf \"%.2f\" $value }}."
+
+      - alert: AetherE2ELatencyHigh
+        expr: histogram_quantile(0.99, sum by (le) (rate(aether_end_to_end_latency_ms_bucket[5m]))) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "End-to-end p99 latency above 100ms"
+          description: "p99 end-to-end latency = {{ printf \"%.1f\" $value }}ms over last 5m (target <100ms)."
+
+      - alert: AetherNoOpportunities
+        expr: rate(aether_arbs_published_total[10m]) * 60 < 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Fewer than 5 opportunities per minute"
+          description: "Arb publish rate = {{ printf \"%.1f\" $value }}/min over last 10m. Detection pipeline may be stalled."
+
+      - alert: AetherETHBalanceLow
+        expr: aether_eth_balance < 0.15
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Searcher ETH balance below 0.15"
+          description: "Hot wallet ETH balance = {{ printf \"%.4f\" $value }}. Top up before bundles start reverting on gas."
+
+      - alert: AetherGasHigh
+        expr: aether_gas_price_gwei > 300
+        for: 30s
+        labels:
+          severity: info
+        annotations:
+          summary: "Gas price above 300 gwei"
+          description: "Base fee = {{ printf \"%.1f\" $value }} gwei. Executor preflight will reject arbs until this drops."
+
+      - alert: AetherBuilderDown
+        expr: |
+          sum by (builder) (rate(aether_executor_builder_submissions_total{result="success"}[2m])) == 0
+          and on (builder)
+          sum by (builder) (rate(aether_executor_builder_submissions_total[2m])) > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Builder {{ $labels.builder }} has no successful submissions"
+          description: "Builder {{ $labels.builder }} received submissions but zero succeeded over the last 2m. Check builder endpoint health and auth."

--- a/internal/risk/manager.go
+++ b/internal/risk/manager.go
@@ -96,6 +96,14 @@ type PreflightResult struct {
 	Reason   string
 }
 
+// MetricsObserver is notified on state changes and breaker trips. Optional;
+// nil observer is a no-op. Implementations must be goroutine-safe. Called
+// under rm.mu — keep callbacks non-blocking (Prometheus primitives are fine).
+type MetricsObserver interface {
+	OnStateChange(state SystemState)
+	OnCircuitBreakerTrip(reason string)
+}
+
 // RiskManager implements circuit breakers and position limits.
 type RiskManager struct {
 	mu                  sync.RWMutex
@@ -119,6 +127,32 @@ type RiskManager struct {
 
 	// Rate-limit: last time the competitive-rate alert was emitted.
 	lastCompAlertTime time.Time
+
+	// Decoupled from Prometheus: executor wraps its own metrics as an observer.
+	metricsObs MetricsObserver
+}
+
+// SetMetricsObserver installs an observer and immediately emits OnStateChange
+// so the metrics layer sees the initial state. Call once at startup.
+func (rm *RiskManager) SetMetricsObserver(obs MetricsObserver) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.metricsObs = obs
+	if obs != nil {
+		obs.OnStateChange(rm.state.Current())
+	}
+}
+
+// notifyTrip transitions state and notifies the observer. Caller holds rm.mu.
+func (rm *RiskManager) notifyTrip(reason string, newState SystemState) {
+	if err := rm.state.Transition(newState); err != nil {
+		log.Printf("CIRCUIT BREAKER: transition to %s failed: %v", newState, err)
+		return
+	}
+	if rm.metricsObs != nil {
+		rm.metricsObs.OnCircuitBreakerTrip(reason)
+		rm.metricsObs.OnStateChange(newState)
+	}
 }
 
 // NewRiskManager creates a new risk manager.
@@ -278,7 +312,7 @@ func (rm *RiskManager) RecordRevert(revertType RevertType) {
 	if len(rm.recentBugReverts) >= rm.config.ConsecutiveRevertsPause {
 		log.Printf("CIRCUIT BREAKER: %d bug reverts in %d minutes, pausing",
 			len(rm.recentBugReverts), rm.config.RevertWindowMinutes)
-		rm.state.Transition(StatePaused)
+		rm.notifyTrip("consecutive_bug_reverts", StatePaused)
 	}
 
 	// --- Competitive-revert stale-data alert (rate-limited: once per window) ---
@@ -308,7 +342,7 @@ func (rm *RiskManager) RecordTrade(volumeWei *big.Int, pnlWei *big.Int) {
 	if lossETH > rm.config.DailyLossHaltETH {
 		log.Printf("CIRCUIT BREAKER: daily loss %.4f ETH exceeds threshold %.4f ETH, halting",
 			lossETH, rm.config.DailyLossHaltETH)
-		rm.state.Transition(StateHalted)
+		rm.notifyTrip("daily_loss_exceeded", StateHalted)
 	}
 }
 

--- a/internal/risk/manager.go
+++ b/internal/risk/manager.go
@@ -144,13 +144,22 @@ func (rm *RiskManager) SetMetricsObserver(obs MetricsObserver) {
 }
 
 // notifyTrip transitions state and notifies the observer. Caller holds rm.mu.
+//
+// The OnCircuitBreakerTrip observer is called BEFORE the state transition so
+// every trip is counted even when the transition is rejected (e.g. the bot is
+// already Halted and another bug-revert burst tries to push to Paused). That
+// is exactly the signal we want to preserve: "we're still seeing breaker
+// conditions in a halted state". OnStateChange is only emitted on a real
+// transition, since no state actually changed otherwise.
 func (rm *RiskManager) notifyTrip(reason string, newState SystemState) {
+	if rm.metricsObs != nil {
+		rm.metricsObs.OnCircuitBreakerTrip(reason)
+	}
 	if err := rm.state.Transition(newState); err != nil {
 		log.Printf("CIRCUIT BREAKER: transition to %s failed: %v", newState, err)
 		return
 	}
 	if rm.metricsObs != nil {
-		rm.metricsObs.OnCircuitBreakerTrip(reason)
 		rm.metricsObs.OnStateChange(newState)
 	}
 }

--- a/internal/risk/manager_test.go
+++ b/internal/risk/manager_test.go
@@ -576,6 +576,114 @@ func TestCalculateTipShare_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
+// fakeMetricsObserver records observer callbacks under its own lock so tests
+// can assert ordering and contents without racing the risk manager's mu.
+type fakeMetricsObserver struct {
+	mu     sync.Mutex
+	states []SystemState
+	trips  []string
+}
+
+func (f *fakeMetricsObserver) OnStateChange(s SystemState) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.states = append(f.states, s)
+}
+
+func (f *fakeMetricsObserver) OnCircuitBreakerTrip(reason string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.trips = append(f.trips, reason)
+}
+
+func (f *fakeMetricsObserver) snapshot() ([]SystemState, []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	states := append([]SystemState(nil), f.states...)
+	trips := append([]string(nil), f.trips...)
+	return states, trips
+}
+
+func TestMetricsObserver_InitialStateReported(t *testing.T) {
+	t.Parallel()
+
+	rm := NewRiskManager(DefaultRiskConfig())
+	obs := &fakeMetricsObserver{}
+	rm.SetMetricsObserver(obs)
+
+	states, trips := obs.snapshot()
+	if len(states) != 1 || states[0] != StateRunning {
+		t.Fatalf("expected one OnStateChange(Running), got %v", states)
+	}
+	if len(trips) != 0 {
+		t.Fatalf("expected no trips, got %v", trips)
+	}
+}
+
+func TestMetricsObserver_BugRevertTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultRiskConfig()
+	cfg.ConsecutiveRevertsPause = 3
+	rm := NewRiskManager(cfg)
+
+	obs := &fakeMetricsObserver{}
+	rm.SetMetricsObserver(obs)
+
+	rm.RecordRevert(RevertBug)
+	rm.RecordRevert(RevertBug)
+	rm.RecordRevert(RevertBug)
+
+	states, trips := obs.snapshot()
+
+	// Expect initial Running + Paused after trip.
+	if len(states) < 2 || states[0] != StateRunning || states[len(states)-1] != StatePaused {
+		t.Fatalf("expected states to start at Running and end at Paused, got %v", states)
+	}
+
+	foundTrip := false
+	for _, r := range trips {
+		if r == "consecutive_bug_reverts" {
+			foundTrip = true
+			break
+		}
+	}
+	if !foundTrip {
+		t.Fatalf("expected 'consecutive_bug_reverts' trip, got %v", trips)
+	}
+}
+
+func TestMetricsObserver_DailyLossTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultRiskConfig()
+	cfg.DailyLossHaltETH = 0.1 // low threshold — 0.2 ETH loss trips it
+	rm := NewRiskManager(cfg)
+
+	obs := &fakeMetricsObserver{}
+	rm.SetMetricsObserver(obs)
+
+	largeLoss := new(big.Int).Neg(fracETHWei(t, 2, 10)) // -0.2 ETH
+	rm.RecordTrade(ethWei(t, 1), largeLoss)
+
+	states, trips := obs.snapshot()
+
+	if len(states) < 2 || states[0] != StateRunning || states[len(states)-1] != StateHalted {
+		t.Fatalf("expected states to start at Running and end at Halted, got %v", states)
+	}
+
+	foundTrip := false
+	for _, r := range trips {
+		if r == "daily_loss_exceeded" {
+			foundTrip = true
+			break
+		}
+	}
+	if !foundTrip {
+		t.Fatalf("expected 'daily_loss_exceeded' trip, got %v", trips)
+	}
+}
+
 func TestWeiToETH(t *testing.T) {
 	t.Parallel()
 

--- a/internal/risk/manager_test.go
+++ b/internal/risk/manager_test.go
@@ -684,6 +684,63 @@ func TestMetricsObserver_DailyLossTrip(t *testing.T) {
 	}
 }
 
+// TestMetricsObserver_TripCountedEvenWhenTransitionRejected asserts that the
+// circuit-breaker trip observer fires even when the underlying state machine
+// rejects the transition — e.g. the bot is already Halted and another
+// bug-revert burst tries to push to Paused. The trip metric must still be
+// bumped so dashboards can show "we're still seeing breaker conditions in a
+// halted state" rather than silently swallowing the signal.
+func TestMetricsObserver_TripCountedEvenWhenTransitionRejected(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultRiskConfig()
+	cfg.ConsecutiveRevertsPause = 3
+	rm := NewRiskManager(cfg)
+
+	// Force the bot into Halted without going through the breaker path.
+	rm.state.ForceState(StateHalted)
+
+	obs := &fakeMetricsObserver{}
+	rm.SetMetricsObserver(obs)
+
+	// Drain the initial OnStateChange(Halted) that SetMetricsObserver emits.
+	initialStates, initialTrips := obs.snapshot()
+	if len(initialStates) != 1 || initialStates[0] != StateHalted {
+		t.Fatalf("setup: expected one OnStateChange(Halted), got %v", initialStates)
+	}
+	if len(initialTrips) != 0 {
+		t.Fatalf("setup: expected zero trips, got %v", initialTrips)
+	}
+
+	// 3 bug reverts would ordinarily trip Running -> Paused. From Halted the
+	// Paused transition is invalid, so the state does NOT change. We still
+	// expect one 'consecutive_bug_reverts' trip to be observed.
+	rm.RecordRevert(RevertBug)
+	rm.RecordRevert(RevertBug)
+	rm.RecordRevert(RevertBug)
+
+	states, trips := obs.snapshot()
+
+	// No new state changes beyond the initial one.
+	if len(states) != 1 {
+		t.Fatalf("expected no state changes after failed transition, got %v", states)
+	}
+	if rm.State() != StateHalted {
+		t.Fatalf("expected state to remain Halted, got %s", rm.State())
+	}
+
+	// Trip must still have been recorded exactly once.
+	tripCount := 0
+	for _, r := range trips {
+		if r == "consecutive_bug_reverts" {
+			tripCount++
+		}
+	}
+	if tripCount != 1 {
+		t.Fatalf("expected exactly one 'consecutive_bug_reverts' trip even when transition rejected, got trips=%v", trips)
+	}
+}
+
 func TestWeiToETH(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

PR1 of 3 for issue #69 — delivers the core observability loop: Prometheus metrics → Grafana dashboards → Alertmanager → Slack. Everything self-hosted; no paid services.

- 4 Grafana dashboards (file-provisioned): **Overview**, **Latency** (p50/p95/p99), **Builder Performance**, **Risk & State**
- 7 Prometheus alert rules: `AetherHalted`, `AetherInclusionRateLow`, `AetherE2ELatencyHigh`, `AetherNoOpportunities`, `AetherETHBalanceLow`, `AetherGasHigh`, `AetherBuilderDown`
- Alertmanager with a single Slack receiver; webhook URL is substituted from `SLACK_WEBHOOK_URL` at container startup — never committed
- Metric-gap fixes in the Go executor: per-builder submission counters (`builder`, `result` labels) + latency histogram, `aether_system_state` gauge, `aether_circuit_breaker_trips_total{reason}` counter
- `MetricsObserver` hook on `RiskManager` so `internal/risk` stays Prometheus-free — `cmd/executor` adapts to the gauge/counter at startup

Follow-up PRs for the remaining WS-7 scope are outlined in [this comment on #69](https://github.com/Pablosinyores/aether/issues/69#issuecomment-4242259187):
- **PR2** — Loki + Promtail log aggregation (WS-7.5)
- **PR3** — OpenTelemetry + Tempo tracing + synthetic canary (WS-7.6, WS-7.7)

## Files

| Area | Files |
|---|---|
| Metrics | \`cmd/executor/metrics.go\`, \`cmd/executor/submitter.go\`, \`cmd/executor/main.go\`, \`cmd/executor/metrics_test.go\`, \`internal/risk/manager.go\`, \`internal/risk/manager_test.go\` |
| Prometheus | \`deploy/docker/prometheus.yml\`, \`deploy/docker/prometheus/alerts.yml\` |
| Alertmanager | \`deploy/docker/alertmanager.yml\` |
| Grafana | \`deploy/docker/grafana/dashboards/{overview,latency,builders,risk}.json\`, \`deploy/docker/grafana/provisioning/dashboards/default.yml\` |
| Compose | \`deploy/docker/docker-compose.yml\` (adds alertmanager service, mounts alerts + dashboards) |
| Env | \`.env.example\` (documents \`SLACK_WEBHOOK_URL\`) |

## Test plan

- [x] \`go test ./cmd/executor/... ./internal/risk/... -count=1 -race\` — pass
- [x] \`go vet ./cmd/executor/... ./internal/risk/...\` — clean
- [x] \`jq empty deploy/docker/grafana/dashboards/*.json\` — valid JSON
- [x] YAML parse of all new/modified \`.yml\` files — valid
- [ ] \`docker compose up -d prometheus grafana alertmanager aether-rust aether-go\` on a host with Docker — dashboards appear in Grafana, 7 rules load in \`http://<host>:9091/alerts\`, Alertmanager reachable at \`:9093\`
- [ ] Trigger each alert (tweak thresholds or push synthetic values), confirm Slack message carries the severity label and alert description
- [ ] Walk through a simulated incident using only Grafana + Slack alerts (E2 gate criterion from the issue)

## Notes for reviewers

- The Slack receiver uses an entrypoint \`sed\` substitution to inject the webhook from env. This avoids feature flags for env expansion across Alertmanager versions and keeps the committed config free of secrets. The substituted file is written to \`/tmp\` inside the container, not to a mounted path.
- \`AetherBuilderDown\` uses an \`and\` clause so it only fires for builders that actually received submissions in the window (avoids paging on an entirely idle system).
- Dashboards use \`schemaVersion: 38\` and explicit \`uid\` fields so they are reimport-safe.
- Observer callbacks run under \`rm.mu\`. Prometheus primitives are lock-free, so this is fine today. Any future observer doing blocking I/O would stall risk processing — documented on the interface.

Closes part of #69 (see linked comment for PR split).