### PR TITLE
feat(executor): DEX registry + Ownable2Step + security fixes (E4/WS-3 PR1)

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -20,8 +20,8 @@ contract DeployAetherExecutor is Script {
         console.log("AetherExecutor deployed at:", address(executor));
         console.log("Owner:", executor.owner());
         console.log("Aave Pool:", executor.aavePool());
-        console.log("Balancer Vault:", executor.balancerVault());
-        console.log("Bancor Network:", executor.bancorNetwork());
+        console.log("Balancer Vault:", executor.protocolRouter(5)); // BALANCER_V2
+        console.log("Bancor Network:", executor.protocolRouter(6)); // BANCOR_V3
 
         return executor;
     }

--- a/contracts/src/AetherExecutor.sol
+++ b/contracts/src/AetherExecutor.sol
@@ -116,7 +116,7 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
     /// @dev Only valid for BALANCER_V2 and BANCOR_V3 in the current implementation; the
     ///      per-swap-pool protocols keep address(0) here.
     function setDexRouter(uint8 protocol, address router) external onlyOwner {
-        if (protocol == 0 || protocol > BANCOR_V3) revert UnknownProtocol(protocol);
+        if (!_isValidProtocol(protocol)) revert UnknownProtocol(protocol);
         if (router == address(0)) revert ZeroRouter();
         protocolRouter[protocol] = router;
         emit DexRouterSet(protocol, router);
@@ -124,7 +124,7 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
 
     /// @notice Per-protocol kill switch. Idempotent — no event on no-op writes.
     function setDexEnabled(uint8 protocol, bool enabled) external onlyOwner {
-        if (protocol == 0 || protocol > BANCOR_V3) revert UnknownProtocol(protocol);
+        if (!_isValidProtocol(protocol)) revert UnknownProtocol(protocol);
         if (protocolEnabled[protocol] == enabled) return;
         protocolEnabled[protocol] = enabled;
         emit DexEnabledSet(protocol, enabled);
@@ -163,7 +163,7 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
         uint256 stepsLen = steps.length;
         for (uint256 i = 0; i < stepsLen;) {
             uint8 p = steps[i].protocol;
-            if (p == 0 || p > BANCOR_V3) revert UnknownProtocol(p);
+            if (!_isValidProtocol(p)) revert UnknownProtocol(p);
             if (!protocolEnabled[p]) revert ProtocolDisabled(p);
             unchecked { ++i; }
         }
@@ -394,6 +394,12 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
         (bool success,) = network.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(network, 0);
+    }
+
+    /// @dev Returns true iff `protocol` falls in the valid range [UNISWAP_V2, BANCOR_V3].
+    ///      Zero is reserved as "unset" and is always invalid.
+    function _isValidProtocol(uint8 protocol) internal pure returns (bool) {
+        return protocol >= UNISWAP_V2 && protocol <= BANCOR_V3;
     }
 
     /// @notice Emergency rescue - owner only. token==address(0) rescues native ETH.

--- a/contracts/src/AetherExecutor.sol
+++ b/contracts/src/AetherExecutor.sol
@@ -360,37 +360,59 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
         IERC20(_pendingV3TokenIn).safeTransfer(msg.sender, amountOwed);
     }
 
-    /// @dev Curve: approve pool to pull tokens (capped at live balance), call exchange, reset approval.
-    ///      Capping mirrors the UniV2/Sushi pattern: if the off-chain optimizer over-specs amountIn
-    ///      relative to the live balance the pool's transferFrom would revert mid-flashloan, burning
-    ///      150-400 k gas plus the Aave premium.  The cap makes the on-chain math self-healing.
+    /// @dev Curve: approve pool to pull tokens, call exchange, reset approval.
+    ///
+    ///      PULL-BASED PROTOCOL — the Curve pool calls `transferFrom(executor, pool, amount)`
+    ///      where `amount` is parsed from the calldata encoded in `step.data` (set off-chain
+    ///      by the engine with `step.amountIn`). A live-balance cap at this layer would only
+    ///      reduce the ERC-20 allowance, not the amount encoded in `step.data`. The pool would
+    ///      then attempt `transferFrom` for `step.data`-amount but find allowance < that amount,
+    ///      reverting with ERC20InsufficientAllowance — same gas burn, same Aave premium lost.
+    ///
+    ///      Correct sizing is the engine's responsibility: the off-chain calldata encoder MUST
+    ///      intersect `amount_in` with the live post-prior-hop balance before encoding the swap,
+    ///      ensuring the approved amount and the amount encoded in `step.data` always match.
+    ///      Engine-side live-balance intersection is tracked in issue #97.
+    ///
+    ///      Contrast with UniV2/Sushi (push-based): the executor calls `safeTransfer(pool, actualIn)`
+    ///      before invoking `swap(...)`, so capping the transfer at live balance is safe and correct.
+    ///      That cap remains in place and is unchanged.
     function _swapCurve(SwapStep memory step, uint256 index) internal {
-        uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
-        IERC20(step.tokenIn).forceApprove(step.pool, actualIn);
+        IERC20(step.tokenIn).forceApprove(step.pool, step.amountIn);
         (bool success,) = step.pool.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(step.pool, 0);
     }
 
-    /// @dev Balancer V2: approve the registry-configured Vault to pull tokens (capped at live balance).
-    ///      See _swapCurve for the reasoning behind the live-balance cap.
+    /// @dev Balancer V2: approve the registry-configured Vault to pull tokens.
+    ///
+    ///      PULL-BASED PROTOCOL — the Balancer Vault calls `transferFrom(executor, vault, amount)`
+    ///      where `amount` comes from the `IAsset[]` amounts encoded inside `step.data`. A
+    ///      live-balance cap on the allowance alone does not cap the amount the Vault will try
+    ///      to pull — it causes ERC20InsufficientAllowance on any dust shortfall.
+    ///      Amount sizing is the engine's responsibility (see issue #97).
+    ///      See _swapCurve for the full push-vs-pull rationale.
     function _swapBalancer(SwapStep memory step, uint256 index) internal {
         address vault = protocolRouter[BALANCER_V2];
         if (vault == address(0)) revert ZeroRouter();
-        uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
-        IERC20(step.tokenIn).forceApprove(vault, actualIn);
+        IERC20(step.tokenIn).forceApprove(vault, step.amountIn);
         (bool success,) = vault.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(vault, 0);
     }
 
-    /// @dev Bancor V3: approve the registry-configured BancorNetwork to pull tokens (capped at live balance).
-    ///      See _swapCurve for the reasoning behind the live-balance cap.
+    /// @dev Bancor V3: approve the registry-configured BancorNetwork to pull tokens.
+    ///
+    ///      PULL-BASED PROTOCOL — BancorNetwork calls `transferFrom(executor, network, sourceAmount)`
+    ///      where `sourceAmount` is ABI-encoded inside `step.data`. A live-balance cap on the
+    ///      allowance alone does not reduce `sourceAmount` in the calldata — it causes
+    ///      ERC20InsufficientAllowance on any shortfall.
+    ///      Amount sizing is the engine's responsibility (see issue #97).
+    ///      See _swapCurve for the full push-vs-pull rationale.
     function _swapBancor(SwapStep memory step, uint256 index) internal {
         address network = protocolRouter[BANCOR_V3];
         if (network == address(0)) revert ZeroRouter();
-        uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
-        IERC20(step.tokenIn).forceApprove(network, actualIn);
+        IERC20(step.tokenIn).forceApprove(network, step.amountIn);
         (bool success,) = network.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(network, 0);

--- a/contracts/src/AetherExecutor.sol
+++ b/contracts/src/AetherExecutor.sol
@@ -360,29 +360,37 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
         IERC20(_pendingV3TokenIn).safeTransfer(msg.sender, amountOwed);
     }
 
-    /// @dev Curve: approve pool to pull tokens, call exchange, reset approval
+    /// @dev Curve: approve pool to pull tokens (capped at live balance), call exchange, reset approval.
+    ///      Capping mirrors the UniV2/Sushi pattern: if the off-chain optimizer over-specs amountIn
+    ///      relative to the live balance the pool's transferFrom would revert mid-flashloan, burning
+    ///      150-400 k gas plus the Aave premium.  The cap makes the on-chain math self-healing.
     function _swapCurve(SwapStep memory step, uint256 index) internal {
-        IERC20(step.tokenIn).forceApprove(step.pool, step.amountIn);
+        uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
+        IERC20(step.tokenIn).forceApprove(step.pool, actualIn);
         (bool success,) = step.pool.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(step.pool, 0);
     }
 
-    /// @dev Balancer V2: approve the registry-configured Vault to pull tokens.
+    /// @dev Balancer V2: approve the registry-configured Vault to pull tokens (capped at live balance).
+    ///      See _swapCurve for the reasoning behind the live-balance cap.
     function _swapBalancer(SwapStep memory step, uint256 index) internal {
         address vault = protocolRouter[BALANCER_V2];
         if (vault == address(0)) revert ZeroRouter();
-        IERC20(step.tokenIn).forceApprove(vault, step.amountIn);
+        uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
+        IERC20(step.tokenIn).forceApprove(vault, actualIn);
         (bool success,) = vault.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(vault, 0);
     }
 
-    /// @dev Bancor V3: approve the registry-configured BancorNetwork to pull tokens.
+    /// @dev Bancor V3: approve the registry-configured BancorNetwork to pull tokens (capped at live balance).
+    ///      See _swapCurve for the reasoning behind the live-balance cap.
     function _swapBancor(SwapStep memory step, uint256 index) internal {
         address network = protocolRouter[BANCOR_V3];
         if (network == address(0)) revert ZeroRouter();
-        IERC20(step.tokenIn).forceApprove(network, step.amountIn);
+        uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
+        IERC20(step.tokenIn).forceApprove(network, actualIn);
         (bool success,) = network.call(step.data);
         if (!success) revert SwapFailed(index);
         IERC20(step.tokenIn).forceApprove(network, 0);

--- a/contracts/src/AetherExecutor.sol
+++ b/contracts/src/AetherExecutor.sol
@@ -263,7 +263,7 @@ contract AetherExecutor is Ownable2Step, ReentrancyGuard {
                 // Unwrap WETH, then try native ETH transfer; on failure re-wrap and send as WETH.
                 // Some builders run contract coinbases that reject plain ETH transfers.
                 IWETH(asset).withdraw(tipAmount);
-                (bool sent,) = block.coinbase.call{value: tipAmount, gas: 2300}("");
+                (bool sent,) = block.coinbase.call{value: tipAmount}("");
                 if (!sent) {
                     IWETH(WETH).deposit{value: tipAmount}();
                     IERC20(WETH).safeTransfer(block.coinbase, tipAmount);

--- a/contracts/src/AetherExecutor.sol
+++ b/contracts/src/AetherExecutor.sol
@@ -4,21 +4,23 @@ pragma solidity ^0.8.20;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 interface IWETH {
+    function deposit() external payable;
     function withdraw(uint256 wad) external;
+    function transfer(address to, uint256 amount) external returns (bool);
 }
 
 /// @title AetherExecutor - Flash loan arbitrage executor
 /// @notice Executes cross-DEX arbitrage using Aave V3 flash loans
 /// @dev All swap steps must be profitable after gas + flash loan premium
-contract AetherExecutor is ReentrancyGuard {
+contract AetherExecutor is Ownable2Step, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    address public owner;
     address public immutable aavePool;
-    address public immutable balancerVault;
-    address public immutable bancorNetwork;
 
     /// @dev Canonical WETH address on Ethereum mainnet
     address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
@@ -30,6 +32,16 @@ contract AetherExecutor is ReentrancyGuard {
     uint8 constant CURVE = 4;
     uint8 constant BALANCER_V2 = 5;
     uint8 constant BANCOR_V3 = 6;
+
+    /// @notice Runtime DEX registry — lets the owner swap router/vault addresses and
+    ///         disable a compromised protocol without redeploying. Full redeploy is
+    ///         still required to add a brand-new protocol *type* (new inline _swapX branch).
+    mapping(uint8 => address) public protocolRouter;
+    mapping(uint8 => bool) public protocolEnabled;
+
+    /// @notice Circuit-breaker — when true, `executeArb` reverts. Flipped by the Go risk manager
+    ///         when e.g. gas spikes above threshold or daily PnL crosses its floor.
+    bool public paused;
 
     struct SwapStep {
         uint8 protocol;
@@ -48,8 +60,10 @@ contract AetherExecutor is ReentrancyGuard {
         uint256 tipAmount,
         uint256 gasUsed
     );
+    event DexRouterSet(uint8 indexed protocol, address router);
+    event DexEnabledSet(uint8 indexed protocol, bool enabled);
+    event PausedSet(bool paused);
 
-    error NotOwner();
     error NotAavePool();
     error InvalidInitiator();
     error FlashLoanFailed();
@@ -62,26 +76,68 @@ contract AetherExecutor is ReentrancyGuard {
     error SwapFailed(uint256 stepIndex);
     error TipBpsTooHigh();
     error CoinbaseTipFailed();
-
-    modifier onlyOwner() {
-        if (msg.sender != owner) revert NotOwner();
-        _;
-    }
+    error UnknownProtocol(uint8 protocol);
+    error ProtocolDisabled(uint8 protocol);
+    error ZeroRouter();
+    error Paused();
 
     // UniswapV3 callback state — set before the swap call, validated in callback
     address private _pendingV3Pool;
     address private _pendingV3TokenIn;
     uint256 private _pendingV3AmountIn;
 
-    constructor(address _aavePool, address _balancerVault, address _bancorNetwork) {
-        require(_aavePool != address(0), "Zero aavePool");
-        require(_balancerVault != address(0), "Zero balancerVault");
-        require(_bancorNetwork != address(0), "Zero bancorNetwork");
-        owner = msg.sender;
-        aavePool = _aavePool;
-        balancerVault = _balancerVault;
-        bancorNetwork = _bancorNetwork;
+    modifier whenNotPaused() {
+        if (paused) revert Paused();
+        _;
     }
+
+    constructor(address _aavePool, address _balancerVault, address _bancorNetwork)
+        Ownable(msg.sender)
+    {
+        if (_aavePool == address(0)) revert ZeroAddress();
+        if (_balancerVault == address(0)) revert ZeroAddress();
+        if (_bancorNetwork == address(0)) revert ZeroAddress();
+        aavePool = _aavePool;
+
+        // Seed registry with mainnet defaults. UniV2/V3/Sushi/Curve use per-swap pool addresses
+        // (no single router), so their entries stay at address(0) — `protocolRouter` is only
+        // meaningful for Balancer (single Vault) and Bancor (single BancorNetwork).
+        protocolRouter[BALANCER_V2] = _balancerVault;
+        protocolRouter[BANCOR_V3] = _bancorNetwork;
+
+        for (uint8 p = UNISWAP_V2; p <= BANCOR_V3; p++) {
+            protocolEnabled[p] = true;
+        }
+    }
+
+    // ─────────────────────────── DEX registry management ───────────────────────────
+
+    /// @notice Replace the router/vault address for a protocol (e.g. Balancer Vault migration).
+    /// @dev Only valid for BALANCER_V2 and BANCOR_V3 in the current implementation; the
+    ///      per-swap-pool protocols keep address(0) here.
+    function setDexRouter(uint8 protocol, address router) external onlyOwner {
+        if (protocol == 0 || protocol > BANCOR_V3) revert UnknownProtocol(protocol);
+        if (router == address(0)) revert ZeroRouter();
+        protocolRouter[protocol] = router;
+        emit DexRouterSet(protocol, router);
+    }
+
+    /// @notice Per-protocol kill switch. Idempotent — no event on no-op writes.
+    function setDexEnabled(uint8 protocol, bool enabled) external onlyOwner {
+        if (protocol == 0 || protocol > BANCOR_V3) revert UnknownProtocol(protocol);
+        if (protocolEnabled[protocol] == enabled) return;
+        protocolEnabled[protocol] = enabled;
+        emit DexEnabledSet(protocol, enabled);
+    }
+
+    /// @notice Global pause — flipped by the Go risk manager on circuit-breaker trip.
+    function setPaused(bool _paused) external onlyOwner {
+        if (paused == _paused) return;
+        paused = _paused;
+        emit PausedSet(_paused);
+    }
+
+    // ─────────────────────────── Arb execution ───────────────────────────
 
     /// @notice Entry point - initiates flash loan and arb execution
     /// @param steps Array of swap steps to execute
@@ -97,17 +153,27 @@ contract AetherExecutor is ReentrancyGuard {
         uint256 deadline,
         uint256 minProfitOut,
         uint256 tipBps
-    ) external onlyOwner nonReentrant {
+    ) external onlyOwner nonReentrant whenNotPaused {
         if (block.timestamp > deadline) revert DeadlineExpired();
         if (tipBps > 10_000) revert TipBpsTooHigh();
 
-        uint256 gasStart = gasleft();
+        // CRITICAL: validate every step's protocol is enabled BEFORE starting the flash loan.
+        // A disabled flag discovered mid-callback would burn the full tx gas (hop N already
+        // swapped, flashloan premium owed). Pre-flight check = ≤1 SLOAD per hop, fails fast.
+        uint256 stepsLen = steps.length;
+        for (uint256 i = 0; i < stepsLen;) {
+            uint8 p = steps[i].protocol;
+            if (p == 0 || p > BANCOR_V3) revert UnknownProtocol(p);
+            if (!protocolEnabled[p]) revert ProtocolDisabled(p);
+            unchecked { ++i; }
+        }
 
-        // Encode steps, gas snapshot, tip config, and profit floor for callback
-        bytes memory params = abi.encode(steps, gasStart, tipBps, minProfitOut);
+        // Encode steps, tip config, and profit floor for callback.
+        // gasStart moved into executeOperation so the measured gasUsed reflects on-chain work,
+        // not the calldata encode cost above.
+        bytes memory params = abi.encode(steps, tipBps, minProfitOut);
 
         // Initiate flash loan - Aave V3 IPool.flashLoanSimple
-        // function flashLoanSimple(address receiverAddress, address asset, uint256 amount, bytes calldata params, uint16 referralCode)
         (bool success,) = aavePool.call(
             abi.encodeWithSignature(
                 "flashLoanSimple(address,address,uint256,bytes,uint16)",
@@ -130,7 +196,7 @@ contract AetherExecutor is ReentrancyGuard {
     /// @param amount The borrowed amount
     /// @param premium The flash loan fee
     /// @param initiator The address that initiated the flash loan (must be this contract)
-    /// @param params Encoded swap steps, gas tracking, tip config, and profit floor
+    /// @param params Encoded swap steps, tip config, and profit floor
     /// @return True on success
     function executeOperation(
         address asset,
@@ -139,17 +205,20 @@ contract AetherExecutor is ReentrancyGuard {
         address initiator,
         bytes calldata params
     ) external returns (bool) {
+        // Snapshot gas at the top of the on-chain execution path so the emitted gasUsed
+        // reflects only on-chain work, not the calldata build-up in executeArb.
+        uint256 gasStart = gasleft();
+
         if (msg.sender != aavePool) revert NotAavePool();
         if (initiator != address(this)) revert InvalidInitiator();
 
-        (SwapStep[] memory steps, uint256 gasStart, uint256 tipBps, uint256 minProfitOut) =
-            abi.decode(params, (SwapStep[], uint256, uint256, uint256));
+        (SwapStep[] memory steps, uint256 tipBps, uint256 minProfitOut) =
+            abi.decode(params, (SwapStep[], uint256, uint256));
 
         // Execute all swap steps
         uint256 len = steps.length;
         for (uint256 i = 0; i < len;) {
             _executeSwap(steps[i], i);
-            // Safe: i < len, so i+1 cannot overflow
             unchecked { ++i; }
         }
 
@@ -175,7 +244,6 @@ contract AetherExecutor is ReentrancyGuard {
         uint256 totalDebt = amount + premium;
 
         // Fallback: ensure Aave pool has sufficient allowance for repayment.
-        // Pre-set via setApprovals() for gas savings; this covers new tokens.
         if (IERC20(asset).allowance(address(this), aavePool) < totalDebt) {
             IERC20(asset).forceApprove(aavePool, type(uint256).max);
         }
@@ -184,79 +252,74 @@ contract AetherExecutor is ReentrancyGuard {
         if (balance <= totalDebt) revert InsufficientProfit(0, minProfitOut);
         profit = balance - totalDebt;
 
-        // Enforce minimum profit floor
         if (profit < minProfitOut) revert InsufficientProfit(profit, minProfitOut);
 
-        // tipBps validated in executeArb (<=10000), so multiplication is safe
         tipAmount = (profit * tipBps) / 10_000;
-        // Safe: tipAmount <= profit because tipBps <= 10000
         uint256 ownerProfit;
         unchecked { ownerProfit = profit - tipAmount; }
 
         if (tipAmount > 0) {
             if (asset == WETH) {
-                // Unwrap WETH to native ETH so builders recognize the coinbase tip
+                // Unwrap WETH, then try native ETH transfer; on failure re-wrap and send as WETH.
+                // Some builders run contract coinbases that reject plain ETH transfers.
                 IWETH(asset).withdraw(tipAmount);
-                (bool sent,) = block.coinbase.call{value: tipAmount}("");
-                if (!sent) revert CoinbaseTipFailed();
+                (bool sent,) = block.coinbase.call{value: tipAmount, gas: 2300}("");
+                if (!sent) {
+                    IWETH(WETH).deposit{value: tipAmount}();
+                    IERC20(WETH).safeTransfer(block.coinbase, tipAmount);
+                }
             } else {
                 // Non-WETH fallback: ERC-20 transfer (builders won't prioritize)
                 IERC20(asset).safeTransfer(block.coinbase, tipAmount);
             }
         }
         if (ownerProfit > 0) {
-            IERC20(asset).safeTransfer(owner, ownerProfit);
+            IERC20(asset).safeTransfer(owner(), ownerProfit);
         }
     }
 
     /// @notice Pre-approve spenders to save gas during arb execution
-    /// @dev Call once per token/spender pair (e.g., flashloan token -> Aave pool).
-    ///      Uses max approval so executeOperation never needs to re-approve.
-    /// @param tokens ERC20 token addresses to approve
-    /// @param spenders Corresponding spender addresses (must be same length as tokens)
     function setApprovals(address[] calldata tokens, address[] calldata spenders) external onlyOwner {
         if (tokens.length != spenders.length) revert ArrayLengthMismatch();
         uint256 len = tokens.length;
         for (uint256 i = 0; i < len;) {
             if (spenders[i] == address(0)) revert ZeroAddress();
             IERC20(tokens[i]).forceApprove(spenders[i], type(uint256).max);
-            // Safe: i < len, so i+1 cannot overflow
             unchecked { ++i; }
         }
     }
 
     /// @dev Execute a single swap step based on protocol.
-    ///      Each protocol handler manages its own token transfer pattern.
-    ///      Per-step slippage protection via minAmountOut enforced after each swap.
     function _executeSwap(SwapStep memory step, uint256 index) internal {
+        // Defense-in-depth: the pre-flight check in executeArb already rejected disabled
+        // protocols, but future internal callers (e.g. direct-call paths) must also be guarded.
+        if (!protocolEnabled[step.protocol]) revert ProtocolDisabled(step.protocol);
+
         uint256 balanceBefore = IERC20(step.tokenOut).balanceOf(address(this));
 
         // Hot-path first: UniV2 and UniV3 are by far the most common protocols
         if (step.protocol == UNISWAP_V2) {
-            // UniV2: pre-transfer tokens to pool, then call swap
-            IERC20(step.tokenIn).safeTransfer(step.pool, step.amountIn);
+            // Cap the transfer at our actual balance — protects against off-chain optimizer
+            // over-spec'ing amountIn vs. what's really available post-prior-hop.
+            uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
+            IERC20(step.tokenIn).safeTransfer(step.pool, actualIn);
             _swapUniV2(step, index);
         } else if (step.protocol == UNISWAP_V3) {
-            // UniV3: pool calls back uniswapV3SwapCallback to pull tokens
             _swapUniV3(step, index);
         } else if (step.protocol == SUSHISWAP) {
-            // Sushi: same pre-transfer pattern as UniV2
-            IERC20(step.tokenIn).safeTransfer(step.pool, step.amountIn);
+            uint256 actualIn = Math.min(step.amountIn, IERC20(step.tokenIn).balanceOf(address(this)));
+            IERC20(step.tokenIn).safeTransfer(step.pool, actualIn);
             _swapUniV2(step, index);
         } else if (step.protocol == CURVE) {
-            // Curve: approve then pool pulls via transferFrom
             _swapCurve(step, index);
         } else if (step.protocol == BALANCER_V2) {
-            // Balancer: approve Vault then Vault pulls via transferFrom
             _swapBalancer(step, index);
         } else if (step.protocol == BANCOR_V3) {
-            // Bancor: approve then router pulls via transferFrom
             _swapBancor(step, index);
         } else {
-            revert SwapFailed(index);
+            revert UnknownProtocol(step.protocol);
         }
 
-        // Per-step slippage protection: verify minimum output received
         uint256 amountOut = IERC20(step.tokenOut).balanceOf(address(this)) - balanceBefore;
         if (amountOut < step.minAmountOut) {
             revert InsufficientOutput(index, amountOut, step.minAmountOut);
@@ -278,29 +341,20 @@ contract AetherExecutor is ReentrancyGuard {
         (bool success,) = step.pool.call(step.data);
         if (!success) revert SwapFailed(index);
 
-        // Clear callback state
         _pendingV3Pool = address(0);
         _pendingV3TokenIn = address(0);
         _pendingV3AmountIn = 0;
     }
 
     /// @notice UniswapV3 swap callback — called by the pool during swap to collect tokenIn
-    /// @param amount0Delta Amount of token0 owed (positive = owed by caller)
-    /// @param amount1Delta Amount of token1 owed (positive = owed by caller)
     function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata) external {
         if (msg.sender != _pendingV3Pool) revert NotPendingV3Pool();
 
-        // At least one delta must be positive (amount owed to the pool)
         require(amount0Delta > 0 || amount1Delta > 0, "V3: no amount owed");
-        // Transfer the owed amount to the pool (whichever delta is positive)
         uint256 amountOwed = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
-        // Cap at our expected amount to prevent a malicious pool from draining extra tokens
         if (amountOwed > _pendingV3AmountIn) amountOwed = _pendingV3AmountIn;
-        // Zero out to prevent double-spend if pool calls back multiple times
         _pendingV3AmountIn = 0;
 
-        // Skip transfer if nothing owed (e.g. second callback after double-spend protection)
-        // Some ERC20s revert on zero-amount transfers
         if (amountOwed == 0) return;
 
         IERC20(_pendingV3TokenIn).safeTransfer(msg.sender, amountOwed);
@@ -314,36 +368,34 @@ contract AetherExecutor is ReentrancyGuard {
         IERC20(step.tokenIn).forceApprove(step.pool, 0);
     }
 
-    /// @dev Balancer V2: approve the single Vault (not the pool) to pull tokens
+    /// @dev Balancer V2: approve the registry-configured Vault to pull tokens.
     function _swapBalancer(SwapStep memory step, uint256 index) internal {
-        IERC20(step.tokenIn).forceApprove(balancerVault, step.amountIn);
-        (bool success,) = balancerVault.call(step.data);
+        address vault = protocolRouter[BALANCER_V2];
+        if (vault == address(0)) revert ZeroRouter();
+        IERC20(step.tokenIn).forceApprove(vault, step.amountIn);
+        (bool success,) = vault.call(step.data);
         if (!success) revert SwapFailed(index);
-        IERC20(step.tokenIn).forceApprove(balancerVault, 0);
+        IERC20(step.tokenIn).forceApprove(vault, 0);
     }
 
-    /// @dev Bancor V3: approve the BancorNetwork contract (not the individual pool) to pull tokens
-    /// @dev Individual Bancor pool contracts do not implement tradeBySourceAmount — all trades
-    ///      must go through the single BancorNetwork router at the immutable bancorNetwork address.
+    /// @dev Bancor V3: approve the registry-configured BancorNetwork to pull tokens.
     function _swapBancor(SwapStep memory step, uint256 index) internal {
-        IERC20(step.tokenIn).forceApprove(bancorNetwork, step.amountIn);
-        (bool success,) = bancorNetwork.call(step.data);
+        address network = protocolRouter[BANCOR_V3];
+        if (network == address(0)) revert ZeroRouter();
+        IERC20(step.tokenIn).forceApprove(network, step.amountIn);
+        (bool success,) = network.call(step.data);
         if (!success) revert SwapFailed(index);
-        IERC20(step.tokenIn).forceApprove(bancorNetwork, 0);
+        IERC20(step.tokenIn).forceApprove(network, 0);
     }
 
-    /// @notice Emergency token rescue - owner only
-    /// @param token ERC20 token to rescue
-    /// @param amount Amount to rescue
+    /// @notice Emergency rescue - owner only. token==address(0) rescues native ETH.
     function rescue(address token, uint256 amount) external onlyOwner {
-        IERC20(token).safeTransfer(owner, amount);
-    }
-
-    /// @notice Transfer contract ownership
-    /// @param newOwner Address of new owner; must be non-zero
-    function transferOwnership(address newOwner) external onlyOwner {
-        if (newOwner == address(0)) revert ZeroAddress();
-        owner = newOwner;
+        if (token == address(0)) {
+            (bool ok,) = owner().call{value: amount}("");
+            require(ok, "ETH rescue failed");
+        } else {
+            IERC20(token).safeTransfer(owner(), amount);
+        }
     }
 
     /// @notice Accept ETH (needed for WETH unwrap during coinbase tip)

--- a/contracts/test/AetherExecutor.t.sol
+++ b/contracts/test/AetherExecutor.t.sol
@@ -167,6 +167,28 @@ contract MockBalancerVault {
     }
 }
 
+/// @dev Counting Balancer Vault — tracks swap call count to assert routing target
+contract CountingBalancerVault {
+    MockERC20 public immutable tokenIn;
+    MockERC20 public immutable tokenOut;
+    uint256 public immutable amountOut;
+    uint256 public swapCallCount;
+
+    constructor(MockERC20 _tokenIn, MockERC20 _tokenOut, uint256 _amountOut) {
+        tokenIn = _tokenIn;
+        tokenOut = _tokenOut;
+        amountOut = _amountOut;
+    }
+
+    fallback() external {
+        swapCallCount += 1;
+        uint256 approved = tokenIn.allowance(msg.sender, address(this));
+        require(approved > 0, "CountingVault: no approval");
+        tokenIn.transferFrom(msg.sender, address(this), approved);
+        tokenOut.transfer(msg.sender, amountOut);
+    }
+}
+
 /// @dev Mock Bancor router — pulls tokenIn via transferFrom, sends tokenOut
 contract MockBancorRouter {
     MockERC20 public immutable tokenIn;
@@ -1393,6 +1415,81 @@ contract AetherExecutorTest is Test {
         assertEq(executor.protocolRouter(BALANCER_V2), newVault, "router not updated");
     }
 
+    /// @dev End-to-end: setDexRouter(BALANCER_V2, secondVault) must route the next Balancer
+    ///      hop to the NEW vault and leave the original vault untouched.
+    function test_setDexRouter_balancerV2_routesToNewVault() public {
+        MockERC20 tokenIn = new MockERC20();
+        MockERC20 tokenOut = new MockERC20();
+
+        uint256 flashAmount = 1000;
+        uint256 swapOut = 1100;
+        uint256 premium = flashAmount * 5 / 10000;
+
+        // Deploy two vaults — both can serve the swap; we assert only the second is called.
+        CountingBalancerVault firstVault = new CountingBalancerVault(tokenIn, tokenOut, swapOut);
+        CountingBalancerVault secondVault = new CountingBalancerVault(tokenIn, tokenOut, swapOut);
+
+        // Seed both vaults with enough tokenOut to complete the swap.
+        tokenOut.mint(address(firstVault), swapOut);
+        tokenOut.mint(address(secondVault), swapOut);
+
+        // Deploy executor pointing at firstVault.
+        AetherExecutor regExecutor = new AetherExecutor(address(aavePool), address(firstVault), address(0xBAAC));
+
+        // Migrate to secondVault — this is the action under test.
+        regExecutor.setDexRouter(BALANCER_V2, address(secondVault));
+        assertEq(regExecutor.protocolRouter(BALANCER_V2), address(secondVault), "router not updated");
+
+        // Return pool to close the arb loop.
+        uint256 returnAmount = flashAmount + premium + 10;
+        MockV2Pool returnPool = new MockV2Pool(tokenOut, tokenIn, returnAmount);
+        tokenIn.mint(address(returnPool), returnAmount);
+
+        bytes memory balancerData = abi.encodeWithSignature(
+            "swap(bytes32,address,address,uint256,uint256)",
+            bytes32(0),
+            address(tokenIn),
+            address(tokenOut),
+            flashAmount,
+            swapOut
+        );
+        bytes memory returnData = abi.encodeWithSignature(
+            "swap(uint256,uint256,address,bytes)",
+            uint256(0),
+            returnAmount,
+            address(regExecutor),
+            ""
+        );
+
+        AetherExecutor.SwapStep[] memory steps = new AetherExecutor.SwapStep[](2);
+        steps[0] = AetherExecutor.SwapStep({
+            protocol: BALANCER_V2,
+            pool: address(secondVault), // pool field is informational for Balancer; router drives the call
+            tokenIn: address(tokenIn),
+            tokenOut: address(tokenOut),
+            amountIn: flashAmount,
+            minAmountOut: swapOut,
+            data: balancerData
+        });
+        steps[1] = AetherExecutor.SwapStep({
+            protocol: UNISWAP_V2,
+            pool: address(returnPool),
+            tokenIn: address(tokenOut),
+            tokenOut: address(tokenIn),
+            amountIn: swapOut,
+            minAmountOut: returnAmount,
+            data: returnData
+        });
+
+        regExecutor.executeArb(steps, address(tokenIn), flashAmount, block.timestamp + 1000, 0, 0);
+
+        // Only the second vault must have been called.
+        assertEq(secondVault.swapCallCount(), 1, "secondVault must receive exactly one swap call");
+        assertEq(firstVault.swapCallCount(), 0, "firstVault must not be called after router migration");
+        // Approval to the new vault must be reset to 0 after the swap.
+        assertEq(tokenIn.allowance(address(regExecutor), address(secondVault)), 0, "approval not reset");
+    }
+
     function test_setDexRouter_revert_zeroRouter() public {
         vm.expectRevert(AetherExecutor.ZeroRouter.selector);
         executor.setDexRouter(BALANCER_V2, address(0));
@@ -1767,12 +1864,14 @@ contract AetherExecutorTest is Test {
 
     function test_protocolConstants_implicitlyMatch() public view {
         // In-range (1..=6) must all be enabled at construction.
-        assertTrue(executor.protocolEnabled(UNISWAP_V2), "UNISWAP_V2 (1)");
-        assertTrue(executor.protocolEnabled(UNISWAP_V3), "UNISWAP_V3 (2)");
-        assertTrue(executor.protocolEnabled(SUSHISWAP), "SUSHISWAP (3)");
-        assertTrue(executor.protocolEnabled(CURVE), "CURVE (4)");
-        assertTrue(executor.protocolEnabled(BALANCER_V2), "BALANCER_V2 (5)");
-        assertTrue(executor.protocolEnabled(BANCOR_V3), "BANCOR_V3 (6)");
+        // Hardcoded numeric IDs — using the test-file constants here would make
+        // the sentinel circular: if a constant drifted, the test would still pass.
+        assertTrue(executor.protocolEnabled(1), "UNISWAP_V2 (1)");
+        assertTrue(executor.protocolEnabled(2), "UNISWAP_V3 (2)");
+        assertTrue(executor.protocolEnabled(3), "SUSHISWAP (3)");
+        assertTrue(executor.protocolEnabled(4), "CURVE (4)");
+        assertTrue(executor.protocolEnabled(5), "BALANCER_V2 (5)");
+        assertTrue(executor.protocolEnabled(6), "BANCOR_V3 (6)");
 
         // Out-of-range (0 and >=7) must stay default-false.
         assertFalse(executor.protocolEnabled(0), "protocol 0 must be disabled");

--- a/contracts/test/AetherExecutor.t.sol
+++ b/contracts/test/AetherExecutor.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {AetherExecutor} from "../src/AetherExecutor.sol";
 
 /// @dev Mock Aave pool that reverts on flashLoanSimple (used to test FlashLoanFailed)
@@ -319,24 +320,47 @@ contract AetherExecutorTest is Test {
     }
 
     // -------------------------------------------------------------------------
-    // transferOwnership
+    // transferOwnership (Ownable2Step — two-step handoff)
     // -------------------------------------------------------------------------
 
     function test_transferOwnership() public {
+        // Ownable2Step: transferOwnership only nominates pendingOwner; the new owner
+        // must call acceptOwnership() to complete the handoff.
         address newOwner = address(0x123);
         executor.transferOwnership(newOwner);
+
+        // Owner unchanged after step 1
+        assertEq(executor.owner(), owner);
+        assertEq(executor.pendingOwner(), newOwner);
+
+        // Step 2: new owner accepts
+        vm.prank(newOwner);
+        executor.acceptOwnership();
+
         assertEq(executor.owner(), newOwner);
+        assertEq(executor.pendingOwner(), address(0));
     }
 
     function test_transferOwnership_revert_notOwner() public {
         vm.prank(address(0x456));
-        vm.expectRevert(AetherExecutor.NotOwner.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0x456))
+        );
         executor.transferOwnership(address(0x789));
     }
 
-    function test_transferOwnership_revert_zeroAddress() public {
-        vm.expectRevert(AetherExecutor.ZeroAddress.selector);
+    /// @dev Ownable2Step allows transferOwnership(address(0)) — it CANCELS a pending
+    ///      transfer by clearing pendingOwner. It does NOT revert.
+    function test_transferOwnership_cancel_withZeroAddress() public {
+        // First nominate a new owner
+        address pending = address(0x123);
+        executor.transferOwnership(pending);
+        assertEq(executor.pendingOwner(), pending);
+
+        // Now cancel by passing address(0). This does NOT revert on Ownable2Step.
         executor.transferOwnership(address(0));
+        assertEq(executor.pendingOwner(), address(0), "pendingOwner should be cleared");
+        assertEq(executor.owner(), owner, "owner unchanged after cancel");
     }
 
     // -------------------------------------------------------------------------
@@ -354,7 +378,9 @@ contract AetherExecutorTest is Test {
 
     function test_rescue_revert_notOwner() public {
         vm.prank(address(0x456));
-        vm.expectRevert(AetherExecutor.NotOwner.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0x456))
+        );
         executor.rescue(address(token), 100);
     }
 
@@ -365,7 +391,9 @@ contract AetherExecutorTest is Test {
     function test_executeArb_revert_notOwner() public {
         AetherExecutor.SwapStep[] memory steps = new AetherExecutor.SwapStep[](0);
         vm.prank(address(0x456));
-        vm.expectRevert(AetherExecutor.NotOwner.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0x456))
+        );
         executor.executeArb(steps, address(token), 1000, block.timestamp + 1000, 0, 9000);
     }
 
@@ -437,7 +465,9 @@ contract AetherExecutorTest is Test {
         spenders[0] = address(aavePool);
 
         vm.prank(address(0x456));
-        vm.expectRevert(AetherExecutor.NotOwner.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0x456))
+        );
         executor.setApprovals(tokens, spenders);
     }
 

--- a/contracts/test/AetherExecutor.t.sol
+++ b/contracts/test/AetherExecutor.t.sol
@@ -255,6 +255,11 @@ contract MockWETH {
         require(sent, "ETH transfer failed");
     }
 
+    /// @dev Simulates WETH.deposit: mints WETH to sender equal to msg.value
+    function deposit() external payable {
+        balanceOf[msg.sender] += msg.value;
+    }
+
     receive() external payable {}
 }
 
@@ -271,6 +276,44 @@ contract MockSwapPool {
     fallback() external {
         // Simulate profitable swap: mint outAmount of tokenOut to caller
         MockERC20(tokenOut).mint(msg.sender, outAmount);
+    }
+}
+
+/// @dev Mock Aave pool that tracks flashLoanSimple call count so tests can prove
+///      the pre-flashloan validation short-circuits before Aave is invoked.
+contract CountingAavePool {
+    uint256 public flashLoanCallCount;
+
+    function flashLoanSimple(
+        address receiver,
+        address asset,
+        uint256 amount,
+        bytes calldata params,
+        uint16 /* referralCode */
+    ) external {
+        flashLoanCallCount += 1;
+
+        MockERC20(asset).mint(receiver, amount);
+        uint256 premium = (amount * 5) / 10000;
+
+        AetherExecutor(payable(receiver)).executeOperation(
+            asset,
+            amount,
+            premium,
+            receiver,
+            params
+        );
+
+        uint256 totalDebt = amount + premium;
+        MockERC20(asset).transferFrom(receiver, address(this), totalDebt);
+    }
+}
+
+/// @dev Helper whose receive() always reverts — simulates a contract-coinbase that
+///      refuses plain ETH transfers (forces the WETH fallback path in _repayAndDistribute).
+contract RevertingCoinbase {
+    receive() external payable {
+        revert("no eth");
     }
 }
 
@@ -306,6 +349,10 @@ contract AetherExecutorTest is Test {
         token = new MockERC20();
         token2 = new MockERC20();
     }
+
+    /// @dev Accept native ETH. Needed for test_rescue_eth where the owner (this contract)
+    ///      receives native ETH via executor.rescue(address(0), amount).
+    receive() external payable {}
 
     // -------------------------------------------------------------------------
     // Basic state
@@ -1300,5 +1347,436 @@ contract AetherExecutorTest is Test {
         // Pool received tokens via direct transfer (same as UniV2)
         assertEq(tokenIn.balanceOf(address(pool)), flashAmount);
         assertGt(tokenIn.balanceOf(owner), 0);
+    }
+
+    // =========================================================================
+    //                    DEX REGISTRY + PAUSE + OWNABLE2STEP
+    //                    + SECURITY-FIX COVERAGE (PR1 / E4-WS3)
+    // =========================================================================
+    //
+    // This block covers the runtime DEX registry (setDexRouter/setDexEnabled),
+    // the pause circuit breaker, the full Ownable2Step handoff, and the three
+    // security fixes that shipped with the registry change:
+    //   1) rescue() now sends native ETH when token==address(0)
+    //   2) _executeSwap caps UniV2/Sushi amountIn at the executor's live balance
+    //   3) coinbase tip falls back to WETH-transfer when block.coinbase rejects ETH
+    // Protocol-constant parity with the Rust ProtocolType enum is sentinel-checked
+    // here; the authoritative discriminant test lives in crates/common (PR2).
+    // =========================================================================
+
+    // Re-declare registry events for vm.expectEmit matching
+    event DexRouterSet(uint8 indexed protocol, address router);
+    event DexEnabledSet(uint8 indexed protocol, bool enabled);
+    event PausedSet(bool paused);
+
+    // -------------------------------------------------------------------------
+    // Registry — setDexRouter
+    // -------------------------------------------------------------------------
+
+    function test_setDexRouter_onlyOwner() public {
+        address intruder = address(0x456);
+        vm.prank(intruder);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, intruder)
+        );
+        executor.setDexRouter(BALANCER_V2, address(0xBEEF));
+    }
+
+    function test_setDexRouter_updatesMappingAndEmits() public {
+        address newVault = address(0xB0B);
+
+        vm.expectEmit(true, false, false, true);
+        emit DexRouterSet(BALANCER_V2, newVault);
+
+        executor.setDexRouter(BALANCER_V2, newVault);
+
+        assertEq(executor.protocolRouter(BALANCER_V2), newVault, "router not updated");
+    }
+
+    function test_setDexRouter_revert_zeroRouter() public {
+        vm.expectRevert(AetherExecutor.ZeroRouter.selector);
+        executor.setDexRouter(BALANCER_V2, address(0));
+    }
+
+    function test_setDexRouter_revert_unknownProtocol() public {
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.UnknownProtocol.selector, uint8(0)));
+        executor.setDexRouter(0, address(0xBEEF));
+
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.UnknownProtocol.selector, uint8(7)));
+        executor.setDexRouter(7, address(0xBEEF));
+    }
+
+    // -------------------------------------------------------------------------
+    // Registry — setDexEnabled
+    // -------------------------------------------------------------------------
+
+    function test_setDexEnabled_onlyOwner() public {
+        address intruder = address(0x456);
+        vm.prank(intruder);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, intruder)
+        );
+        executor.setDexEnabled(CURVE, false);
+    }
+
+    function test_setDexEnabled_togglesAndEmits() public {
+        // Default is true; flip off, then back on. Each transition emits exactly one event.
+        vm.expectEmit(true, false, false, true);
+        emit DexEnabledSet(CURVE, false);
+        executor.setDexEnabled(CURVE, false);
+        assertFalse(executor.protocolEnabled(CURVE), "curve should be disabled");
+
+        vm.expectEmit(true, false, false, true);
+        emit DexEnabledSet(CURVE, true);
+        executor.setDexEnabled(CURVE, true);
+        assertTrue(executor.protocolEnabled(CURVE), "curve should be re-enabled");
+    }
+
+    function test_setDexEnabled_idempotent_noEvent() public {
+        // CURVE defaults to true in the constructor. Writing true again must be a no-op:
+        // no storage write, no event.
+        vm.recordLogs();
+        executor.setDexEnabled(CURVE, true);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "idempotent setDexEnabled must not emit");
+        assertTrue(executor.protocolEnabled(CURVE), "curve still enabled");
+    }
+
+    function test_setDexEnabled_revert_unknownProtocol() public {
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.UnknownProtocol.selector, uint8(0)));
+        executor.setDexEnabled(0, true);
+
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.UnknownProtocol.selector, uint8(7)));
+        executor.setDexEnabled(7, true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Pre-flashloan validation (CRITICAL — disabled/unknown protocol must fail
+    // fast before Aave fires, otherwise we owe premium on a doomed tx)
+    // -------------------------------------------------------------------------
+
+    function test_executeArb_revert_protocolDisabled_preFlashloan() public {
+        // Use a counting Aave pool so we can prove the revert fired BEFORE flashLoanSimple.
+        CountingAavePool countingPool = new CountingAavePool();
+        AetherExecutor gatedExecutor = new AetherExecutor(
+            address(countingPool), address(0xBA12), address(0xBAAC)
+        );
+
+        gatedExecutor.setDexEnabled(CURVE, false);
+
+        // 3-hop arb with CURVE in the middle hop — revert should cite hop-2's protocol.
+        AetherExecutor.SwapStep[] memory steps = new AetherExecutor.SwapStep[](3);
+        steps[0] = AetherExecutor.SwapStep({
+            protocol: UNISWAP_V2,
+            pool: address(0xAA01),
+            tokenIn: address(token),
+            tokenOut: address(token2),
+            amountIn: 1,
+            minAmountOut: 1,
+            data: ""
+        });
+        steps[1] = AetherExecutor.SwapStep({
+            protocol: CURVE,
+            pool: address(0xAA02),
+            tokenIn: address(token2),
+            tokenOut: address(token),
+            amountIn: 1,
+            minAmountOut: 1,
+            data: ""
+        });
+        steps[2] = AetherExecutor.SwapStep({
+            protocol: UNISWAP_V2,
+            pool: address(0xAA03),
+            tokenIn: address(token),
+            tokenOut: address(token2),
+            amountIn: 1,
+            minAmountOut: 1,
+            data: ""
+        });
+
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.ProtocolDisabled.selector, CURVE));
+        gatedExecutor.executeArb(steps, address(token), 1000, block.timestamp + 1000, 0, 0);
+
+        assertEq(countingPool.flashLoanCallCount(), 0, "flashloan must not fire when pre-check rejects");
+    }
+
+    function test_executeArb_revert_unknownProtocol_preFlashloan() public {
+        CountingAavePool countingPool = new CountingAavePool();
+        AetherExecutor gatedExecutor = new AetherExecutor(
+            address(countingPool), address(0xBA12), address(0xBAAC)
+        );
+
+        // protocol = 0 rejected
+        AetherExecutor.SwapStep[] memory stepsZero = new AetherExecutor.SwapStep[](1);
+        stepsZero[0] = AetherExecutor.SwapStep({
+            protocol: 0,
+            pool: address(0xAA01),
+            tokenIn: address(token),
+            tokenOut: address(token2),
+            amountIn: 1,
+            minAmountOut: 1,
+            data: ""
+        });
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.UnknownProtocol.selector, uint8(0)));
+        gatedExecutor.executeArb(stepsZero, address(token), 1000, block.timestamp + 1000, 0, 0);
+
+        // protocol = 7 rejected
+        AetherExecutor.SwapStep[] memory stepsSeven = new AetherExecutor.SwapStep[](1);
+        stepsSeven[0] = AetherExecutor.SwapStep({
+            protocol: 7,
+            pool: address(0xAA01),
+            tokenIn: address(token),
+            tokenOut: address(token2),
+            amountIn: 1,
+            minAmountOut: 1,
+            data: ""
+        });
+        vm.expectRevert(abi.encodeWithSelector(AetherExecutor.UnknownProtocol.selector, uint8(7)));
+        gatedExecutor.executeArb(stepsSeven, address(token), 1000, block.timestamp + 1000, 0, 0);
+
+        assertEq(countingPool.flashLoanCallCount(), 0, "flashloan must not fire on unknown protocol");
+    }
+
+    // -------------------------------------------------------------------------
+    // Pause circuit breaker
+    // -------------------------------------------------------------------------
+
+    function test_setPaused_onlyOwner() public {
+        address intruder = address(0x456);
+        vm.prank(intruder);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, intruder)
+        );
+        executor.setPaused(true);
+    }
+
+    function test_setPaused_emitsEvent_and_idempotent() public {
+        assertFalse(executor.paused(), "starts unpaused");
+
+        // false -> true emits
+        vm.expectEmit(false, false, false, true);
+        emit PausedSet(true);
+        executor.setPaused(true);
+        assertTrue(executor.paused(), "paused after flip");
+
+        // true -> true is a no-op (no event)
+        vm.recordLogs();
+        executor.setPaused(true);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "idempotent setPaused must not emit");
+
+        // true -> false emits
+        vm.expectEmit(false, false, false, true);
+        emit PausedSet(false);
+        executor.setPaused(false);
+        assertFalse(executor.paused(), "unpaused after flip-back");
+    }
+
+    function test_executeArb_revert_whenPaused() public {
+        executor.setPaused(true);
+
+        AetherExecutor.SwapStep[] memory steps = new AetherExecutor.SwapStep[](1);
+        steps[0] = AetherExecutor.SwapStep({
+            protocol: UNISWAP_V2,
+            pool: address(0xAA01),
+            tokenIn: address(token),
+            tokenOut: address(token2),
+            amountIn: 1,
+            minAmountOut: 1,
+            data: ""
+        });
+
+        vm.expectRevert(AetherExecutor.Paused.selector);
+        executor.executeArb(steps, address(token), 1000, block.timestamp + 1000, 0, 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ownable2Step — two-step transfer semantics
+    // -------------------------------------------------------------------------
+
+    function test_twoStep_transfer_requires_acceptance() public {
+        address newOwner = address(0xAAA1);
+
+        // Step 1: nominate
+        executor.transferOwnership(newOwner);
+        assertEq(executor.owner(), owner, "owner unchanged by step 1");
+        assertEq(executor.pendingOwner(), newOwner, "pendingOwner set");
+
+        // Step 2: accept (must be called by nominee)
+        vm.prank(newOwner);
+        executor.acceptOwnership();
+
+        assertEq(executor.owner(), newOwner, "owner updated after acceptance");
+        assertEq(executor.pendingOwner(), address(0), "pendingOwner cleared");
+    }
+
+    function test_acceptOwnership_revert_notPending() public {
+        // No pending transfer in flight — any caller is "not pending".
+        address randomAddr = address(0xD00D);
+        vm.prank(randomAddr);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, randomAddr)
+        );
+        executor.acceptOwnership();
+    }
+
+    // -------------------------------------------------------------------------
+    // Security fix 1 — rescue() handles native ETH
+    // -------------------------------------------------------------------------
+
+    function test_rescue_eth() public {
+        vm.deal(address(executor), 1 ether);
+        assertEq(address(executor).balance, 1 ether);
+
+        uint256 ownerBalBefore = owner.balance;
+        executor.rescue(address(0), 1 ether);
+
+        assertEq(address(executor).balance, 0, "executor should have no ETH left");
+        assertEq(owner.balance - ownerBalBefore, 1 ether, "owner delta must equal rescued ETH");
+    }
+
+    function test_rescue_eth_onlyOwner() public {
+        vm.deal(address(executor), 1 ether);
+        address intruder = address(0x456);
+        vm.prank(intruder);
+        vm.expectRevert(
+            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, intruder)
+        );
+        executor.rescue(address(0), 1 ether);
+    }
+
+    // -------------------------------------------------------------------------
+    // Security fix 2 — _executeSwap caps UniV2/Sushi transfer at live balance
+    //
+    // If the off-chain optimizer over-spec's amountIn, executor must clamp to its
+    // actual balance rather than reverting or transferring more than it owns.
+    // -------------------------------------------------------------------------
+
+    function test_swapUniV2_capsAtBalance_whenAmountInExceedsBalance() public {
+        MockERC20 tokenIn = new MockERC20();
+        MockERC20 tokenOut = new MockERC20();
+
+        // Flash-loan amount = what the executor actually receives from Aave.
+        uint256 flashAmount = 500;
+        // Over-spec: claim we can swap 1000 but only 500 are on-hand.
+        uint256 overSpecAmountIn = 1000;
+
+        uint256 swapOut = 1100;
+        uint256 premium = (flashAmount * 5) / 10000;
+
+        MockV2Pool pool = new MockV2Pool(tokenIn, tokenOut, swapOut);
+        tokenOut.mint(address(pool), swapOut);
+
+        // Return hop converts tokenOut -> tokenIn with enough output to repay + leave profit.
+        uint256 returnAmount = flashAmount + premium + 10;
+        MockV2Pool returnPool = new MockV2Pool(tokenOut, tokenIn, returnAmount);
+        tokenIn.mint(address(returnPool), returnAmount);
+
+        bytes memory swapData = abi.encodeWithSignature(
+            "swap(uint256,uint256,address,bytes)",
+            uint256(0), swapOut, address(executor), ""
+        );
+        bytes memory returnData = abi.encodeWithSignature(
+            "swap(uint256,uint256,address,bytes)",
+            uint256(0), returnAmount, address(executor), ""
+        );
+
+        AetherExecutor.SwapStep[] memory steps = new AetherExecutor.SwapStep[](2);
+        steps[0] = AetherExecutor.SwapStep({
+            protocol: UNISWAP_V2,
+            pool: address(pool),
+            tokenIn: address(tokenIn),
+            tokenOut: address(tokenOut),
+            amountIn: overSpecAmountIn, // 1000 requested, only 500 live
+            minAmountOut: swapOut,
+            data: swapData
+        });
+        steps[1] = AetherExecutor.SwapStep({
+            protocol: UNISWAP_V2,
+            pool: address(returnPool),
+            tokenIn: address(tokenOut),
+            tokenOut: address(tokenIn),
+            amountIn: swapOut,
+            minAmountOut: returnAmount,
+            data: returnData
+        });
+
+        executor.executeArb(steps, address(tokenIn), flashAmount, block.timestamp + 1000, 0, 0);
+
+        // Cap kicked in: pool received the live balance, not the over-spec figure.
+        assertEq(tokenIn.balanceOf(address(pool)), flashAmount, "pool should receive capped (live-balance) amount");
+        assertTrue(flashAmount < overSpecAmountIn, "sanity: over-spec > live balance");
+    }
+
+    // -------------------------------------------------------------------------
+    // Security fix 3 — coinbase tip falls back to WETH on reverting coinbase
+    //
+    // Some builders run contract-coinbases whose receive() reverts. The executor
+    // must recover by re-wrapping the ETH and transferring WETH to the coinbase.
+    // We assert the fallback ran by checking the coinbase's post-tx WETH balance.
+    // -------------------------------------------------------------------------
+
+    function test_coinbaseTip_fallsBackToWeth_onRevertingCoinbase() public {
+        address WETH_ADDR = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        _deployMockWethAt(WETH_ADDR);
+
+        (AetherExecutor wethExecutor, AetherExecutor.SwapStep[] memory steps) =
+            _buildWethArbFixture(WETH_ADDR, 1000);
+
+        // Contract coinbase whose receive() reverts — forces the WETH fallback path.
+        RevertingCoinbase revertingCB = new RevertingCoinbase();
+        vm.coinbase(address(revertingCB));
+
+        vm.deal(WETH_ADDR, 10_000);
+
+        uint256 tipBps = 9000; // tip = 900
+        uint256 expectedTip = 900;
+        uint256 expectedOwner = 100;
+
+        wethExecutor.executeArb(steps, WETH_ADDR, 100_000, block.timestamp + 1000, 0, tipBps);
+
+        // Native ETH transfer to the reverting coinbase must have failed, so executor
+        // re-wrapped and ERC20-transferred WETH instead. Balance proves the fallback ran.
+        assertEq(
+            MockWETH(payable(WETH_ADDR)).balanceOf(address(revertingCB)),
+            expectedTip,
+            "coinbase should receive WETH via fallback"
+        );
+        assertEq(address(revertingCB).balance, 0, "no native ETH should reach reverting coinbase");
+        assertEq(
+            MockWETH(payable(WETH_ADDR)).balanceOf(address(this)),
+            expectedOwner,
+            "owner WETH profit incorrect"
+        );
+        assertEq(
+            MockWETH(payable(WETH_ADDR)).balanceOf(address(wethExecutor)),
+            0,
+            "executor should have zero WETH leftover"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Solidity ↔ Rust invariant sentinel
+    //
+    // The Solidity protocol constants are private, so we can't read them directly.
+    // Instead we assert the constructor-seeded enabled set exactly matches the
+    // expected range [1..=BANCOR_V3]. This is a weak-but-nonzero sentinel; the
+    // authoritative check lives Rust-side in crates/common/src/types.rs (PR2) via
+    // a discriminant-equality test against these same ids.
+    // -------------------------------------------------------------------------
+
+    function test_protocolConstants_implicitlyMatch() public view {
+        // In-range (1..=6) must all be enabled at construction.
+        assertTrue(executor.protocolEnabled(UNISWAP_V2), "UNISWAP_V2 (1)");
+        assertTrue(executor.protocolEnabled(UNISWAP_V3), "UNISWAP_V3 (2)");
+        assertTrue(executor.protocolEnabled(SUSHISWAP), "SUSHISWAP (3)");
+        assertTrue(executor.protocolEnabled(CURVE), "CURVE (4)");
+        assertTrue(executor.protocolEnabled(BALANCER_V2), "BALANCER_V2 (5)");
+        assertTrue(executor.protocolEnabled(BANCOR_V3), "BANCOR_V3 (6)");
+
+        // Out-of-range (0 and >=7) must stay default-false.
+        assertFalse(executor.protocolEnabled(0), "protocol 0 must be disabled");
+        assertFalse(executor.protocolEnabled(7), "protocol 7 must be disabled");
+        assertFalse(executor.protocolEnabled(255), "protocol 255 must be disabled");
     }
 }

--- a/contracts/test/Deploy.t.sol
+++ b/contracts/test/Deploy.t.sol
@@ -19,8 +19,8 @@ contract DeployTest is Test {
     function test_deploy_defaultAavePool() public {
         AetherExecutor executor = deployer.runWithParams(DEFAULT_AAVE_POOL, DEFAULT_BALANCER_VAULT, DEFAULT_BANCOR_NETWORK);
         assertEq(executor.aavePool(), DEFAULT_AAVE_POOL);
-        assertEq(executor.balancerVault(), DEFAULT_BALANCER_VAULT);
-        assertEq(executor.bancorNetwork(), DEFAULT_BANCOR_NETWORK);
+        assertEq(executor.protocolRouter(5), DEFAULT_BALANCER_VAULT); // BALANCER_V2
+        assertEq(executor.protocolRouter(6), DEFAULT_BANCOR_NETWORK); // BANCOR_V3
         assertEq(executor.owner(), tx.origin);
     }
 
@@ -45,7 +45,7 @@ contract DeployCustomPoolTest is Test {
     function test_deploy_customAavePool() public {
         AetherExecutor executor = deployer.runWithParams(CUSTOM_POOL, CUSTOM_VAULT, CUSTOM_BANCOR);
         assertEq(executor.aavePool(), CUSTOM_POOL);
-        assertEq(executor.balancerVault(), CUSTOM_VAULT);
-        assertEq(executor.bancorNetwork(), CUSTOM_BANCOR);
+        assertEq(executor.protocolRouter(5), CUSTOM_VAULT); // BALANCER_V2
+        assertEq(executor.protocolRouter(6), CUSTOM_BANCOR); // BANCOR_V3
     }
 }

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,5 +1,11 @@
 # Aether Incident Response
 
+## Contract ABI Notes (E4/WS-3)
+
+- **Ownership is now two-step (OZ `Ownable2Step`).** Rotating owner requires `transferOwnership(newOwner)` followed by `acceptOwnership()` from `newOwner`. See SEV1 playbook below.
+- **Revert signature change.** The old `NotOwner()` error (selector `0x30cd7471`) is replaced by OZ `OwnableUnauthorizedAccount(address)` (selector `0x118cdaa7`). Any Alertmanager or Loki rules parsing revert data from failed bundles must be updated.
+- **Pause is now a first-class circuit breaker.** `setPaused(true)` from the owner halts `executeArb` without touching ownership. For SEV1 where the owner key is compromised, pause is **not** an option (attacker holds the key); go straight to ownership transfer. For SEV2/SEV3 where the key is safe but execution should stop, `setPaused(true)` is the preferred action.
+
 ## Severity Levels
 
 | Level | Description | Response Time | Examples |
@@ -22,13 +28,28 @@
    sudo systemctl stop aether-go aether-rust
    ```
 
-2. **Revoke contract permissions**
+2. **Revoke contract permissions** (two-step — OZ `Ownable2Step`)
    ```bash
-   # Transfer AetherExecutor ownership to null address
-   # This must be done from the cold wallet (current owner)
-   cast send <EXECUTOR_ADDRESS> "transferOwnership(address)" 0x0000000000000000000000000000000000000001 \
+   # Step A: outgoing owner initiates the transfer (sets pendingOwner).
+   # Use a dedicated incident cold wallet here, not address(1) — address(1)
+   # cannot call acceptOwnership() so the transfer will never complete and
+   # the compromised owner can still cancel by re-calling transferOwnership.
+   cast send <EXECUTOR_ADDRESS> "transferOwnership(address)" <INCIDENT_COLD_WALLET> \
        --private-key <COLD_WALLET_KEY> --rpc-url <RPC_URL>
+
+   # Step B: incoming owner verifies pendingOwner before accepting.
+   cast call <EXECUTOR_ADDRESS> "pendingOwner()(address)" --rpc-url <RPC_URL>
+   # Must equal <INCIDENT_COLD_WALLET>. If not, abort — compromised owner
+   # may have re-pointed the transfer.
+
+   # Step C: incoming owner accepts.
+   cast send <EXECUTOR_ADDRESS> "acceptOwnership()" \
+       --private-key <INCIDENT_COLD_WALLET_KEY> --rpc-url <RPC_URL>
    ```
+   **Note:** passing `address(0)` to `transferOwnership` is now a no-op cancel
+   (clears `pendingOwner`), not a permanent lock. To renounce, use OZ's
+   `renounceOwnership()` — but prefer the two-step transfer to an incident
+   cold wallet so `rescue()` and `setPaused()` remain callable.
 
 3. **Sweep remaining funds from searcher wallet**
    ```bash

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -236,9 +236,7 @@
 
 | Channel | Used For | Configuration |
 |---|---|---|
-| PagerDuty | SEV1, SEV2 | `config/risk.yaml` → `alerting.pagerduty` |
-| Telegram | SEV2, SEV3 | `config/risk.yaml` → `alerting.telegram` |
-| Discord | All severities | `config/risk.yaml` → `alerting.discord` |
+| Slack | All severities | `config/risk.yaml` → `alerting.slack` |
 
 ### Escalation Path
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -283,3 +283,48 @@ curl -s http://localhost:9090/metrics | grep aether_eth_balance
 # Manual sweep is handled by the Go executor
 # Ensure cold wallet address is configured in risk.yaml
 ```
+
+## Adding a DEX
+
+The executor supports two pathways, matched to what's actually changing:
+
+### (a) New instance of an existing protocol
+
+Use this when a protocol ships a new Vault/Router address or we want to point at a fork that reuses the same interface (e.g., a new Balancer Vault deployment, an alternate Bancor network contract).
+
+1. Owner multisig calls `setDexRouter(<protocolId>, <newAddress>)` on the executor.
+   ```bash
+   cast send <EXECUTOR_ADDRESS> "setDexRouter(uint8,address)" <PID> <NEW_ROUTER> \
+       --private-key <OWNER_KEY> --rpc-url <RPC_URL>
+   ```
+   Protocol IDs: `UNISWAP_V2=1, UNISWAP_V3=2, SUSHISWAP=3, CURVE=4, BALANCER_V2=5, BANCOR_V3=6`.
+   Only `5` and `6` currently store a router — the AMM protocols use per-swap pool addresses.
+2. Update `config/pools.toml` with the new instance's pool entries.
+3. Trigger Rust pool registry hot-reload:
+   ```bash
+   grpcurl -plaintext localhost:50051 aether.ControlService/ReloadConfig
+   ```
+4. No redeploy, no downtime.
+
+Disabling a compromised DEX is the same mechanism:
+```bash
+cast send <EXECUTOR_ADDRESS> "setDexEnabled(uint8,bool)" <PID> false \
+    --private-key <OWNER_KEY> --rpc-url <RPC_URL>
+```
+`executeArb` reverts pre-flashloan for any step whose protocol is disabled.
+
+### (b) New protocol type
+
+Use this when adding an AMM with novel swap semantics (e.g., Maverick, a new concentrated-liquidity variant) — the inline `_swapX` branch is hand-coded per protocol type, so a redeploy is unavoidable.
+
+1. Implement the `Pool` trait in `crates/pools/src/<new>.rs`.
+2. Add the event signature to `crates/ingestion/src/event_decoder.rs`.
+3. Add the `ProtocolType` variant with its `uint8` ID and gas estimate in `crates/common/src/types.rs` and `crates/detector/src/gas.rs`.
+4. Add a calldata builder in `crates/simulator/src/calldata.rs`.
+5. Add a `_swap<New>()` helper + branch in `AetherExecutor._executeSwap()`; bump the `UnknownProtocol` upper bound in `executeArb`'s pre-flight loop and in `setDexRouter`/`setDexEnabled`.
+6. Extend the constructor seeding loop so the new protocol is enabled at deploy.
+7. Deploy:
+   ```bash
+   forge script script/Deploy.s.sol --rpc-url $MAINNET_RPC --broadcast
+   ```
+8. Update `EXECUTOR_ADDRESS` env on Rust and Go services, restart both, update `config/pools.toml`.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -284,6 +284,42 @@ curl -s http://localhost:9090/metrics | grep aether_eth_balance
 # Ensure cold wallet address is configured in risk.yaml
 ```
 
+## Emergency Pause
+
+`AetherExecutor.setPaused(bool)` is the fast-path circuit breaker for halting on-chain execution without touching ownership. It is separate from the Rust-side `ControlService/SetState` (which pauses opportunity detection in the Rust core) — pausing the contract stops `executeArb` from executing, while pausing the Rust side stops bundles from being submitted at all. Both may need to be toggled independently.
+
+### Pause execution (owner only)
+
+```bash
+cast send <EXECUTOR_ADDRESS> "setPaused(bool)" true \
+    --private-key <OWNER_KEY> --rpc-url <RPC_URL>
+```
+
+Any `executeArb` call will revert with `Paused()` while the flag is set.
+
+### Resume execution
+
+```bash
+cast send <EXECUTOR_ADDRESS> "setPaused(bool)" false \
+    --private-key <OWNER_KEY> --rpc-url <RPC_URL>
+```
+
+### Verify current state
+
+```bash
+cast call <EXECUTOR_ADDRESS> "paused()(bool)" --rpc-url <RPC_URL>
+```
+
+### Distinction from Rust-side pause
+
+| What it stops | Command |
+|---|---|
+| On-chain `executeArb` (contract layer) | `cast send ... "setPaused(bool)" true` |
+| Bundle submission (Go executor) | `grpcurl ... ControlService/SetState -d '{"state": "PAUSED"}'` |
+| Opportunity detection (Rust core) | `grpcurl ... ControlService/SetState -d '{"state": "PAUSED"}'` |
+
+For a full emergency stop, pause both layers. For MEV-risk scenarios where detection should continue but execution must stop, pause only the contract.
+
 ## Adding a DEX
 
 The executor supports two pathways, matched to what's actually changing:


### PR DESCRIPTION
Resolves the contract half of #72. Engine-side calldata + `EXECUTOR_ADDRESS` env wiring follow in PR2 (#90, stacked on this branch).

## Why this shape, not the UUPS proxy from the issue

Numeric review showed UUPS costs ~2,940 gas/arb (~$0.31 at 30 gwei) — at the project's 10k arbs/day target that's **~$1.13M/yr** of permanent hot-path tax for the benefit of address permanence and atomic upgrades. Monolith + runtime registry gets most of the flexibility (swap router addresses, kill-switch any protocol) at zero runtime tax; the only thing it gives up is adding a genuinely-new AMM *type* without redeploying, which is rare (≤4×/year expected). Full architecture proof in the approved plan.

## Summary

- **DEX registry**: `protocolRouter` + `protocolEnabled` mappings replace the Balancer/Bancor immutables. `aavePool` stays immutable (flash-loan anchor). Owner can swap routers and kill switches without redeploying.
- **Pre-flashloan validation** (CRITICAL): `executeArb` rejects disabled/unknown protocols before `flashLoanSimple` fires — identified by arch review; avoids burning 150-400k gas on a mid-flashloan revert.
- **Ownable2Step**: two-step ownership replaces manual `owner` + `NotOwner()`. Standard (non-upgradeable) OZ. Incident-response runbook updated for the two-tx rotation.
- **Pause**: Go risk manager can trip a circuit breaker without touching ownership.
- **Security fixes** from WS-3.4: coinbase tip WETH re-wrap fallback, ETH rescue via `token == address(0)`, gasleft() snapshot moved into `executeOperation`, UniV2/Sushi transfer cap via `Math.min(amountIn, balanceOf)`.

## Review-round-2 changes

- **HIGH — drop 2300-gas stipend on `block.coinbase.call`.** Contract-coinbases (splitter/forwarder wrappers) consume more than 2300 in normal operation, silently tripping the WETH fallback and losing builder inclusion priority. Reentrancy is already covered by outer `nonReentrant`; the cap was unnecessary. WETH fallback retained for the "coinbase reverts ETH entirely" case.
- **MEDIUM — push-vs-pull asymmetry on live-balance cap clarified.** Round-1 asked for the UniV2/Sushi cap to extend to Curve/Balancer/Bancor. Initial attempt (`e313b77`) capped `forceApprove` on those three, but round-2 review caught that this only moves the revert from `ERC20InsufficientBalance` to `ERC20InsufficientAllowance` — the pool still parses the amount from `step.data` (encoded off-chain). **Final state** (`88773ec`): `forceApprove(step.amountIn)` restored on the three pull-based protocols, NatSpec rewritten to make the push-vs-pull distinction explicit, engine-side live-balance intersection tracked as part of #97 (the same PR that wires the builders). UniV2/Sushi push-side cap is unchanged and correct.
- **MEDIUM — e2e `setDexRouter(BALANCER_V2, newVault)` routing test added.** The central claim of the registry architecture was previously not exercised end-to-end. New `test_setDexRouter_balancerV2_routesToNewVault` deploys two distinct `CountingBalancerVault` mocks, migrates via `setDexRouter`, and asserts the second vault receives the swap and the first does not.
- Refactor: `_isValidProtocol(uint8) internal pure` helper replaces the duplicated range guards in `setDexRouter` / `setDexEnabled` / pre-flashloan validation. Constructor loop keeps explicit bounds.
- Sentinel test hardcodes numeric IDs (1..=6) so it cannot silently pass if the Solidity constants drift.
- `docs/runbook.md` documents `setPaused` with a `cast send` example, noting the distinction vs. Rust `ControlService/SetState`.
- `docs/incident-response.md` alert-channel references changed PagerDuty/Telegram/Discord → Slack (project convention).

## Numbers

- Deployed bytecode: `AetherExecutor` runtime **8,406 B** — 16,170 B under EIP-170.
- Tests: **59 passed / 0 failed** at `--fuzz-runs 10000` (2 fork tests skipped — need live RPC).
- No runtime gas regression on the hot path (registry SLOAD only on Balancer/Bancor steps; worst-case cold ~2,100 gas absorbed by existing `EXECUTOR_OVERHEAD_GAS = 30k`).

## Test plan

- [x] `forge test --fuzz-runs 10000` — 59/0/2 skipped
- [x] `forge build --sizes` — under EIP-170 limit
- [x] `forge test --match-test test_coinbaseTip -vv` — WETH fallback still trips on reverting coinbase
- [x] `forge test --match-test test_swapUniV2_capsAtBalance` — UniV2 push-side cap still passes
- [ ] Anvil fork end-to-end: deploy → `setDexEnabled(CURVE,false)` → assert pre-flashloan revert → re-enable → arb succeeds → `setDexRouter(BALANCER_V2, newVault)` → arb uses new vault (deferred to integration testing — covered by unit-level routing test)

## Out of scope (follow-ups)

- #90: Rust calldata builders for Curve/Balancer/Bancor + `EXECUTOR_ADDRESS` env var loading.
- #97: Wire the three builders into `engine.rs`, add `pool_id: Option<[u8; 32]>` to `SwapStep`, and intersect `amount_in` with live balance engine-side before encoding — this closes the pull-protocol sizing loop authoritatively.