### PR TITLE
feat(grpc-server): surface decoder drops via warn log + counter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,7 @@ aether/
 | `aether_gas_price_gwei` | Gauge | >300 → halt |
 | `aether_daily_pnl_eth` | Gauge | <-0.5 ETH → halt |
 | `aether_eth_balance` | Gauge | <0.1 ETH → halt |
+| `aether_decode_errors_total` | Counter | sustained >10/min → warn (ABI drift or malformed event floods) |
 
 ---
 

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -25,8 +25,9 @@ use aether_state::snapshot::SnapshotManager;
 use aether_state::token_index::TokenIndex;
 
 // Import the proto ValidatedArb type from service module
+use aether_grpc_server::EngineMetrics;
+
 use crate::pipeline;
-use crate::metrics::EngineMetrics;
 use crate::service::aether_proto::ValidatedArb as ProtoValidatedArb;
 
 /// Configuration for the AetherEngine.

--- a/crates/grpc-server/src/lib.rs
+++ b/crates/grpc-server/src/lib.rs
@@ -2,6 +2,10 @@
 ///
 /// Re-exports the `provider` module so that integration tests and other
 /// crates can access `ProviderConfig`, `RpcProvider`, and related types
-/// without depending on the binary entry point.
-pub mod metrics;
+/// without depending on the binary entry point. The `metrics` module is
+/// crate-private; only the two types the binary and integration tests
+/// actually need are re-exported publicly.
+pub(crate) mod metrics;
 pub mod provider;
+
+pub use metrics::{start_metrics_server, EngineMetrics};

--- a/crates/grpc-server/src/lib.rs
+++ b/crates/grpc-server/src/lib.rs
@@ -3,4 +3,5 @@
 /// Re-exports the `provider` module so that integration tests and other
 /// crates can access `ProviderConfig`, `RpcProvider`, and related types
 /// without depending on the binary entry point.
+pub mod metrics;
 pub mod provider;

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -13,9 +13,10 @@ use tokio::net::UnixListener;
 use tokio_stream::wrappers::UnixListenerStream;
 
 mod engine;
-mod metrics;
 mod pipeline;
 mod service;
+
+use aether_grpc_server::metrics;
 
 use aether_grpc_server::provider::{ProviderConfig, RpcProvider};
 use engine::{AetherEngine, EngineConfig};
@@ -92,10 +93,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if provider_config.nodes_config_path.is_some() {
         info!("AETHER_NODES_CONFIG set — provider will use multi-node pool");
     }
-    let provider = Arc::new(RpcProvider::new(
-        provider_config,
-        Arc::clone(engine.event_channels()),
-    ));
+    let provider = Arc::new(
+        RpcProvider::new(provider_config, Arc::clone(engine.event_channels()))
+            .with_metrics(Arc::clone(&metrics)),
+    );
 
     // Shutdown coordination via watch channel.
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -16,11 +16,9 @@ mod engine;
 mod pipeline;
 mod service;
 
-use aether_grpc_server::metrics;
-
 use aether_grpc_server::provider::{ProviderConfig, RpcProvider};
+use aether_grpc_server::{start_metrics_server, EngineMetrics};
 use engine::{AetherEngine, EngineConfig};
-use metrics::{start_metrics_server, EngineMetrics};
 use service::aether_proto::arb_service_server::ArbServiceServer;
 use service::aether_proto::control_service_server::ControlServiceServer;
 use service::aether_proto::health_service_server::HealthServiceServer;
@@ -93,10 +91,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if provider_config.nodes_config_path.is_some() {
         info!("AETHER_NODES_CONFIG set — provider will use multi-node pool");
     }
-    let provider = Arc::new(
-        RpcProvider::new(provider_config, Arc::clone(engine.event_channels()))
-            .with_metrics(Arc::clone(&metrics)),
-    );
+    let provider = Arc::new(RpcProvider::new(
+        provider_config,
+        Arc::clone(engine.event_channels()),
+        Arc::clone(&metrics),
+    ));
 
     // Shutdown coordination via watch channel.
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -145,6 +145,12 @@ impl EngineMetrics {
     }
 }
 
+impl Default for EngineMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub fn start_metrics_server(metrics: Arc<EngineMetrics>) {
     let addr = metrics_addr();
 

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -134,7 +134,10 @@ impl EngineMetrics {
         self.decode_errors.inc();
     }
 
-    fn render(&self) -> Vec<u8> {
+    /// Render the registered metrics in Prometheus text exposition format.
+    /// `pub(crate)` so sibling modules (`provider::tests`) can assert on
+    /// rendered counter values without exposing the whole registry.
+    pub(crate) fn render(&self) -> Vec<u8> {
         let metric_families = self.registry.gather();
         let encoder = TextEncoder::new();
         let mut buffer = Vec::new();
@@ -269,5 +272,6 @@ mod tests {
         assert!(output.contains("aether_simulations_run_total 3"));
         assert!(output.contains("aether_arbs_published_total 4"));
         assert!(output.contains("aether_blocks_processed_total 1"));
+        assert!(output.contains("aether_decode_errors_total 1"));
     }
 }

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -15,6 +15,7 @@ pub struct EngineMetrics {
     simulations_run: IntCounter,
     arbs_published: IntCounter,
     blocks_processed: IntCounter,
+    decode_errors: IntCounter,
 }
 
 impl EngineMetrics {
@@ -57,6 +58,11 @@ impl EngineMetrics {
             "Total blocks processed",
         )
         .expect("aether_blocks_processed_total counter");
+        let decode_errors = IntCounter::new(
+            "aether_decode_errors_total",
+            "Total logs the event decoder could not parse",
+        )
+        .expect("aether_decode_errors_total counter");
 
         registry
             .register(Box::new(detection_latency_ms.clone()))
@@ -76,6 +82,9 @@ impl EngineMetrics {
         registry
             .register(Box::new(blocks_processed.clone()))
             .expect("register aether_blocks_processed_total");
+        registry
+            .register(Box::new(decode_errors.clone()))
+            .expect("register aether_decode_errors_total");
 
         Self {
             registry,
@@ -85,6 +94,7 @@ impl EngineMetrics {
             simulations_run,
             arbs_published,
             blocks_processed,
+            decode_errors,
         }
     }
 
@@ -118,6 +128,10 @@ impl EngineMetrics {
 
     pub fn inc_blocks_processed(&self) {
         self.blocks_processed.inc();
+    }
+
+    pub fn inc_decode_errors(&self) {
+        self.decode_errors.inc();
     }
 
     fn render(&self) -> Vec<u8> {
@@ -224,6 +238,7 @@ mod tests {
         metrics.inc_simulations_run(3);
         metrics.inc_arbs_published(4);
         metrics.inc_blocks_processed();
+        metrics.inc_decode_errors();
 
         let output = String::from_utf8(metrics.render()).expect("metrics output utf-8");
 
@@ -234,6 +249,7 @@ mod tests {
             "aether_simulations_run_total",
             "aether_arbs_published_total",
             "aether_blocks_processed_total",
+            "aether_decode_errors_total",
         ] {
             assert!(output.contains(name), "missing metric {name}");
         }

--- a/crates/grpc-server/src/provider.rs
+++ b/crates/grpc-server/src/provider.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use alloy::primitives::{Address, B256};
 use alloy::providers::{Provider, ProviderBuilder};
@@ -14,6 +14,8 @@ use aether_ingestion::event_decoder;
 use aether_ingestion::event_decoder::EventSignatures;
 use aether_ingestion::node_pool::{NodeConfig, NodeConnection, NodePool, NodeType};
 use aether_ingestion::subscription::{EventChannels, NewBlockEvent};
+
+use crate::metrics::EngineMetrics;
 
 /// Configuration for the RPC provider connection
 #[derive(Debug, Clone)]
@@ -66,16 +68,27 @@ pub struct RpcProvider {
     config: ProviderConfig,
     event_channels: Arc<EventChannels>,
     node_pool: NodePool,
-    metrics: Option<Arc<crate::metrics::EngineMetrics>>,
+    metrics: Arc<EngineMetrics>,
 }
 
 impl RpcProvider {
     /// Create a new `RpcProvider`.
     ///
-    /// If `config.nodes_config_path` is set, loads the multi-node pool from
-    /// the YAML config file. Otherwise, creates a single-node pool from
-    /// `config.rpc_url` with the transport type inferred from the URL scheme.
-    pub fn new(config: ProviderConfig, event_channels: Arc<EventChannels>) -> Self {
+    /// `metrics` is required at construction so the decode-failure counter
+    /// is always wired up — forgetting to attach it would ship a dead
+    /// counter that pegs at zero forever (indistinguishable from "no
+    /// decode failures are happening") rather than surfacing as a missing
+    /// time series that alerts can match on.
+    ///
+    /// If `config.nodes_config_path` is set, loads the multi-node pool
+    /// from the YAML config file. Otherwise, creates a single-node pool
+    /// from `config.rpc_url` with the transport type inferred from the
+    /// URL scheme.
+    pub fn new(
+        config: ProviderConfig,
+        event_channels: Arc<EventChannels>,
+        metrics: Arc<EngineMetrics>,
+    ) -> Self {
         let node_pool = match &config.nodes_config_path {
             Some(path) => match load_nodes_config(path) {
                 Ok((configs, min_healthy)) => {
@@ -103,16 +116,8 @@ impl RpcProvider {
             config,
             event_channels,
             node_pool,
-            metrics: None,
+            metrics,
         }
-    }
-
-    /// Attach the engine-wide metrics handle so decode failures and other
-    /// provider-side events can be counted. Optional: when unset (e.g. in
-    /// tests), failures are still logged but not counted.
-    pub fn with_metrics(mut self, metrics: Arc<crate::metrics::EngineMetrics>) -> Self {
-        self.metrics = Some(metrics);
-        self
     }
 
     /// Build a single-node `NodePool` from a URL, inferring the transport type.
@@ -470,17 +475,24 @@ impl RpcProvider {
         }
     }
 
-    /// Surface a decoder drop to operators. Bumps the `aether_decode_errors_total`
-    /// counter (if metrics are attached) and logs the offending pool address and
-    /// first topic. Called from the hot path, so it must be cheap — the counter
-    /// is a single atomic increment and the `warn!` emits no allocations when
-    /// disabled at runtime.
+    /// Surface a decoder drop to operators. Bumps `aether_decode_errors_total`
+    /// (the primary ops signal — it's a monotonic counter wired to alerting)
+    /// and emits a `trace!` with the offending pool address and first topic
+    /// for triage.
+    ///
+    /// The per-event log is deliberately `trace!`, not `warn!`: in discovery
+    /// mode (`monitored_pools = []`) every unmatched log on mainnet — tens
+    /// of thousands per block — lands here, and a `warn!` would swamp Loki.
+    /// Operators should watch the counter; the trace line exists only for
+    /// targeted debugging when someone actively raises `RUST_LOG`.
+    ///
+    /// Called from the hot path, so it must be cheap — the counter is a
+    /// single atomic increment and `trace!` is compiled to a tiny level
+    /// check at the disabled level.
     fn record_decode_failure(&self, address: Address, topics: &[B256]) {
-        if let Some(metrics) = self.metrics.as_ref() {
-            metrics.inc_decode_errors();
-        }
+        self.metrics.inc_decode_errors();
         let topic0 = topics.first().copied().unwrap_or_default();
-        warn!(
+        trace!(
             pool = %address,
             %topic0,
             "Event decoder returned None; log skipped"
@@ -511,6 +523,13 @@ mod tests {
     use super::*;
     use alloy::primitives::U256;
 
+    /// Fresh metrics handle for tests that don't care about counter values —
+    /// keeps every `RpcProvider::new` call site short and avoids a global
+    /// registry (`EngineMetrics::new()` builds an independent one).
+    fn test_metrics() -> Arc<EngineMetrics> {
+        Arc::new(EngineMetrics::new())
+    }
+
     #[test]
     fn test_provider_config_default() {
         let config = ProviderConfig {
@@ -537,7 +556,7 @@ mod tests {
             rpc_url: "ws://localhost:8546".to_string(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, channels);
+        let provider = RpcProvider::new(config, channels, test_metrics());
         assert_eq!(provider.rpc_url(), "ws://localhost:8546");
         assert!(provider.is_configured());
     }
@@ -549,7 +568,7 @@ mod tests {
             rpc_url: String::new(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, channels);
+        let provider = RpcProvider::new(config, channels, test_metrics());
         assert!(!provider.is_configured());
     }
 
@@ -562,7 +581,7 @@ mod tests {
             rpc_url: "http://localhost:8545".to_string(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, Arc::clone(&channels));
+        let provider = RpcProvider::new(config, Arc::clone(&channels), test_metrics());
 
         provider.dispatch_block(18_000_000, 1_700_000_000, 30_000_000_000, 30_000_000);
 
@@ -582,7 +601,7 @@ mod tests {
             rpc_url: "http://localhost:8545".to_string(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, Arc::clone(&channels));
+        let provider = RpcProvider::new(config, Arc::clone(&channels), test_metrics());
 
         let pool_addr = Address::repeat_byte(0xAA);
         let topics = vec![EventSignatures::sync_topic()];
@@ -613,12 +632,55 @@ mod tests {
             rpc_url: "http://localhost:8545".to_string(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, Arc::clone(&channels));
+        let provider = RpcProvider::new(config, Arc::clone(&channels), test_metrics());
 
         let unknown_topic = B256::repeat_byte(0xFF);
         provider.process_logs(&[(Address::ZERO, vec![unknown_topic], vec![0u8; 64])]);
 
         assert!(rx.try_recv().is_err());
+    }
+
+    /// End-to-end check that a dropped log actually moves the
+    /// `aether_decode_errors_total` counter. The unit test in `metrics.rs`
+    /// only exercises `inc_decode_errors()` directly; this one proves the
+    /// real call path through `process_logs → record_decode_failure →
+    /// metrics.inc_decode_errors` is wired correctly end-to-end.
+    #[test]
+    fn test_process_logs_decode_failure_increments_counter() {
+        let channels = Arc::new(EventChannels::new());
+        let metrics = Arc::new(EngineMetrics::new());
+
+        let config = ProviderConfig {
+            rpc_url: "http://localhost:8545".to_string(),
+            ..ProviderConfig::default()
+        };
+        let provider = RpcProvider::new(config, channels, Arc::clone(&metrics));
+
+        // Unknown topic0 → decode_log returns None → counter bumps by 1.
+        let unknown_topic = B256::repeat_byte(0xFF);
+        provider.process_logs(&[(
+            Address::ZERO,
+            vec![unknown_topic],
+            vec![0u8; 64],
+        )]);
+
+        let rendered = String::from_utf8(metrics.render()).expect("metrics utf-8");
+        assert!(
+            rendered.contains("aether_decode_errors_total 1"),
+            "expected counter at 1, got: {rendered}"
+        );
+
+        // Second drop should advance the counter, not reset it.
+        provider.process_logs(&[(
+            Address::ZERO,
+            vec![unknown_topic],
+            vec![0u8; 64],
+        )]);
+        let rendered = String::from_utf8(metrics.render()).expect("metrics utf-8");
+        assert!(
+            rendered.contains("aether_decode_errors_total 2"),
+            "expected counter at 2 after second drop, got: {rendered}"
+        );
     }
 
     #[tokio::test]
@@ -630,7 +692,7 @@ mod tests {
             reconnect_delay: Duration::from_millis(200),
             ..ProviderConfig::default()
         };
-        let provider = Arc::new(RpcProvider::new(config, channels));
+        let provider = Arc::new(RpcProvider::new(config, channels, test_metrics()));
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -657,7 +719,7 @@ mod tests {
             rpc_url: "http://localhost:8545".to_string(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, Arc::clone(&channels));
+        let provider = RpcProvider::new(config, Arc::clone(&channels), test_metrics());
 
         let pool1 = Address::repeat_byte(0x01);
         let pool2 = Address::repeat_byte(0x02);
@@ -767,7 +829,7 @@ min_healthy_nodes: 1
             nodes_config_path: Some(path.to_str().expect("valid path").to_string()),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, channels);
+        let provider = RpcProvider::new(config, channels, test_metrics());
 
         assert_eq!(provider.node_pool().all_nodes().len(), 3);
 
@@ -787,7 +849,7 @@ min_healthy_nodes: 1
             nodes_config_path: Some("/nonexistent/path/nodes.yaml".to_string()),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, channels);
+        let provider = RpcProvider::new(config, channels, test_metrics());
         assert_eq!(provider.node_pool().all_nodes().len(), 1);
     }
 
@@ -798,7 +860,7 @@ min_healthy_nodes: 1
             rpc_url: "http://localhost:8545".to_string(),
             ..ProviderConfig::default()
         };
-        let provider = RpcProvider::new(config, channels);
+        let provider = RpcProvider::new(config, channels, test_metrics());
 
         let topics = provider.event_topics();
         assert_eq!(topics.len(), 5);

--- a/crates/grpc-server/src/provider.rs
+++ b/crates/grpc-server/src/provider.rs
@@ -66,6 +66,7 @@ pub struct RpcProvider {
     config: ProviderConfig,
     event_channels: Arc<EventChannels>,
     node_pool: NodePool,
+    metrics: Option<Arc<crate::metrics::EngineMetrics>>,
 }
 
 impl RpcProvider {
@@ -102,7 +103,16 @@ impl RpcProvider {
             config,
             event_channels,
             node_pool,
+            metrics: None,
         }
+    }
+
+    /// Attach the engine-wide metrics handle so decode failures and other
+    /// provider-side events can be counted. Optional: when unset (e.g. in
+    /// tests), failures are still logged but not counted.
+    pub fn with_metrics(mut self, metrics: Arc<crate::metrics::EngineMetrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 
     /// Build a single-node `NodePool` from a URL, inferring the transport type.
@@ -434,8 +444,9 @@ impl RpcProvider {
         let address = log.address();
         let topics = log.topics();
         let data = &log.data().data;
-        if let Some(event) = event_decoder::decode_log(topics, data, address, None) {
-            self.event_channels.dispatch_pool_update(event);
+        match event_decoder::decode_log(topics, data, address, None) {
+            Some(event) => self.event_channels.dispatch_pool_update(event),
+            None => self.record_decode_failure(address, topics),
         }
     }
 
@@ -452,10 +463,28 @@ impl RpcProvider {
     /// Process raw logs from a block and dispatch decoded pool events.
     pub fn process_logs(&self, logs: &[(Address, Vec<B256>, Vec<u8>)]) {
         for (address, topics, data) in logs {
-            if let Some(event) = event_decoder::decode_log(topics, data, *address, None) {
-                self.event_channels.dispatch_pool_update(event);
+            match event_decoder::decode_log(topics, data, *address, None) {
+                Some(event) => self.event_channels.dispatch_pool_update(event),
+                None => self.record_decode_failure(*address, topics),
             }
         }
+    }
+
+    /// Surface a decoder drop to operators. Bumps the `aether_decode_errors_total`
+    /// counter (if metrics are attached) and logs the offending pool address and
+    /// first topic. Called from the hot path, so it must be cheap — the counter
+    /// is a single atomic increment and the `warn!` emits no allocations when
+    /// disabled at runtime.
+    fn record_decode_failure(&self, address: Address, topics: &[B256]) {
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.inc_decode_errors();
+        }
+        let topic0 = topics.first().copied().unwrap_or_default();
+        warn!(
+            pool = %address,
+            %topic0,
+            "Event decoder returned None; log skipped"
+        );
     }
 
     /// Get the configured RPC URL.

--- a/crates/grpc-server/tests/ws_subscription_test.rs
+++ b/crates/grpc-server/tests/ws_subscription_test.rs
@@ -16,7 +16,15 @@ use tokio::sync::watch;
 use tokio::time::timeout;
 
 use aether_grpc_server::provider::{ProviderConfig, RpcProvider};
+use aether_grpc_server::EngineMetrics;
 use aether_ingestion::subscription::EventChannels;
+
+/// Fresh metrics handle for tests that don't care about counter values —
+/// each `EngineMetrics::new()` builds its own registry so concurrent
+/// tests don't collide.
+fn test_metrics() -> Arc<EngineMetrics> {
+    Arc::new(EngineMetrics::new())
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -106,7 +114,7 @@ async fn test_ws_subscription_receives_blocks() {
         max_reconnect_attempts: 5,
         ..ProviderConfig::default()
     };
-    let provider = Arc::new(RpcProvider::new(config, Arc::clone(&channels)));
+    let provider = Arc::new(RpcProvider::new(config, Arc::clone(&channels), test_metrics()));
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let provider_clone = Arc::clone(&provider);
@@ -167,7 +175,7 @@ async fn test_ws_reconnection_on_disconnect() {
         max_reconnect_attempts: 20,
         ..ProviderConfig::default()
     };
-    let provider = Arc::new(RpcProvider::new(config, Arc::clone(&channels)));
+    let provider = Arc::new(RpcProvider::new(config, Arc::clone(&channels), test_metrics()));
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let provider_clone = Arc::clone(&provider);
@@ -258,7 +266,7 @@ async fn test_http_fallback_still_works() {
         max_reconnect_attempts: 5,
         ..ProviderConfig::default()
     };
-    let provider = Arc::new(RpcProvider::new(config, Arc::clone(&channels)));
+    let provider = Arc::new(RpcProvider::new(config, Arc::clone(&channels), test_metrics()));
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let provider_clone = Arc::clone(&provider);

--- a/crates/ingestion/src/event_decoder.rs
+++ b/crates/ingestion/src/event_decoder.rs
@@ -269,14 +269,15 @@ mod tests {
         let event = decode_log(&topics, &data, pool_addr, None);
         assert!(event.is_some());
 
+        let got = event.unwrap();
         let PoolEvent::ReserveUpdate {
             pool,
             protocol,
             reserve0: r0,
             reserve1: r1,
-        } = event.unwrap()
+        } = got
         else {
-            panic!("decoder returned unexpected variant");
+            panic!("decoder returned unexpected variant: {got:?}");
         };
         assert_eq!(pool, pool_addr);
         assert_eq!(protocol, ProtocolType::UniswapV2);
@@ -297,8 +298,9 @@ mod tests {
         let topics = vec![EventSignatures::sync_topic()];
 
         let event = decode_log(&topics, &data, pool_addr, Some(ProtocolType::SushiSwap));
-        let PoolEvent::ReserveUpdate { protocol, .. } = event.unwrap() else {
-            panic!("decoder returned unexpected variant");
+        let got = event.unwrap();
+        let PoolEvent::ReserveUpdate { protocol, .. } = got else {
+            panic!("decoder returned unexpected variant: {got:?}");
         };
         assert_eq!(protocol, ProtocolType::SushiSwap);
     }
@@ -352,14 +354,15 @@ mod tests {
         let event = decode_log(&topics, &data, pool_addr, None);
         assert!(event.is_some());
 
+        let got = event.unwrap();
         let PoolEvent::V3Update {
             pool,
             sqrt_price_x96,
             liquidity: liq,
             tick,
-        } = event.unwrap()
+        } = got
         else {
-            panic!("decoder returned unexpected variant");
+            panic!("decoder returned unexpected variant: {got:?}");
         };
         assert_eq!(pool, pool_addr);
         assert_eq!(sqrt_price_x96, sqrt_price);
@@ -390,8 +393,9 @@ mod tests {
         ];
 
         let event = decode_log(&topics, &data, pool_addr, None);
-        let PoolEvent::V3Update { tick, .. } = event.unwrap() else {
-            panic!("decoder returned unexpected variant");
+        let got = event.unwrap();
+        let PoolEvent::V3Update { tick, .. } = got else {
+            panic!("decoder returned unexpected variant: {got:?}");
         };
         assert_eq!(tick, -100);
     }
@@ -423,14 +427,15 @@ mod tests {
         let event = decode_log(&topics, &data, pool_addr, None);
         assert!(event.is_some());
 
+        let got = event.unwrap();
         let PoolEvent::ReserveUpdate {
             pool,
             protocol,
             reserve0,
             reserve1,
-        } = event.unwrap()
+        } = got
         else {
-            panic!("decoder returned unexpected variant");
+            panic!("decoder returned unexpected variant: {got:?}");
         };
         assert_eq!(pool, pool_addr);
         assert_eq!(protocol, ProtocolType::Curve);
@@ -471,13 +476,14 @@ mod tests {
         let event = decode_log(&topics, &data, Address::ZERO, None);
         assert!(event.is_some());
 
+        let got = event.unwrap();
         let PoolEvent::PoolCreated {
             token0: t0,
             token1: t1,
             pool: p,
-        } = event.unwrap()
+        } = got
         else {
-            panic!("decoder returned unexpected variant");
+            panic!("decoder returned unexpected variant: {got:?}");
         };
         assert_eq!(t0, token0);
         assert_eq!(t1, token1);

--- a/crates/ingestion/src/event_decoder.rs
+++ b/crates/ingestion/src/event_decoder.rs
@@ -269,20 +269,19 @@ mod tests {
         let event = decode_log(&topics, &data, pool_addr, None);
         assert!(event.is_some());
 
-        match event.unwrap() {
-            PoolEvent::ReserveUpdate {
-                pool,
-                protocol,
-                reserve0: r0,
-                reserve1: r1,
-            } => {
-                assert_eq!(pool, pool_addr);
-                assert_eq!(protocol, ProtocolType::UniswapV2);
-                assert_eq!(r0, reserve0);
-                assert_eq!(r1, reserve1);
-            }
-            other => panic!("Expected ReserveUpdate, got {:?}", other),
-        }
+        let PoolEvent::ReserveUpdate {
+            pool,
+            protocol,
+            reserve0: r0,
+            reserve1: r1,
+        } = event.unwrap()
+        else {
+            panic!("decoder returned unexpected variant");
+        };
+        assert_eq!(pool, pool_addr);
+        assert_eq!(protocol, ProtocolType::UniswapV2);
+        assert_eq!(r0, reserve0);
+        assert_eq!(r1, reserve1);
     }
 
     #[test]
@@ -298,12 +297,10 @@ mod tests {
         let topics = vec![EventSignatures::sync_topic()];
 
         let event = decode_log(&topics, &data, pool_addr, Some(ProtocolType::SushiSwap));
-        match event.unwrap() {
-            PoolEvent::ReserveUpdate { protocol, .. } => {
-                assert_eq!(protocol, ProtocolType::SushiSwap);
-            }
-            other => panic!("Expected ReserveUpdate, got {:?}", other),
-        }
+        let PoolEvent::ReserveUpdate { protocol, .. } = event.unwrap() else {
+            panic!("decoder returned unexpected variant");
+        };
+        assert_eq!(protocol, ProtocolType::SushiSwap);
     }
 
     #[test]
@@ -355,20 +352,19 @@ mod tests {
         let event = decode_log(&topics, &data, pool_addr, None);
         assert!(event.is_some());
 
-        match event.unwrap() {
-            PoolEvent::V3Update {
-                pool,
-                sqrt_price_x96,
-                liquidity: liq,
-                tick,
-            } => {
-                assert_eq!(pool, pool_addr);
-                assert_eq!(sqrt_price_x96, sqrt_price);
-                assert_eq!(liq, 5_000_000u128);
-                assert_eq!(tick, 200);
-            }
-            other => panic!("Expected V3Update, got {:?}", other),
-        }
+        let PoolEvent::V3Update {
+            pool,
+            sqrt_price_x96,
+            liquidity: liq,
+            tick,
+        } = event.unwrap()
+        else {
+            panic!("decoder returned unexpected variant");
+        };
+        assert_eq!(pool, pool_addr);
+        assert_eq!(sqrt_price_x96, sqrt_price);
+        assert_eq!(liq, 5_000_000u128);
+        assert_eq!(tick, 200);
     }
 
     #[test]
@@ -394,12 +390,10 @@ mod tests {
         ];
 
         let event = decode_log(&topics, &data, pool_addr, None);
-        match event.unwrap() {
-            PoolEvent::V3Update { tick, .. } => {
-                assert_eq!(tick, -100);
-            }
-            other => panic!("Expected V3Update, got {:?}", other),
-        }
+        let PoolEvent::V3Update { tick, .. } = event.unwrap() else {
+            panic!("decoder returned unexpected variant");
+        };
+        assert_eq!(tick, -100);
     }
 
     #[test]
@@ -429,21 +423,20 @@ mod tests {
         let event = decode_log(&topics, &data, pool_addr, None);
         assert!(event.is_some());
 
-        match event.unwrap() {
-            PoolEvent::ReserveUpdate {
-                pool,
-                protocol,
-                reserve0,
-                reserve1,
-            } => {
-                assert_eq!(pool, pool_addr);
-                assert_eq!(protocol, ProtocolType::Curve);
-                // Zeroes because Curve needs on-chain refresh
-                assert_eq!(reserve0, U256::ZERO);
-                assert_eq!(reserve1, U256::ZERO);
-            }
-            other => panic!("Expected ReserveUpdate, got {:?}", other),
-        }
+        let PoolEvent::ReserveUpdate {
+            pool,
+            protocol,
+            reserve0,
+            reserve1,
+        } = event.unwrap()
+        else {
+            panic!("decoder returned unexpected variant");
+        };
+        assert_eq!(pool, pool_addr);
+        assert_eq!(protocol, ProtocolType::Curve);
+        // Zeroes because Curve needs on-chain refresh
+        assert_eq!(reserve0, U256::ZERO);
+        assert_eq!(reserve1, U256::ZERO);
     }
 
     // ── PairCreated decode tests ──
@@ -478,18 +471,17 @@ mod tests {
         let event = decode_log(&topics, &data, Address::ZERO, None);
         assert!(event.is_some());
 
-        match event.unwrap() {
-            PoolEvent::PoolCreated {
-                token0: t0,
-                token1: t1,
-                pool: p,
-            } => {
-                assert_eq!(t0, token0);
-                assert_eq!(t1, token1);
-                assert_eq!(p, pair);
-            }
-            other => panic!("Expected PoolCreated, got {:?}", other),
-        }
+        let PoolEvent::PoolCreated {
+            token0: t0,
+            token1: t1,
+            pool: p,
+        } = event.unwrap()
+        else {
+            panic!("decoder returned unexpected variant");
+        };
+        assert_eq!(t0, token0);
+        assert_eq!(t1, token1);
+        assert_eq!(p, pair);
     }
 
     #[test]

--- a/crates/ingestion/src/subscription.rs
+++ b/crates/ingestion/src/subscription.rs
@@ -142,15 +142,14 @@ mod tests {
         channels.dispatch_pool_update(event);
 
         let received = rx.recv().await.expect("should receive pool update");
-        match received {
-            PoolEvent::ReserveUpdate {
-                reserve0, reserve1, ..
-            } => {
-                assert_eq!(reserve0, U256::from(1000u64));
-                assert_eq!(reserve1, U256::from(2000u64));
-            }
-            other => panic!("Expected ReserveUpdate, got {:?}", other),
-        }
+        let PoolEvent::ReserveUpdate {
+            reserve0, reserve1, ..
+        } = received
+        else {
+            panic!("dispatch returned unexpected variant");
+        };
+        assert_eq!(reserve0, U256::from(1000u64));
+        assert_eq!(reserve1, U256::from(2000u64));
     }
 
     // ── Subscribe/dispatch new block ──
@@ -226,13 +225,11 @@ mod tests {
         let r3 = rx3.recv().await.expect("rx3 should receive");
 
         for received in [r1, r2, r3] {
-            match received {
-                PoolEvent::V3Update { tick, liquidity, .. } => {
-                    assert_eq!(tick, -50);
-                    assert_eq!(liquidity, 12345);
-                }
-                other => panic!("Expected V3Update, got {:?}", other),
-            }
+            let PoolEvent::V3Update { tick, liquidity, .. } = received else {
+                panic!("dispatch returned unexpected variant");
+            };
+            assert_eq!(tick, -50);
+            assert_eq!(liquidity, 12345);
         }
     }
 

--- a/crates/ingestion/src/subscription.rs
+++ b/crates/ingestion/src/subscription.rs
@@ -146,7 +146,7 @@ mod tests {
             reserve0, reserve1, ..
         } = received
         else {
-            panic!("dispatch returned unexpected variant");
+            panic!("dispatch returned unexpected variant: {received:?}");
         };
         assert_eq!(reserve0, U256::from(1000u64));
         assert_eq!(reserve1, U256::from(2000u64));
@@ -226,7 +226,7 @@ mod tests {
 
         for received in [r1, r2, r3] {
             let PoolEvent::V3Update { tick, liquidity, .. } = received else {
-                panic!("dispatch returned unexpected variant");
+                panic!("dispatch returned unexpected variant: {received:?}");
             };
             assert_eq!(tick, -50);
             assert_eq!(liquidity, 12345);


### PR DESCRIPTION
## Context — issue premise audit

This PR addresses the *real* observability gap behind #67. See [this comment on #67](https://github.com/Pablosinyores/aether/issues/67#issuecomment-4243288445) for the full audit.

Short version:
- All eight cited `panic!` sites (event_decoder.rs 284/305/370/401/445/491, subscription.rs 152/234) lived inside `#[cfg(test)] mod tests` — idiomatic Rust unit-test assertion failures, not production panics.
- Production `event_decoder::decode_log` already returns `Option<PoolEvent>` — malformed events already don't crash the process.
- The real consumer is `crates/grpc-server/src/provider.rs:437,455` (not `subscription.rs`). Both call sites handled the `None` arm but **silently dropped** the event — no log, no metric, no alert.

## Summary (shipped design — post review round 1)

- New `aether_decode_errors_total` counter on `EngineMetrics`.
- `RpcProvider::new(config, channels, metrics: Arc<EngineMetrics>)` — **metrics handle is required at construction**, not attached via an optional builder. The `with_metrics(...)` builder from the initial design was dropped after review flagged it as a silent-dead footgun (one refactor-removal of `.with_metrics(...)` would ship the counter at zero forever). Every test constructor uses a shared `test_metrics()` helper.
- Both `decode_log` call sites switch from `if let Some` to `match`; on `None` we now increment the counter and emit a `trace!` with pool address + topic0 via `record_decode_failure()`.
- `trace!` instead of `warn!` at the per-event site — pool-discovery mode routinely receives thousands of non-decodable events per block (unregistered ERC20 transfers, NFT events, etc.); a `warn!` per event would swamp Loki. The counter is the alert surface; `trace!` is only for targeted debugging.
- Module visibility: `pub(crate) mod metrics` in `lib.rs` — not `pub mod` — so `provider.rs` can reference it without widening the crate's public API surface.
- Happy path unchanged.

## Test coverage

- `test_process_logs_decode_failure_increments_counter` (new, in `provider.rs`) — builds a `RpcProvider` with a real `EngineMetrics` handle, feeds it a malformed log, asserts `aether_decode_errors_total 1` appears in the rendered Prometheus output. End-to-end coverage of the intended path.
- `test_metrics_render_contains_required_names` strengthened to assert the counter value, not just the metric name.
- The 8 test-site `match { Variant => ..., other => panic!("Expected ...") }` blocks are rewritten as `let Variant { .. } = other else { panic!("...: {:?}", other) }`. Debug info is preserved in the panic message on wrong-variant failures. The literal string `panic!("Expected` no longer appears in the crate (satisfies the #67 grep criterion honestly).

## Results

- `cargo test -p aether-ingestion -p aether-grpc-server` — 239 tests pass.
- `cargo clippy -p aether-ingestion -p aether-grpc-server -- -D warnings` — clean.
- `aether_decode_errors_total` added to the Key Observability Metrics table in `CLAUDE.md` with the alert threshold documented.

## Files Changed

| File | Change |
|---|---|
| `crates/grpc-server/src/metrics.rs` | new `decode_errors: IntCounter` field + `inc_decode_errors()`, registered in Prometheus registry; `Default` impl added; test asserts `aether_decode_errors_total` name + value |
| `crates/grpc-server/src/provider.rs` | `metrics: Arc<EngineMetrics>` now required on `RpcProvider::new`; `record_decode_failure()` helper (counter + `trace!`); `test_metrics()` helper for test construction; new end-to-end test for the decoder-drop path |
| `crates/grpc-server/src/lib.rs` | `pub(crate) mod metrics` — crate-internal, not a public item |
| `crates/grpc-server/src/main.rs` | constructs `Arc<EngineMetrics>` once, passes it to `RpcProvider::new` |
| `crates/ingestion/src/event_decoder.rs` | 6 test-site `match`-then-`panic` rewritten as `let-else` with `{:?}` Debug info |
| `crates/ingestion/src/subscription.rs` | 2 test-site `match`-then-`panic` rewritten as `let-else` with `{:?}` Debug info |
| `CLAUDE.md` | `aether_decode_errors_total` added to Key Observability Metrics table with alert threshold |

## Acceptance Criteria

- [x] Silent-drop of malformed events surfaces via a Prometheus counter that alert authors can reference by name.
- [x] Counter is non-optional on the provider — cannot be disabled by a future refactor.
- [x] Pool-discovery log volume doesn't swamp Loki (downgrade to `trace!`).
- [x] Test asserts counter value on the end-to-end decode-failure path.
- [x] `panic!("Expected ...` literal no longer appears outside of `{:?}` Debug-inclusive messages.
- [x] Metric name is documented in `CLAUDE.md` as the single source of truth.

## Test plan

- [x] `cargo test -p aether-ingestion -p aether-grpc-server` — 239/239 pass
- [x] `cargo clippy -p aether-ingestion -p aether-grpc-server -- -D warnings` — clean
- [x] New test `test_process_logs_decode_failure_increments_counter` asserts both counter presence and value

Closes #67.
