### PR TITLE
feat(observability): self-hosted log aggregation (loki + structured logs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ ALCHEMY_API_KEY=your_alchemy_api_key_here
 RUST_LOG=info
 AETHER_CONFIG_DIR=./config
 ETH_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}
+# LOG_FORMAT=json switches the Rust tracing-subscriber to a structured JSON layer
+# so Promtail can ship logs to Loki. Leave unset (or set to anything else) for
+# human-readable output during local development.
+# LOG_FORMAT=json
 
 # Go
 GOMAXPROCS=2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2"
 anyhow = "1"
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # Math
 ruint = "1"
 # Arc swap for MVCC

--- a/cmd/executor/bundle.go
+++ b/cmd/executor/bundle.go
@@ -4,8 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -96,7 +97,8 @@ func (bc *BundleConstructor) BuildBundle(
 func GenerateBundleID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		log.Fatalf("crypto/rand failure: %v", err)
+		slog.Error("crypto/rand failure", "err", err)
+		os.Exit(1)
 	}
 	return hex.EncodeToString(b)
 }

--- a/cmd/executor/gas_oracle.go
+++ b/cmd/executor/gas_oracle.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"math/big"
 	"sync"
 	"time"
@@ -127,7 +127,7 @@ func (go_ *GasOracle) FetchOnce(ctx context.Context) (GasFees, error) {
 		baseFee = feeHistory.BaseFee[len(feeHistory.BaseFee)-1]
 	}
 	if baseFee == nil || baseFee.Sign() == 0 {
-		log.Printf("Gas oracle: WARNING eth_feeHistory returned zero/nil baseFee, keeping last known values")
+		slog.Warn("gas oracle: eth_feeHistory returned zero/nil baseFee, keeping last known values")
 		return go_.CurrentFees(), nil
 	}
 
@@ -156,14 +156,14 @@ func (go_ *GasOracle) UpdateLoop(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			fees, err := go_.FetchOnce(ctx)
 			if err != nil {
-				log.Printf("Gas oracle: RPC error (keeping last known): %v", err)
+				slog.Warn("gas oracle: RPC error, keeping last known", "err", err)
 			} else {
 				recordGasPrice(fees.GasPriceGwei)
 			}
-			log.Printf("Gas oracle: baseFee=%.4f gwei, maxFee=%.4f gwei, priorityFee=%.4f gwei",
-				weiToGwei(fees.BaseFee),
-				weiToGwei(fees.MaxFeePerGas),
-				weiToGwei(fees.MaxPriorityFee))
+			slog.Debug("gas oracle: fees updated",
+				"base_fee_gwei", weiToGwei(fees.BaseFee),
+				"max_fee_gwei", weiToGwei(fees.MaxFeePerGas),
+				"priority_fee_gwei", weiToGwei(fees.MaxPriorityFee))
 		}
 	}
 }

--- a/cmd/executor/gas_oracle_test.go
+++ b/cmd/executor/gas_oracle_test.go
@@ -46,8 +46,8 @@ func TestGasOracle_Update(t *testing.T) {
 
 	go_ := NewGasOracle(300.0)
 
-	newBaseFee := big.NewInt(50e9)   // 50 gwei
-	newPriority := big.NewInt(5e9)   // 5 gwei
+	newBaseFee := big.NewInt(50e9) // 50 gwei
+	newPriority := big.NewInt(5e9) // 5 gwei
 	go_.Update(newBaseFee, newPriority)
 
 	fees := go_.CurrentFees()
@@ -118,14 +118,14 @@ func TestGasOracle_IsGasTooHigh(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		maxGwei    float64
+		name        string
+		maxGwei     float64
 		baseFeeGwei int64
-		want       bool
+		want        bool
 	}{
 		{"below threshold", 300, 200, false},
 		{"above threshold", 300, 350, true},
-		{"at threshold", 300, 300, false},      // GasPriceGwei == maxGasGwei → not strictly greater
+		{"at threshold", 300, 300, false}, // GasPriceGwei == maxGasGwei → not strictly greater
 		{"way above", 100, 500, true},
 		{"just below", 300, 299, false},
 		{"just above", 300, 301, true},
@@ -153,16 +153,16 @@ func TestGasOracle_MaxFeeFormula(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		baseFeeGwei    int64
-		priorityGwei   int64
+		name            string
+		baseFeeGwei     int64
+		priorityGwei    int64
 		expectedMaxGwei int64
 	}{
-		{"30+2", 30, 2, 62},     // 2*30 + 2
-		{"50+5", 50, 5, 105},    // 2*50 + 5
+		{"30+2", 30, 2, 62},      // 2*30 + 2
+		{"50+5", 50, 5, 105},     // 2*50 + 5
 		{"100+10", 100, 10, 210}, // 2*100 + 10
-		{"1+1", 1, 1, 3},        // 2*1 + 1
-		{"0+0", 0, 0, 0},        // 2*0 + 0
+		{"1+1", 1, 1, 3},         // 2*1 + 1
+		{"0+0", 0, 0, 0},         // 2*0 + 0
 	}
 
 	for _, tc := range tests {
@@ -204,8 +204,8 @@ func TestGasOracle_FetchOnce_RealFees(t *testing.T) {
 	mock := &mockFeeHistoryProvider{
 		result: &ethereum.FeeHistory{
 			OldestBlock:  big.NewInt(100),
-			BaseFee:      []*big.Int{big.NewInt(45e9)},        // 45 gwei
-			Reward:       [][]*big.Int{{big.NewInt(3e9)}},      // 3 gwei priority
+			BaseFee:      []*big.Int{big.NewInt(45e9)},    // 45 gwei
+			Reward:       [][]*big.Int{{big.NewInt(3e9)}}, // 3 gwei priority
 			GasUsedRatio: []float64{0.5},
 		},
 	}
@@ -357,7 +357,7 @@ func TestGasOracle_UpdateLoop_ErrorThenRecover(t *testing.T) {
 	mock := &sequenceMockFeeHistory{
 		results: []*ethereum.FeeHistory{
 			nil, // call 0: error
-			{    // call 1: success
+			{ // call 1: success
 				OldestBlock:  big.NewInt(100),
 				BaseFee:      []*big.Int{big.NewInt(25e9)},
 				Reward:       [][]*big.Int{{big.NewInt(1e9)}},

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/big"
 	"os"
 	"os/signal"
@@ -48,7 +48,7 @@ func loadConfig() Config {
 	buildersPath := config.ConfigPath("builders.yaml")
 	bc, err := config.LoadBuildersConfig(buildersPath)
 	if err != nil {
-		log.Printf("Config: builders.yaml not loaded (%v), using defaults", err)
+		slog.Warn("builders.yaml not loaded, using defaults", "path", buildersPath, "err", err)
 	} else {
 		builders := make([]BuilderConfig, 0, len(bc.Builders))
 		for _, b := range bc.Builders {
@@ -62,13 +62,13 @@ func loadConfig() Config {
 			})
 		}
 		cfg.BuilderConfigs = builders
-		log.Printf("Config: loaded %d builders from %s", len(builders), buildersPath)
+		slog.Info("builders loaded", "count", len(builders), "path", buildersPath)
 	}
 
 	// Override gRPC address from environment if set.
 	if addr := os.Getenv("GRPC_ADDRESS"); addr != "" {
 		cfg.GRPCAddress = addr
-		log.Printf("Config: GRPC_ADDRESS=%s (from env)", addr)
+		slog.Info("grpc address overridden from env", "addr", addr)
 	}
 
 	return cfg
@@ -80,14 +80,16 @@ func loadRiskConfig() risk.RiskConfig {
 	riskPath := config.ConfigPath("risk.yaml")
 	rc, err := risk.LoadRiskConfig(riskPath)
 	if err != nil {
-		log.Printf("Config: risk.yaml not loaded (%v), using defaults", err)
+		slog.Warn("risk.yaml not loaded, using defaults", "path", riskPath, "err", err)
 		return risk.DefaultRiskConfig()
 	}
-	log.Printf("Config: loaded risk config from %s", riskPath)
+	slog.Info("risk config loaded", "path", riskPath)
 	return rc
 }
 
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	fmt.Println("aether-executor: bundle construction and submission service")
 
 	cfg := loadConfig()
@@ -102,25 +104,26 @@ func main() {
 	execPath := config.ConfigPath("executor.yaml")
 	execCfg, err := config.LoadExecutorConfig(execPath)
 	if err != nil {
-		log.Fatalf("FATAL: executor config (%s) missing or invalid: %v", execPath, err)
+		slog.Error("executor config missing or invalid", "path", execPath, "err", err)
+		os.Exit(1)
 	}
-	log.Printf("Config: executor_address=%s expected_chain_id=%d",
-		execCfg.ExecutorAddress, execCfg.ExpectedChainID)
+	slog.Info("executor config loaded", "executor_address", execCfg.ExecutorAddress, "expected_chain_id", execCfg.ExpectedChainID)
 
 	// ETH_RPC_URL is now required — the chain-ID check, bytecode check, and
 	// live balance polling all need a node connection.
 	rpcURL := os.Getenv("ETH_RPC_URL")
 	if rpcURL == "" {
-		log.Fatalf("FATAL: ETH_RPC_URL not set — required for chain-id / bytecode / balance checks")
+		slog.Error("ETH_RPC_URL not set — required for chain-id / bytecode / balance checks")
+		os.Exit(1)
 	}
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer dialCancel()
 	ethClient, err := ethclient.DialContext(dialCtx, rpcURL)
 	if err != nil {
-		log.Fatalf("FATAL: failed to connect to ETH_RPC_URL (%s): %v",
-			redactRPCURL(rpcURL), redactRPCError(err, rpcURL))
+		slog.Error("failed to connect to ETH_RPC_URL", "url", redactRPCURL(rpcURL), "err", redactRPCError(err, rpcURL))
+		os.Exit(1)
 	}
-	log.Printf("Connected to Ethereum node")
+	slog.Info("connected to ethereum node")
 
 	// Cross-check chain ID: the node must agree with the expected chain in
 	// executor.yaml. A mismatch here typically means someone pointed a
@@ -129,13 +132,14 @@ func main() {
 	defer chainCancel()
 	chainID, err := ethClient.ChainID(chainCtx)
 	if err != nil {
-		log.Fatalf("FATAL: eth_chainId failed: %v", redactRPCError(err, rpcURL))
+		slog.Error("eth_chainId failed", "err", redactRPCError(err, rpcURL))
+		os.Exit(1)
 	}
 	if chainID.Int64() != execCfg.ExpectedChainID {
-		log.Fatalf("FATAL: chain-id mismatch — node reports %d, config expects %d",
-			chainID.Int64(), execCfg.ExpectedChainID)
+		slog.Error("chain-id mismatch", "node_chain_id", chainID.Int64(), "config_chain_id", execCfg.ExpectedChainID)
+		os.Exit(1)
 	}
-	log.Printf("Chain ID verified: %d", chainID.Int64())
+	slog.Info("chain ID verified", "chain_id", chainID.Int64())
 
 	// Verify the configured executor contract actually exists on-chain. A
 	// zero-bytecode result means we'd be sending bundles to a non-contract.
@@ -143,23 +147,23 @@ func main() {
 	defer codeCancel()
 	code, err := ethClient.CodeAt(codeCtx, common.HexToAddress(execCfg.ExecutorAddress), nil)
 	if err != nil {
-		log.Fatalf("FATAL: eth_getCode(%s) failed: %v",
-			execCfg.ExecutorAddress, redactRPCError(err, rpcURL))
+		slog.Error("eth_getCode failed", "executor_address", execCfg.ExecutorAddress, "err", redactRPCError(err, rpcURL))
+		os.Exit(1)
 	}
 	if len(code) == 0 {
-		log.Fatalf("FATAL: executor address %s has no bytecode on chain %d",
-			execCfg.ExecutorAddress, chainID.Int64())
+		slog.Error("executor address has no bytecode on chain", "executor_address", execCfg.ExecutorAddress, "chain_id", chainID.Int64())
+		os.Exit(1)
 	}
-	log.Printf("Executor contract verified on-chain: %s (%d bytes of code)",
-		execCfg.ExecutorAddress, len(code))
+	slog.Info("executor contract verified on-chain", "executor_address", execCfg.ExecutorAddress, "code_bytes", len(code))
 
 	// Load searcher private key for transaction signing and bundle submission.
 	searcherKey := os.Getenv("SEARCHER_KEY")
 
-	// Create submitter BEFORE clearing the key — it needs the key for FlashbotsSigner.
+	// Create submitter BEFORE clearing the key - it needs the key for FlashbotsSigner.
 	submitter, err := NewSubmitter(cfg.BuilderConfigs, searcherKey)
 	if err != nil {
-		log.Fatalf("Failed to create submitter: %v", err)
+		slog.Error("failed to create submitter", "err", err)
+		os.Exit(1)
 	}
 
 	var txSigner *TransactionSigner
@@ -167,11 +171,12 @@ func main() {
 		var signerErr error
 		txSigner, signerErr = NewTransactionSigner(searcherKey, chainID.Int64())
 		if signerErr != nil {
-			log.Fatalf("Failed to load SEARCHER_KEY: %v", signerErr)
+			slog.Error("failed to load SEARCHER_KEY", "err", signerErr)
+			os.Exit(1)
 		}
-		log.Printf("Searcher address: %s", txSigner.Address().Hex())
+		slog.Info("searcher signer loaded", "addr", txSigner.Address().Hex())
 	} else {
-		log.Println("WARNING: SEARCHER_KEY not set — transactions will not be signed")
+		slog.Warn("SEARCHER_KEY not set, transactions will not be signed")
 	}
 
 	os.Unsetenv("SEARCHER_KEY")
@@ -185,16 +190,17 @@ func main() {
 	if txSigner != nil {
 		nonceManager.SetSyncSource(txSigner.Address(), ethClient)
 		if err := nonceManager.SyncFromChain(ctx); err != nil {
-			log.Printf("WARNING: failed to sync nonce for %s: %v", txSigner.Address().Hex(), err)
+			slog.Warn("failed to sync nonce", "addr", txSigner.Address().Hex(), "err", err)
 		}
 	} else {
-		log.Printf("WARNING: SEARCHER_KEY not set — nonce manager will use initial nonce 0")
+		slog.Warn("SEARCHER_KEY not set, nonce manager will use initial nonce 0")
 	}
 
 	gasOracle := NewGasOracle(cfg.MaxGasGwei)
 	gasOracle.SetClient(ethClient)
+	// Fetch real gas prices before first arb evaluation.
 	if _, err := gasOracle.FetchOnce(ctx); err != nil {
-		log.Printf("WARNING: initial gas oracle fetch failed: %v", err)
+		slog.Warn("initial gas oracle fetch failed", "err", err)
 	}
 	bundler := NewBundleConstructor(nonceManager, gasOracle, txSigner, chainID.Int64())
 	riskMgr := risk.NewRiskManager(loadRiskConfig())
@@ -234,8 +240,8 @@ func main() {
 	// and bytecode checks.
 	if txSigner != nil {
 		if err := fetchAndStoreBalance(ctx, ethClient, txSigner.Address(), liveBalance); err != nil {
-			log.Fatalf("FATAL: initial eth_getBalance(%s) failed: %v",
-				txSigner.Address().Hex(), redactRPCError(err, rpcURL))
+			slog.Error("initial eth_getBalance failed", "addr", txSigner.Address().Hex(), "err", redactRPCError(err, rpcURL))
+			os.Exit(1)
 		}
 		wg.Add(1)
 		go func() {
@@ -246,20 +252,19 @@ func main() {
 
 	startMetricsServer()
 
+	transport := "TCP"
 	if strings.HasPrefix(cfg.GRPCAddress, "unix:") {
-		log.Printf("Executor service started, gRPC target: %s (UDS)", cfg.GRPCAddress)
-	} else {
-		log.Printf("Executor service started, gRPC target: %s (TCP)", cfg.GRPCAddress)
+		transport = "UDS"
 	}
-	log.Printf("Configured %d builders", len(cfg.BuilderConfigs))
+	slog.Info("executor service started", "grpc_target", cfg.GRPCAddress, "transport", transport)
+	slog.Info("builders configured", "count", len(cfg.BuilderConfigs))
 
 	// Connect to Rust engine gRPC server.
 	// grpc.NewClient is lazy — the connection is established on first RPC,
 	// so this call returns immediately even if the Rust server is not running.
 	grpcClient, err := aethergrpc.Dial(cfg.GRPCAddress)
 	if err != nil {
-		log.Printf("WARNING: could not create gRPC client for %s: %v", cfg.GRPCAddress, err)
-		log.Printf("Executor will start without arb stream")
+		slog.Warn("could not create gRPC client, executor will start without arb stream", "addr", cfg.GRPCAddress, "err", err)
 	} else {
 		defer grpcClient.Close()
 
@@ -274,14 +279,14 @@ func main() {
 	// Wait for shutdown signal
 	select {
 	case sig := <-sigCh:
-		log.Printf("Received signal %v, shutting down...", sig)
+		slog.Info("received signal, shutting down", "signal", sig.String())
 		cancel()
 	case <-ctx.Done():
 	}
 
 	// Wait for goroutines
 	wg.Wait()
-	log.Println("Executor service stopped")
+	slog.Info("executor service stopped")
 }
 
 // processArb handles a single validated arb through the full pipeline:
@@ -308,7 +313,7 @@ func processArb(
 	result := rm.PreflightCheck(profitWei, tradeValueWei, gasGwei, tipSharePct, ethBalance)
 	if !result.Approved {
 		recordRiskRejection()
-		log.Printf("Arb %s rejected by preflight: %s", arb.Id, result.Reason)
+		slog.InfoContext(ctx, "arb rejected by preflight", "arb_id", arb.Id, "reason", result.Reason)
 		return false, nil
 	}
 
@@ -324,7 +329,7 @@ func processArb(
 	recordSubmissionReverts(rm, results)
 	successes := SuccessCount(results)
 
-	log.Printf("Arb %s: submitted to %d builders, %d accepted", arb.Id, len(results), successes)
+	slog.InfoContext(ctx, "arb submitted", "arb_id", arb.Id, "builders", len(results), "accepted", successes)
 
 	// Record result for miss rate tracking
 	included := successes > 0
@@ -399,7 +404,7 @@ func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *B
 
 		stream, err := client.StreamArbs(ctx, minProfitETH)
 		if err != nil {
-			log.Printf("StreamArbs connect error: %v, retrying in %v...", err, reconnectDelay)
+			slog.WarnContext(ctx, "StreamArbs connect error, will retry", "err", err, "retry_in", reconnectDelay.String())
 			select {
 			case <-ctx.Done():
 				return
@@ -408,25 +413,24 @@ func consumeArbStream(ctx context.Context, client *aethergrpc.Client, bundler *B
 			}
 		}
 
-		log.Println("Connected to Rust engine arb stream")
+		slog.InfoContext(ctx, "connected to rust engine arb stream")
 
 		for {
 			arb, err := stream.Recv()
 			if err != nil {
-				log.Printf("Arb stream recv error: %v, reconnecting...", err)
+				slog.WarnContext(ctx, "arb stream recv error, reconnecting", "err", err)
 				break
 			}
 			receivedAt := time.Now() // Go-side clock avoids cross-process skew
 
-			log.Printf("Received arb: id=%s hops=%d gas=%d block=%d",
-				arb.Id, len(arb.Hops), arb.TotalGas, arb.BlockNumber)
+			slog.InfoContext(ctx, "arb received", "arb_id", arb.Id, "hops", len(arb.Hops), "gas", arb.TotalGas, "block", arb.BlockNumber)
 
 			submitted, err := processArb(ctx, arb, receivedAt, rm, bundler, submitter, executorAddr, liveBalance.Get())
 			switch {
 			case err != nil:
-				log.Printf("Error processing arb %s: %v", arb.Id, err)
+				slog.ErrorContext(ctx, "error processing arb", "arb_id", arb.Id, "err", err)
 			case !submitted:
-				log.Printf("Skipped arb %s (risk-manager veto or below threshold)", arb.Id)
+				slog.InfoContext(ctx, "arb skipped", "arb_id", arb.Id, "reason", "risk-manager veto or below threshold")
 			}
 		}
 	}

--- a/cmd/executor/metrics.go
+++ b/cmd/executor/metrics.go
@@ -20,9 +20,10 @@ import (
 )
 
 // Naming convention:
-//   aether_executor_* — executor-process-specific counters (bundle ops, risk)
-//   aether_*          — system-level spec metrics shared across processes
-//                       (latency, gas price, PnL, ETH balance)
+//
+//	aether_executor_* — executor-process-specific counters (bundle ops, risk)
+//	aether_*          — system-level spec metrics shared across processes
+//	                    (latency, gas price, PnL, ETH balance)
 var (
 	bundlesSubmitted = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "aether_executor_bundles_submitted_total",

--- a/cmd/executor/nonce.go
+++ b/cmd/executor/nonce.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -52,7 +52,7 @@ func (nm *NonceManager) Sync(onChainNonce uint64) {
 	if onChainNonce > current {
 		nm.current.Store(onChainNonce)
 		nm.pending.Store(0)
-		log.Printf("Nonce synced: %d -> %d", current, onChainNonce)
+		slog.Info("nonce synced", "from", current, "to", onChainNonce)
 	}
 }
 
@@ -93,13 +93,12 @@ func (nm *NonceManager) SyncLoop(ctx context.Context, interval time.Duration) {
 			return
 		case <-ticker.C:
 			if nm.client == nil || nm.address == (common.Address{}) {
-				log.Printf("Nonce sync check: current=%d, pending=%d",
-					nm.Current(), nm.PendingCount())
+				slog.Debug("nonce sync check", "current", nm.Current(), "pending", nm.PendingCount())
 				continue
 			}
 
 			if err := nm.SyncFromChain(ctx); err != nil {
-				log.Printf("Nonce sync failed: %v", err)
+				slog.Error("nonce sync failed", "err", err)
 			}
 		}
 	}

--- a/cmd/executor/submitter.go
+++ b/cmd/executor/submitter.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -135,11 +135,15 @@ func (s *Submitter) SubmitToAll(ctx context.Context, bundle *Bundle) []Submissio
 	results := make([]SubmissionResult, 0, len(s.builders))
 	for result := range resultCh {
 		if result.Success {
-			log.Printf("Bundle accepted by %s (hash: %s, latency: %v)",
-				result.Builder, result.BundleHash, result.Latency)
+			slog.Info("bundle accepted by builder",
+				"builder", result.Builder,
+				"bundle_hash", result.BundleHash,
+				"latency", result.Latency)
 		} else {
-			log.Printf("Bundle rejected by %s: %v (latency: %v)",
-				result.Builder, result.Error, result.Latency)
+			slog.Warn("bundle rejected by builder",
+				"builder", result.Builder,
+				"err", result.Error,
+				"latency", result.Latency)
 		}
 		results = append(results, result)
 	}
@@ -278,8 +282,7 @@ func (s *Submitter) submitToBuilder(ctx context.Context, builder BuilderConfig, 
 	}
 	if rpcResp.Result != nil {
 		if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
-			log.Printf("warn: builder %s returned unparseable result (%v): %s",
-				builder.Name, err, string(rpcResp.Result))
+			slog.Warn("builder returned unparseable result", "builder", builder.Name, "err", err, "raw", string(rpcResp.Result))
 		}
 	}
 

--- a/cmd/monitor/alerter.go
+++ b/cmd/monitor/alerter.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"time"
 )
 
@@ -77,11 +77,26 @@ func (a *Alerter) dispatch(channel AlertChannel, alert Alert) {
 	// In production, this would call the actual API for each channel
 	switch channel {
 	case ChannelPagerDuty:
-		log.Printf("[PagerDuty] [%s] %s: %s", alert.Severity, alert.Title, alert.Message)
+		slog.Info("alert dispatched",
+			"channel", "pagerduty",
+			"severity", alert.Severity,
+			"title", alert.Title,
+			"message", alert.Message,
+		)
 	case ChannelTelegram:
-		log.Printf("[Telegram] [%s] %s: %s", alert.Severity, alert.Title, alert.Message)
+		slog.Info("alert dispatched",
+			"channel", "telegram",
+			"severity", alert.Severity,
+			"title", alert.Title,
+			"message", alert.Message,
+		)
 	case ChannelDiscord:
-		log.Printf("[Discord] [%s] %s: %s", alert.Severity, alert.Title, alert.Message)
+		slog.Info("alert dispatched",
+			"channel", "discord",
+			"severity", alert.Severity,
+			"title", alert.Title,
+			"message", alert.Message,
+		)
 	}
 }
 

--- a/cmd/monitor/dashboard.go
+++ b/cmd/monitor/dashboard.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -176,7 +176,7 @@ func (d *Dashboard) ServeDashboard(addr string) error {
 	mux.HandleFunc("/", d.handleDashboard)
 	mux.HandleFunc("/api/stats", d.handleStats)
 
-	log.Printf("Dashboard server listening on %s", addr)
+	slog.Info("dashboard server listening", "addr", addr)
 	return http.ListenAndServe(addr, mux)
 }
 

--- a/cmd/monitor/dashboard.go
+++ b/cmd/monitor/dashboard.go
@@ -219,16 +219,16 @@ func (d *Dashboard) handleDashboard(w http.ResponseWriter, r *http.Request) {
 func (d *Dashboard) handleStats(w http.ResponseWriter, r *http.Request) {
 	m := d.scrapeAll()
 	data := map[string]float64{
-		"blocks":           parseOrZero(m["aether_blocks_processed_total"]),
-		"cycles":           parseOrZero(m["aether_cycles_detected_total"]),
-		"simulations":      parseOrZero(m["aether_simulations_run_total"]),
-		"arbs_published":   parseOrZero(m["aether_arbs_published_total"]),
+		"blocks":            parseOrZero(m["aether_blocks_processed_total"]),
+		"cycles":            parseOrZero(m["aether_cycles_detected_total"]),
+		"simulations":       parseOrZero(m["aether_simulations_run_total"]),
+		"arbs_published":    parseOrZero(m["aether_arbs_published_total"]),
 		"bundles_submitted": parseOrZero(m["aether_executor_bundles_submitted_total"]),
-		"bundles_included": parseOrZero(m["aether_executor_bundles_included_total"]),
-		"risk_rejections":  parseOrZero(m["aether_executor_risk_rejections_total"]),
-		"daily_pnl_eth":    parseOrZero(m["aether_daily_pnl_eth"]),
-		"gas_price_gwei":   parseOrZero(m["aether_gas_price_gwei"]),
-		"eth_balance":      parseOrZero(m["aether_eth_balance"]),
+		"bundles_included":  parseOrZero(m["aether_executor_bundles_included_total"]),
+		"risk_rejections":   parseOrZero(m["aether_executor_risk_rejections_total"]),
+		"daily_pnl_eth":     parseOrZero(m["aether_daily_pnl_eth"]),
+		"gas_price_gwei":    parseOrZero(m["aether_gas_price_gwei"]),
+		"eth_balance":       parseOrZero(m["aether_eth_balance"]),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(data)

--- a/cmd/monitor/metrics.go
+++ b/cmd/monitor/metrics.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"sync"
@@ -42,7 +42,7 @@ func (m *Metrics) ServeMetrics(addr string) error {
 	mux.HandleFunc("/metrics", m.handleMetrics)
 	mux.HandleFunc("/health", m.handleHealth)
 
-	log.Printf("Metrics server listening on %s", addr)
+	slog.Info("metrics server listening", "addr", addr)
 	return http.ListenAndServe(addr, mux)
 }
 
@@ -96,6 +96,8 @@ func (m *Metrics) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	fmt.Println("aether-monitor: metrics, dashboard, and alerting service")
 
 	metricsPort := os.Getenv("METRICS_PORT")
@@ -114,20 +116,22 @@ func main() {
 	// Start metrics server
 	go func() {
 		if err := metrics.ServeMetrics(":" + metricsPort); err != nil {
-			log.Fatalf("Metrics server failed: %v", err)
+			slog.Error("metrics server failed", "err", err)
+			os.Exit(1)
 		}
 	}()
 
 	// Start dashboard
 	go func() {
 		if err := dashboard.ServeDashboard(":" + dashboardPort); err != nil {
-			log.Fatalf("Dashboard server failed: %v", err)
+			slog.Error("dashboard server failed", "err", err)
+			os.Exit(1)
 		}
 	}()
 
-	log.Println("Monitor service started")
-	log.Printf("Metrics: http://localhost:%s/metrics", metricsPort)
-	log.Printf("Dashboard: http://localhost:%s/", dashboardPort)
+	slog.Info("monitor service started")
+	slog.Info("metrics endpoint", "url", fmt.Sprintf("http://localhost:%s/metrics", metricsPort))
+	slog.Info("dashboard endpoint", "url", fmt.Sprintf("http://localhost:%s/", dashboardPort))
 
 	// Send startup alert
 	alerter.Send(SeverityInfo, "System Started", "Aether monitor service started")

--- a/cmd/pooldiscovery/main.go
+++ b/cmd/pooldiscovery/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -85,7 +85,7 @@ func NewPoolDiscoverer(rpcURL string, limit int) *PoolDiscoverer {
 // In production this would make real eth_call RPC requests to factory contracts.
 // Currently returns well-known high-liquidity pools for the configured protocols.
 func (pd *PoolDiscoverer) DiscoverPools() ([]PoolEntry, error) {
-	log.Printf("Discovering pools from %s (limit: %d)", pd.rpcURL, pd.limit)
+	slog.Info("discovering pools", "rpc_url", pd.rpcURL, "limit", pd.limit)
 
 	var allPools []PoolEntry
 
@@ -93,7 +93,7 @@ func (pd *PoolDiscoverer) DiscoverPools() ([]PoolEntry, error) {
 	for _, factory := range pd.factories {
 		pools, err := pd.discoverV2Pools(factory)
 		if err != nil {
-			log.Printf("Warning: failed to discover %s pools: %v", factory.Name, err)
+			slog.Warn("failed to discover pools", "factory", factory.Name, "err", err)
 			continue
 		}
 		allPools = append(allPools, pools...)
@@ -102,7 +102,7 @@ func (pd *PoolDiscoverer) DiscoverPools() ([]PoolEntry, error) {
 	// Discover UniswapV3 pools (different factory interface, multiple fee tiers)
 	v3Pools, err := pd.discoverV3Pools()
 	if err != nil {
-		log.Printf("Warning: failed to discover Uniswap V3 pools: %v", err)
+		slog.Warn("failed to discover pools", "factory", "Uniswap V3", "err", err)
 	} else {
 		allPools = append(allPools, v3Pools...)
 	}
@@ -115,7 +115,7 @@ func (pd *PoolDiscoverer) DiscoverPools() ([]PoolEntry, error) {
 		filtered = filtered[:pd.limit]
 	}
 
-	log.Printf("Discovered %d pools total, %d after filtering", len(allPools), len(filtered))
+	slog.Info("pool discovery complete", "total", len(allPools), "filtered", len(filtered))
 	return filtered, nil
 }
 
@@ -124,7 +124,7 @@ func (pd *PoolDiscoverer) DiscoverPools() ([]PoolEntry, error) {
 // then token0() and token1() on each pair contract.
 // Currently: returns well-known high-liquidity pairs for this protocol.
 func (pd *PoolDiscoverer) discoverV2Pools(factory FactoryConfig) ([]PoolEntry, error) {
-	log.Printf("Querying %s factory at %s", factory.Name, factory.Address)
+	slog.Info("querying factory", "factory", factory.Name, "addr", factory.Address)
 
 	// In production, this would be:
 	// 1. Call factory.allPairsLength() to get total count
@@ -142,7 +142,7 @@ func (pd *PoolDiscoverer) discoverV2Pools(factory FactoryConfig) ([]PoolEntry, e
 // getPool(token0, token1, fee) for known token pairs and fee tiers.
 // Currently: returns well-known V3 pools.
 func (pd *PoolDiscoverer) discoverV3Pools() ([]PoolEntry, error) {
-	log.Printf("Querying Uniswap V3 factory at %s", UniswapV3FactoryAddr)
+	slog.Info("querying factory", "factory", "Uniswap V3", "addr", UniswapV3FactoryAddr)
 
 	// V3 fee tiers: 100 (0.01%), 500 (0.05%), 3000 (0.30%), 10000 (1.00%)
 	// In production, this would query PoolCreated events or call getPool()
@@ -274,6 +274,8 @@ func FormatTOML(pools []PoolEntry) string {
 }
 
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	rpcURL := flag.String("rpc-url", "", "Ethereum JSON-RPC endpoint URL")
 	output := flag.String("output", "config/pools.toml", "Output file path for pools.toml")
 	limit := flag.Int("limit", 100, "Maximum number of pools to discover")
@@ -284,31 +286,31 @@ func main() {
 		*rpcURL = os.Getenv("ETH_RPC_URL")
 	}
 	if *rpcURL == "" {
-		log.Println("Warning: no --rpc-url or ETH_RPC_URL set, using simulated discovery")
+		slog.Warn("no --rpc-url or ETH_RPC_URL set, using simulated discovery")
 		*rpcURL = "simulated"
 	}
 
 	fmt.Println("aether-pooldiscovery: DEX pool discovery utility")
-	log.Printf("RPC URL: %s", *rpcURL)
-	log.Printf("Output: %s", *output)
-	log.Printf("Limit: %d", *limit)
+	slog.Info("pool discovery starting", "rpc_url", *rpcURL, "output", *output, "limit", *limit)
 
 	discoverer := NewPoolDiscoverer(*rpcURL, *limit)
 	pools, err := discoverer.DiscoverPools()
 	if err != nil {
-		log.Fatalf("Pool discovery failed: %v", err)
+		slog.Error("pool discovery failed", "err", err)
+		os.Exit(1)
 	}
 
 	if len(pools) == 0 {
-		log.Println("No pools discovered")
+		slog.Info("no pools discovered")
 		return
 	}
 
 	toml := FormatTOML(pools)
 
 	if err := os.WriteFile(*output, []byte(toml), 0644); err != nil {
-		log.Fatalf("Failed to write %s: %v", *output, err)
+		slog.Error("failed to write output file", "path", *output, "err", err)
+		os.Exit(1)
 	}
 
-	log.Printf("Wrote %d pools to %s", len(pools), *output)
+	slog.Info("wrote pools", "count", len(pools), "path", *output)
 }

--- a/cmd/pooldiscovery/main_test.go
+++ b/cmd/pooldiscovery/main_test.go
@@ -138,9 +138,9 @@ func TestContainsTargetToken(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		addr  string
-		want  bool
+		name string
+		addr string
+		want bool
 	}{
 		{"WETH", WETH, true},
 		{"USDC", USDC, true},

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -32,11 +32,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize structured logging with tracing.
     // Respects RUST_LOG env var; defaults to `info` level.
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
+    // LOG_FORMAT=json switches to a JSON layer for log aggregation (Loki);
+    // any other value keeps the human-readable pretty output for `cargo run`.
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    match std::env::var("LOG_FORMAT").as_deref() {
+        Ok("json") => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_current_span(true)
+                .with_span_list(false)
+                .with_env_filter(env_filter)
+                .init();
+        }
+        _ => {
+            tracing_subscriber::fmt().with_env_filter(env_filter).init();
+        }
+    }
 
     info!("Starting Aether gRPC server");
 

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok("json") => {
             tracing_subscriber::fmt()
                 .json()
+                .flatten_event(true)
                 .with_current_span(true)
                 .with_span_list(false)
                 .with_env_filter(env_filter)

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - reth-ipc:/tmp
     environment:
       - RUST_LOG=info
+      - LOG_FORMAT=json
       - AETHER_CONFIG_DIR=/app/config
       - GRPC_ADDRESS=0.0.0.0:50051
       - ETH_RPC_URL=${ETH_RPC_URL:-}
@@ -103,7 +104,32 @@ services:
     networks:
       - aether-net
 
-  # Loki: deferred — logs available via `docker logs`, Loki planned for production deployment
+  loki:
+    image: grafana/loki:2.9.4
+    container_name: aether-loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    restart: unless-stopped
+    networks:
+      - aether-net
+
+  promtail:
+    image: grafana/promtail:2.9.4
+    container_name: aether-promtail
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail-data:/var/lib/promtail
+    depends_on:
+      - loki
+    restart: unless-stopped
+    networks:
+      - aether-net
 
   # Local Ethereum node (opt-in). Start with: docker compose --profile node up -d
   # Shares /tmp/reth via volume so aether-rust can connect over IPC (/tmp/reth.ipc)
@@ -127,6 +153,8 @@ services:
 volumes:
   grafana-data:
   alertmanager-data:
+  loki-data:
+  promtail-data:
   reth-data:
   reth-ipc:
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -113,6 +113,11 @@ services:
     volumes:
       - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
       - loki-data:/loki
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/ready | grep -q ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
     restart: unless-stopped
     networks:
       - aether-net
@@ -126,7 +131,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - promtail-data:/var/lib/promtail
     depends_on:
-      - loki
+      loki:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - aether-net

--- a/deploy/docker/grafana/dashboards/overview.json
+++ b/deploy/docker/grafana/dashboards/overview.json
@@ -170,6 +170,31 @@
       ],
       "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
       "options": { "legend": { "showLegend": true } }
+    },
+    {
+      "id": 8,
+      "type": "logs",
+      "title": "Recent errors",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 21 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service=~\"aether-.*\"} | json | level=~\"(?i)(error|warn)\"",
+          "maxLines": 200
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
     }
   ]
 }

--- a/deploy/docker/grafana/provisioning/datasources/loki.yml
+++ b/deploy/docker/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true
+    jsonData:
+      maxLines: 1000

--- a/deploy/docker/loki/loki-config.yml
+++ b/deploy/docker/loki/loki-config.yml
@@ -1,0 +1,48 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_query_length: 721h
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem
+
+ruler:
+  alertmanager_url: http://alertmanager:9093
+
+analytics:
+  reporting_enabled: false

--- a/deploy/docker/loki/loki-config.yml
+++ b/deploy/docker/loki/loki-config.yml
@@ -33,6 +33,9 @@ limits_config:
   reject_old_samples_max_age: 168h
   max_query_length: 721h
   allow_structured_metadata: true
+  max_streams_per_user: 500
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
 
 compactor:
   working_directory: /loki/compactor

--- a/deploy/docker/promtail/promtail-config.yml
+++ b/deploy/docker/promtail/promtail-config.yml
@@ -1,0 +1,27 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 15s
+        filters:
+          - name: label
+            values: ["com.docker.compose.project"]
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: container_name
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        target_label: compose_project

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -673,4 +673,3 @@ func TestLoadExecutorConfig_RejectsUnknownKey(t *testing.T) {
 		t.Errorf("error %q does not name the offending key", err.Error())
 	}
 }
-

--- a/internal/risk/manager.go
+++ b/internal/risk/manager.go
@@ -2,7 +2,7 @@ package risk
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -146,7 +146,7 @@ func (rm *RiskManager) SetMetricsObserver(obs MetricsObserver) {
 // notifyTrip transitions state and notifies the observer. Caller holds rm.mu.
 func (rm *RiskManager) notifyTrip(reason string, newState SystemState) {
 	if err := rm.state.Transition(newState); err != nil {
-		log.Printf("CIRCUIT BREAKER: transition to %s failed: %v", newState, err)
+		slog.Error("circuit breaker transition failed", "new_state", newState, "err", err)
 		return
 	}
 	if rm.metricsObs != nil {
@@ -206,8 +206,13 @@ func (rm *RiskManager) CalculateTipShare(profitWei *big.Int, gasGwei float64) fl
 
 	tipShare = clampTip(tipShare, rm.config.MinTipSharePct, rm.config.MaxTipSharePct)
 	if tipShare != rm.lastTipSharePct {
-		log.Printf("TIP STRATEGY: tip share adjusted %.1f%% -> %.1f%% (inclusion %.1f%%, miss %.1f%%, gas %.1f gwei)",
-			rm.lastTipSharePct, tipShare, inclusionRate, missRate, gasGwei)
+		slog.Info("tip strategy adjusted",
+			"from_pct", rm.lastTipSharePct,
+			"to_pct", tipShare,
+			"inclusion_pct", inclusionRate,
+			"miss_pct", missRate,
+			"gas_gwei", gasGwei,
+		)
 	}
 
 	rm.lastAdjustedAtIdx = rm.bundleResultIdx
@@ -310,8 +315,10 @@ func (rm *RiskManager) RecordRevert(revertType RevertType) {
 
 	// --- Bug-revert circuit breaker ---
 	if len(rm.recentBugReverts) >= rm.config.ConsecutiveRevertsPause {
-		log.Printf("CIRCUIT BREAKER: %d bug reverts in %d minutes, pausing",
-			len(rm.recentBugReverts), rm.config.RevertWindowMinutes)
+		slog.Error("circuit breaker: consecutive bug reverts, pausing",
+			"count", len(rm.recentBugReverts),
+			"window_min", rm.config.RevertWindowMinutes,
+		)
 		rm.notifyTrip("consecutive_bug_reverts", StatePaused)
 	}
 
@@ -321,8 +328,11 @@ func (rm *RiskManager) RecordRevert(revertType RevertType) {
 	if totalReverts > 0 && now.Sub(rm.lastCompAlertTime) >= window {
 		compPct := float64(len(rm.recentCompReverts)) / float64(totalReverts) * 100
 		if compPct >= rm.config.CompetitiveRevertAlertPct {
-			log.Printf("ALERT: competitive revert rate %.0f%% (>= %.0f%%) in last %d min — possible stale data",
-				compPct, rm.config.CompetitiveRevertAlertPct, rm.config.RevertWindowMinutes)
+			slog.Warn("high competitive revert rate, possible stale data",
+				"comp_pct", compPct,
+				"threshold_pct", rm.config.CompetitiveRevertAlertPct,
+				"window_min", rm.config.RevertWindowMinutes,
+			)
 			rm.lastCompAlertTime = now
 		}
 	}
@@ -340,8 +350,10 @@ func (rm *RiskManager) RecordTrade(volumeWei *big.Int, pnlWei *big.Int) {
 	// Check daily loss halt
 	lossETH := WeiToETH(new(big.Int).Neg(rm.dailyPnL))
 	if lossETH > rm.config.DailyLossHaltETH {
-		log.Printf("CIRCUIT BREAKER: daily loss %.4f ETH exceeds threshold %.4f ETH, halting",
-			lossETH, rm.config.DailyLossHaltETH)
+		slog.Error("circuit breaker: daily loss threshold exceeded, halting",
+			"loss_eth", lossETH,
+			"threshold_eth", rm.config.DailyLossHaltETH,
+		)
 		rm.notifyTrip("daily_loss_exceeded", StateHalted)
 	}
 }
@@ -387,7 +399,7 @@ func (rm *RiskManager) maybeResetDaily() {
 		rm.dailyVolume = big.NewInt(0)
 		rm.dailyPnL = big.NewInt(0)
 		rm.dailyResetTime = time.Now().Truncate(24 * time.Hour).Add(24 * time.Hour)
-		log.Println("Daily counters reset")
+		slog.Info("daily counters reset")
 	}
 }
 

--- a/internal/risk/manager.go
+++ b/internal/risk/manager.go
@@ -106,20 +106,20 @@ type MetricsObserver interface {
 
 // RiskManager implements circuit breakers and position limits.
 type RiskManager struct {
-	mu                  sync.RWMutex
-	config              RiskConfig
-	state               *SystemStateMachine
-	tipStrategy         TipStrategy
-	lastTipSharePct     float64
-	recentBugReverts    []time.Time // Only these count toward circuit breaker
-	recentCompReverts   []time.Time // Tracked separately for metrics / stale-data alert
-	dailyVolume         *big.Int    // Wei
-	dailyPnL            *big.Int    // Wei (can be negative)
-	dailyResetTime      time.Time
-	bundleResults      []bool // Sliding window ring buffer
-	bundleResultIdx    int    // Next write position; always increments (never resets)
-	bundleResultCount  int    // Entries filled (capped at window size)
-	lastAdjustedAtIdx  int    // Gate: bundleResultIdx value at last tip adjustment
+	mu                sync.RWMutex
+	config            RiskConfig
+	state             *SystemStateMachine
+	tipStrategy       TipStrategy
+	lastTipSharePct   float64
+	recentBugReverts  []time.Time // Only these count toward circuit breaker
+	recentCompReverts []time.Time // Tracked separately for metrics / stale-data alert
+	dailyVolume       *big.Int    // Wei
+	dailyPnL          *big.Int    // Wei (can be negative)
+	dailyResetTime    time.Time
+	bundleResults     []bool // Sliding window ring buffer
+	bundleResultIdx   int    // Next write position; always increments (never resets)
+	bundleResultCount int    // Entries filled (capped at window size)
+	lastAdjustedAtIdx int    // Gate: bundleResultIdx value at last tip adjustment
 
 	// Prometheus-style counters (read via atomic; no external dependency).
 	BugRevertTotal  atomic.Int64

--- a/internal/risk/manager_test.go
+++ b/internal/risk/manager_test.go
@@ -301,7 +301,7 @@ func TestRecordRevert_CompetitiveRateAlert(t *testing.T) {
 
 	// Set a low alert threshold to make it easy to trigger.
 	config := DefaultRiskConfig()
-	config.ConsecutiveRevertsPause = 100 // effectively disable CB for this test
+	config.ConsecutiveRevertsPause = 100  // effectively disable CB for this test
 	config.CompetitiveRevertAlertPct = 80 // alert at 80%+
 	rm := NewRiskManager(config)
 

--- a/internal/risk/state.go
+++ b/internal/risk/state.go
@@ -2,7 +2,7 @@ package risk
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 )
 
@@ -46,7 +46,7 @@ func (sm *SystemStateMachine) Transition(newState SystemState) error {
 	}
 
 	sm.state = newState
-	log.Printf("System state: %s -> %s", oldState, newState)
+	slog.Info("system state transition", "from", string(oldState), "to", string(newState))
 	return nil
 }
 
@@ -54,7 +54,7 @@ func (sm *SystemStateMachine) Transition(newState SystemState) error {
 func (sm *SystemStateMachine) ForceState(newState SystemState) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	log.Printf("System state forced: %s -> %s", sm.state, newState)
+	slog.Warn("system state forced", "from", string(sm.state), "to", string(newState))
 	sm.state = newState
 }
 


### PR DESCRIPTION
## Summary

PR2 of the observability series for issue #69 (WS-7.5). Stacked on top of #83. Adds self-hosted log aggregation so we can answer \"why did it revert?\" without ssh'ing in, and swaps Rust and Go logging to structured JSON at the entry points Promtail sees.

## What's in

- **Loki + Promtail** services in `deploy/docker/docker-compose.yml`, both self-hosted on `aether-net`. Loki runs single-binary with filesystem storage and 168h retention; Promtail scrapes the Docker socket and attaches `service` + `container_name` labels.
- **Grafana Loki datasource** provisioned alongside Prometheus, pinned UID `loki` so dashboards can reference it stably.
- **Rust `tracing-subscriber` JSON layer** gated by `LOG_FORMAT=json` (set on the `aether-rust` container). Unset / any other value keeps the existing pretty output for local `cargo run`.
- **Go `log/slog` JSON handler** installed as the default logger in each binary entry (`cmd/executor`, `cmd/monitor`, `cmd/pooldiscovery`). `log.Printf` call sites at the module boundaries are converted to `slog.Info`/`Warn`/`Error` with structured key/value fields. `internal/risk/manager.go` boundary logs go through `slog` too (using the default logger). Deeper utility loggers in `gas_oracle.go`, `nonce.go`, `submitter.go`, `bundle.go`, `state.go` are intentionally left as stdlib `log` for now to keep the diff scoped.
- **Recent errors panel** appended to the Overview dashboard, querying `{service=~\"aether-.*\"} | json | level=~\"(?i)(error|warn)\"` with a 200-line cap, newest first.

## What's out (stacked PR3 — WS-7.6 / WS-7.7)

- OpenTelemetry tracing to Tempo
- `scripts/canary.py`

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/executor/... ./internal/risk/... ./cmd/monitor/... ./cmd/pooldiscovery/...` green
- [x] `cargo check -p aether-grpc-server` clean
- [x] `cargo test -p aether-grpc-server --lib` green
- [x] `docker-compose.yml`, `loki-config.yml`, `promtail-config.yml`, `loki.yml`, `overview.json` all parse as valid YAML/JSON
- [ ] Bring the stack up (`docker compose -f deploy/docker/docker-compose.yml up -d`), confirm `curl http://localhost:3100/ready` returns `ready`, confirm Grafana shows both datasources healthy and the Overview dashboard renders the new panel.
- [ ] Synthesize an error in the Go executor and confirm it shows up in the Recent Errors panel within one scrape interval.

## Notes

- Targeting `feat/observability-pr1` (PR #83). Once that merges, GitHub will rebase this onto `main` automatically.
- The `SLACK_WEBHOOK_URL` env substitution for Alertmanager introduced in PR1 is left untouched; no new secrets are required for PR2.