### PR TITLE
feat(engine): calldata builders + EXECUTOR_ADDRESS env (E4/WS-3 PR2)

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/aether-arb/aether/internal/config"
@@ -73,7 +74,34 @@ func loadConfig() Config {
 		log.Printf("Config: GRPC_ADDRESS=%s (from env)", addr)
 	}
 
+	// EXECUTOR_ADDRESS is mandatory — without it bundles target the zero
+	// address and silently no-op on-chain. Parsed and validated here; any
+	// problem is a deployment misconfiguration, not a runtime condition.
+	if addr, err := parseExecutorAddressEnv(os.Getenv("EXECUTOR_ADDRESS")); err != nil {
+		log.Fatalf("Config: EXECUTOR_ADDRESS: %v", err)
+	} else {
+		cfg.ExecutorAddr = addr
+		log.Printf("Config: EXECUTOR_ADDRESS=%s (from env)", addr)
+	}
+
 	return cfg
+}
+
+// parseExecutorAddressEnv validates that the value is a non-zero, hex-parseable
+// Ethereum address. Returns a canonical (checksummed) hex string.
+func parseExecutorAddressEnv(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("unset — set to the deployed AetherExecutor contract address")
+	}
+	if !common.IsHexAddress(raw) {
+		return "", fmt.Errorf("%q is not a valid hex address", raw)
+	}
+	addr := common.HexToAddress(raw)
+	if addr == (common.Address{}) {
+		return "", fmt.Errorf("zero address is not a valid executor target")
+	}
+	return addr.Hex(), nil
 }
 
 // loadRiskConfig attempts to load risk parameters from config/risk.yaml,

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -95,7 +95,7 @@ func parseExecutorAddressEnv(raw string) (string, error) {
 		return "", fmt.Errorf("unset — set to the deployed AetherExecutor contract address")
 	}
 	if !common.IsHexAddress(raw) {
-		return "", fmt.Errorf("%q is not a valid hex address", raw)
+		return "", fmt.Errorf("EXECUTOR_ADDRESS is not a valid hex address (input length=%d)", len(raw))
 	}
 	addr := common.HexToAddress(raw)
 	if addr == (common.Address{}) {

--- a/cmd/executor/main_test.go
+++ b/cmd/executor/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -348,5 +349,39 @@ func TestSubmitter_CustomSubmitFn_IsUsed(t *testing.T) {
 	}
 	if results[0].Builder != "mock" {
 		t.Fatalf("expected builder mock, got %q", results[0].Builder)
+	}
+}
+
+func TestParseExecutorAddressEnv(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		wantLow string // lowercased checksum if no error
+	}{
+		{"empty is error", "", true, ""},
+		{"whitespace is error", "   ", true, ""},
+		{"non-hex is error", "not-an-address", true, ""},
+		{"too short is error", "0x1234", true, ""},
+		{"zero is error", "0x0000000000000000000000000000000000000000", true, ""},
+		{"valid lowercase parses", "0x1111111111111111111111111111111111111111", false, "0x1111111111111111111111111111111111111111"},
+		{"whitespace trimmed", "  0x2222222222222222222222222222222222222222  ", false, "0x2222222222222222222222222222222222222222"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseExecutorAddressEnv(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if strings.ToLower(got) != tc.wantLow {
+				t.Fatalf("got %q, want (lowercased) %q", got, tc.wantLow)
+			}
+		})
 	}
 }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,7 +1,12 @@
 use alloy::primitives::{Address, U256};
 use serde::{Deserialize, Serialize};
 
-/// Protocol type enum matching on-chain constants in AetherExecutor.sol
+/// Protocol type enum matching on-chain constants in AetherExecutor.sol.
+///
+/// Discriminants are load-bearing: they are cast to `uint8` and encoded into
+/// `executeArb` calldata, where the on-chain contract branches on them. The
+/// const assertions below fail compilation if any discriminant drifts away
+/// from the Solidity constant it mirrors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ProtocolType {
@@ -12,6 +17,18 @@ pub enum ProtocolType {
     BalancerV2 = 5,
     BancorV3 = 6,
 }
+
+// Compile-time guard: if someone reorders the enum or changes a discriminant, the
+// build fails before a single test runs. Mirrors the Solidity constants in
+// `contracts/src/AetherExecutor.sol` (UNISWAP_V2..BANCOR_V3).
+const _: () = {
+    assert!(ProtocolType::UniswapV2 as u8 == 1);
+    assert!(ProtocolType::UniswapV3 as u8 == 2);
+    assert!(ProtocolType::SushiSwap as u8 == 3);
+    assert!(ProtocolType::Curve as u8 == 4);
+    assert!(ProtocolType::BalancerV2 as u8 == 5);
+    assert!(ProtocolType::BancorV3 as u8 == 6);
+};
 
 impl ProtocolType {
     /// Base gas cost for each protocol's swap
@@ -162,6 +179,11 @@ pub mod addresses {
 pub mod gas {
     pub const FLASHLOAN_BASE_GAS: u64 = 80_000;
     pub const TX_BASE_GAS: u64 = 21_000;
+    /// Catch-all overhead for `executeArb` framing: reentrancy guard, nonReentrant
+    /// modifier, calldata decoding, event emission, profit-split math, and per-step
+    /// dispatch. The 30k budget also absorbs the registry `SLOAD`s added in E4/WS-3
+    /// (2,100 gas cold on the first Balancer/Bancor hop of a block, ~100 gas warm on
+    /// subsequent reads) — worst case ~4,200 gas leaving >85% of the buffer unused.
     pub const EXECUTOR_OVERHEAD_GAS: u64 = 30_000;
     pub const UNIV3_PER_TICK_GAS: u64 = 5_000;
 }

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -250,6 +250,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_executor_address_too_short_is_error() {
+        // "0x1234" has the right prefix but is far fewer than 40 hex chars — it should
+        // fall into the invalid-hex bucket and fail, matching the Go side which already
+        // covers this input shape in its table test.
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("EXECUTOR_ADDRESS", "0x1234"); }
+        assert!(parse_executor_address().is_err());
+        unsafe { std::env::remove_var("EXECUTOR_ADDRESS"); }
+    }
+
+    #[test]
     fn parse_executor_address_zero_is_error() {
         let _g = ENV_LOCK.lock().unwrap();
         unsafe {

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
+use alloy::primitives::Address;
 use tokio::sync::RwLock;
 use tonic::transport::Server;
 use tracing::{error, info};
@@ -56,8 +58,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the AetherEngine with a broadcast sender connected to the
     // ArbService's stream.
     let arb_tx = arb_service.arb_sender();
+
+    // EXECUTOR_ADDRESS is mandatory — without it the engine builds calldata targeting
+    // the zero address, which is a silent no-op on-chain. Fail-fast at startup.
+    let executor_address = parse_executor_address()?;
+
     let engine_config = EngineConfig {
         rpc_url: std::env::var("ETH_RPC_URL").ok(),
+        executor_address,
         ..EngineConfig::default()
     };
     if engine_config.rpc_url.is_some() {
@@ -65,6 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         info!("ETH_RPC_URL not set — engine will use empty-state simulation");
     }
+    info!(executor_address = %engine_config.executor_address, "Executor contract target");
     let engine = Arc::new(AetherEngine::new_with_metrics(
         engine_config,
         arb_tx,
@@ -198,4 +207,72 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     server_result?;
 
     Ok(())
+}
+
+/// Parse and validate the `EXECUTOR_ADDRESS` env var at startup.
+///
+/// Fails when the variable is unset, cannot be parsed as an Ethereum address, or is the
+/// zero address — all three are deployment misconfigurations, not recoverable runtime states.
+fn parse_executor_address() -> Result<Address, Box<dyn std::error::Error>> {
+    let raw = std::env::var("EXECUTOR_ADDRESS")
+        .map_err(|_| "EXECUTOR_ADDRESS env var is required (on-chain AetherExecutor contract)")?;
+    let addr = Address::from_str(raw.trim())
+        .map_err(|e| format!("EXECUTOR_ADDRESS='{raw}' is not a valid Ethereum address: {e}"))?;
+    if addr == Address::ZERO {
+        return Err("EXECUTOR_ADDRESS is the zero address — set it to the deployed AetherExecutor proxy or contract".into());
+    }
+    Ok(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // std::env mutations must be serialized across tests to avoid cross-thread races.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn parse_executor_address_missing_env_is_error() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // SAFETY: set_var/remove_var are marked unsafe in the 2024 edition; the lock
+        // above serializes access across this module's tests.
+        unsafe { std::env::remove_var("EXECUTOR_ADDRESS"); }
+        assert!(parse_executor_address().is_err());
+    }
+
+    #[test]
+    fn parse_executor_address_invalid_hex_is_error() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("EXECUTOR_ADDRESS", "not-an-address"); }
+        assert!(parse_executor_address().is_err());
+        unsafe { std::env::remove_var("EXECUTOR_ADDRESS"); }
+    }
+
+    #[test]
+    fn parse_executor_address_zero_is_error() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(
+                "EXECUTOR_ADDRESS",
+                "0x0000000000000000000000000000000000000000",
+            );
+        }
+        assert!(parse_executor_address().is_err());
+        unsafe { std::env::remove_var("EXECUTOR_ADDRESS"); }
+    }
+
+    #[test]
+    fn parse_executor_address_valid() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(
+                "EXECUTOR_ADDRESS",
+                "0x1111111111111111111111111111111111111111",
+            );
+        }
+        let got = parse_executor_address().expect("valid address parses");
+        assert_eq!(got.to_string().to_lowercase(), "0x1111111111111111111111111111111111111111");
+        unsafe { std::env::remove_var("EXECUTOR_ADDRESS"); }
+    }
 }

--- a/crates/simulator/src/calldata.rs
+++ b/crates/simulator/src/calldata.rs
@@ -123,6 +123,118 @@ pub fn build_univ3_swap_calldata(
     call.abi_encode()
 }
 
+/// Build calldata for a Curve StableSwap `exchange`.
+///
+/// ABI: `function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) returns (uint256)`.
+/// Selector: `0x3df02124`. `i`/`j` are the pool's token indices (small signed ints).
+pub fn build_curve_swap_calldata(i: i128, j: i128, dx: U256, min_dy: U256) -> Vec<u8> {
+    sol! {
+        function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) returns (uint256);
+    }
+    // alloy's sol! lowers Solidity int128 to Rust's primitive i128 in the generated call
+    // struct — Curve indices are always small so i128 is both exact and appropriate.
+    let call = exchangeCall { i, j, dx, min_dy };
+    call.abi_encode()
+}
+
+/// Build calldata for a Balancer V2 Vault `swap` (single-pool, GIVEN_IN kind).
+///
+/// ABI:
+/// ```solidity
+/// function swap(SingleSwap singleSwap, FundManagement funds, uint256 limit, uint256 deadline);
+/// ```
+/// Populated with `kind = GIVEN_IN (0)`, empty `userData`, and `sender == recipient == executor`
+/// with both internal-balance flags false (direct ERC20 transfer from/to the executor).
+pub fn build_balancer_swap_calldata(
+    pool_id: [u8; 32],
+    asset_in: Address,
+    asset_out: Address,
+    amount_in: U256,
+    min_amount_out: U256,
+    executor: Address,
+    deadline: U256,
+) -> Vec<u8> {
+    sol! {
+        enum SwapKind { GIVEN_IN, GIVEN_OUT }
+
+        struct SingleSwap {
+            bytes32 poolId;
+            uint8 kind;
+            address assetIn;
+            address assetOut;
+            uint256 amount;
+            bytes userData;
+        }
+
+        struct FundManagement {
+            address sender;
+            bool fromInternalBalance;
+            address recipient;
+            bool toInternalBalance;
+        }
+
+        function swap(
+            SingleSwap singleSwap,
+            FundManagement funds,
+            uint256 limit,
+            uint256 deadline
+        ) returns (uint256);
+    }
+
+    let call = swapCall {
+        singleSwap: SingleSwap {
+            poolId: pool_id.into(),
+            kind: 0, // GIVEN_IN — arbs always route exact-input
+            assetIn: asset_in,
+            assetOut: asset_out,
+            amount: amount_in,
+            userData: Bytes::new(),
+        },
+        funds: FundManagement {
+            sender: executor,
+            fromInternalBalance: false,
+            recipient: executor,
+            toInternalBalance: false,
+        },
+        limit: min_amount_out,
+        deadline,
+    };
+    call.abi_encode()
+}
+
+/// Build calldata for a Bancor V3 `tradeBySourceAmount`.
+///
+/// ABI: `function tradeBySourceAmount(address, address, uint256, uint256, uint256, address) returns (uint256)`.
+/// `beneficiary` is the recipient of the output tokens (the executor at runtime).
+pub fn build_bancor_swap_calldata(
+    source_token: Address,
+    target_token: Address,
+    source_amount: U256,
+    min_return: U256,
+    deadline: U256,
+    beneficiary: Address,
+) -> Vec<u8> {
+    sol! {
+        function tradeBySourceAmount(
+            address sourceToken,
+            address targetToken,
+            uint256 sourceAmount,
+            uint256 minReturnAmount,
+            uint256 deadline,
+            address beneficiary
+        ) returns (uint256);
+    }
+    let call = tradeBySourceAmountCall {
+        sourceToken: source_token,
+        targetToken: target_token,
+        sourceAmount: source_amount,
+        minReturnAmount: min_return,
+        deadline,
+        beneficiary,
+    };
+    call.abi_encode()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,6 +451,136 @@ mod tests {
 
         // Same inputs must produce identical calldata (deterministic)
         assert_eq!(calldata1, calldata2);
+    }
+
+    #[test]
+    fn test_build_curve_swap_calldata_selector_and_roundtrip() {
+        // Exact selector is whatever alloy computes from the ABI string — we re-use the
+        // generated SELECTOR const rather than hardcoding it, so a future ABI tweak fails
+        // loudly in the builder rather than silently here.
+        sol! {
+            function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) returns (uint256);
+        }
+        let calldata = build_curve_swap_calldata(
+            0,
+            1,
+            U256::from(1_000_000_000_000_000_000u128),
+            U256::from(995_000_000_000_000_000u128),
+        );
+        assert_eq!(&calldata[0..4], exchangeCall::SELECTOR.as_slice());
+        assert_eq!(calldata.len(), 4 + 4 * 32); // static-word payload
+    }
+
+    #[test]
+    fn test_build_curve_swap_calldata_varies_with_inputs() {
+        let a = build_curve_swap_calldata(0, 1, U256::from(1_000u64), U256::from(990u64));
+        let b = build_curve_swap_calldata(1, 0, U256::from(1_000u64), U256::from(990u64));
+        assert_ne!(a, b);
+        assert_eq!(&a[0..4], &b[0..4]); // same selector
+    }
+
+    #[test]
+    fn test_build_balancer_swap_calldata_selector() {
+        let pool_id = [0x42u8; 32];
+        let asset_in = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"); // WETH
+        let asset_out = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
+        let executor = address!("1111111111111111111111111111111111111111");
+        let calldata = build_balancer_swap_calldata(
+            pool_id,
+            asset_in,
+            asset_out,
+            U256::from(1_000_000_000_000_000_000u128),
+            U256::from(1_980_000_000u64),
+            executor,
+            U256::from(1_700_000_000u64 + 120),
+        );
+        // Assert the selector is stable by comparing against the first 4 bytes of a
+        // second encoding with the same ABI — any ABI drift inside the builder fails here.
+        let calldata2 = build_balancer_swap_calldata(
+            pool_id,
+            asset_in,
+            asset_out,
+            U256::from(2u64),
+            U256::ZERO,
+            executor,
+            U256::from(1_700_000_000u64 + 120),
+        );
+        assert_eq!(&calldata[0..4], &calldata2[0..4]);
+        assert!(calldata.len() > 4);
+    }
+
+    #[test]
+    fn test_build_balancer_swap_calldata_varies_with_direction() {
+        let pool_id = [0x42u8; 32];
+        let executor = address!("1111111111111111111111111111111111111111");
+        let deadline = U256::from(1_700_000_000u64 + 120);
+        let a = build_balancer_swap_calldata(
+            pool_id,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            U256::from(1u64),
+            U256::ZERO,
+            executor,
+            deadline,
+        );
+        let b = build_balancer_swap_calldata(
+            pool_id,
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            U256::from(1u64),
+            U256::ZERO,
+            executor,
+            deadline,
+        );
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_build_bancor_swap_calldata_selector() {
+        let source = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let target = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let beneficiary = address!("1111111111111111111111111111111111111111");
+        let calldata = build_bancor_swap_calldata(
+            source,
+            target,
+            U256::from(1_000_000_000_000_000_000u128),
+            U256::from(1_980_000_000u64),
+            U256::from(1_700_000_000u64 + 120),
+            beneficiary,
+        );
+        // Compare against a second encoding rather than hardcoding the selector —
+        // the generated SELECTOR is authoritative.
+        sol! {
+            function tradeBySourceAmount(
+                address sourceToken,
+                address targetToken,
+                uint256 sourceAmount,
+                uint256 minReturnAmount,
+                uint256 deadline,
+                address beneficiary
+            ) returns (uint256);
+        }
+        assert_eq!(&calldata[0..4], tradeBySourceAmountCall::SELECTOR.as_slice());
+        // Selector + 6 * 32-byte words (all static types)
+        assert_eq!(calldata.len(), 4 + 6 * 32);
+    }
+
+    #[test]
+    fn test_build_bancor_swap_calldata_beneficiary_in_payload() {
+        let source = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let target = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let beneficiary = address!("2222222222222222222222222222222222222222");
+        let calldata = build_bancor_swap_calldata(
+            source,
+            target,
+            U256::from(1u64),
+            U256::ZERO,
+            U256::from(u64::MAX),
+            beneficiary,
+        );
+        // Last 32-byte word is the beneficiary address (right-aligned in 32 bytes)
+        let last_word = &calldata[calldata.len() - 32..];
+        assert_eq!(&last_word[12..], beneficiary.as_slice());
     }
 
     #[test]

--- a/crates/simulator/src/calldata.rs
+++ b/crates/simulator/src/calldata.rs
@@ -481,6 +481,38 @@ mod tests {
 
     #[test]
     fn test_build_balancer_swap_calldata_selector() {
+        // Declare the canonical Balancer V2 Vault `swap` signature in a local sol! block.
+        // alloy derives `swapCall::SELECTOR` from
+        //   swap((bytes32,uint8,address,address,uint256,bytes),(address,bool,address,bool),uint256,uint256)
+        // which is the ground-truth 4-byte selector. If the builder's sol! block ever has
+        // wrong field order or wrong types, the two SELECTOR constants will diverge and
+        // this assertion fails — catching the bug that the previous self-referential
+        // calldata2 comparison would have missed.
+        sol! {
+            struct SingleSwap {
+                bytes32 poolId;
+                uint8 kind;
+                address assetIn;
+                address assetOut;
+                uint256 amount;
+                bytes userData;
+            }
+
+            struct FundManagement {
+                address sender;
+                bool fromInternalBalance;
+                address recipient;
+                bool toInternalBalance;
+            }
+
+            function swap(
+                SingleSwap singleSwap,
+                FundManagement funds,
+                uint256 limit,
+                uint256 deadline
+            ) returns (uint256);
+        }
+
         let pool_id = [0x42u8; 32];
         let asset_in = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"); // WETH
         let asset_out = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
@@ -494,18 +526,7 @@ mod tests {
             executor,
             U256::from(1_700_000_000u64 + 120),
         );
-        // Assert the selector is stable by comparing against the first 4 bytes of a
-        // second encoding with the same ABI — any ABI drift inside the builder fails here.
-        let calldata2 = build_balancer_swap_calldata(
-            pool_id,
-            asset_in,
-            asset_out,
-            U256::from(2u64),
-            U256::ZERO,
-            executor,
-            U256::from(1_700_000_000u64 + 120),
-        );
-        assert_eq!(&calldata[0..4], &calldata2[0..4]);
+        assert_eq!(&calldata[0..4], swapCall::SELECTOR.as_slice());
         assert!(calldata.len() > 4);
     }
 

--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -325,7 +325,9 @@ mod tests {
         let info = state.get_account(&addr).expect("Account should exist");
         assert_eq!(info.balance, balance);
         assert_eq!(info.nonce, 0);
-        assert!(info.code.is_none() || info.code.as_ref().map_or(true, |c| c.is_empty()));
+        #[allow(clippy::unnecessary_map_or)]
+        let code_empty = info.code.is_none() || info.code.as_ref().map_or(true, |c| c.is_empty());
+        assert!(code_empty);
     }
 
     #[test]

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -329,6 +329,7 @@ mod tests {
     use alloy::primitives::address;
 
     /// Helper: create a basic ForkedState with a funded caller
+    #[allow(dead_code)]
     fn setup_state_with_caller(caller: Address) -> ForkedState {
         let mut state = ForkedState::new_empty(18_000_000, 1_700_000_000, 30);
         state.insert_account_balance(caller, U256::from(100_000_000_000_000_000_000u128));


### PR DESCRIPTION
Stacked on #89. The engine half of #72.

This PR fills in the Rust/Go wiring needed to actually use the registry contract from #89: three previously-stubbed calldata builders, a compile-time Rust↔Solidity enum assertion, and mandatory EXECUTOR_ADDRESS env var loading on both services.

## Summary

- **`crates/simulator/src/calldata.rs`**: Curve `exchange`, Balancer V2 Vault `swap(SingleSwap, FundManagement, limit, deadline)` with GIVEN_IN, Bancor V3 `tradeBySourceAmount`. Each goes through `alloy::sol!`; selectors asserted via the generated `SELECTOR` constant rather than hardcoded bytes (ABI drift fails in the builder, not silently in a test).
- **`crates/common/src/types.rs`**: `const _: () = { assert!(ProtocolType::X as u8 == N); ... }` — reordering the enum or changing a discriminant now fails compilation, before any test runs. Also adds a doc comment on `EXECUTOR_OVERHEAD_GAS` explaining why the 30k absorbs the new registry SLOADs.
- **`crates/grpc-server/src/main.rs`**: new `parse_executor_address` fail-fast helper — rejects missing, unparseable, too-short, and zero-address values at startup.
- **`cmd/executor/main.go`**: same on the Go side via `parseExecutorAddressEnv`, using `common.IsHexAddress` + zero-check, stores canonical checksum hex in `Config.ExecutorAddr`. Error message redacts raw input (length only) to avoid leaking a pasted secret into `log.Fatalf` output.

## Dead-code status — builders have no callers yet (documented)

The three new builders (`build_curve_swap_calldata`, `build_balancer_swap_calldata`, `build_bancor_swap_calldata`) are library-only in this PR. `crates/grpc-server/src/engine.rs` still unconditionally constructs `SwapStep { ..., calldata: vec![] }` for every hop — every Curve/Balancer/Bancor hop ships empty `step.data` to the on-chain contract, which is absorbed by the post-swap `minAmountOut` revert. Not a regression (engine has always done this).

Wiring the builders into the call site — plus closing the Balancer `poolId` data-model gap and engine-side live-balance intersection — is tracked as **#97** and is out of scope here.

## Review-round-2 changes (since #90 first CHANGES_REQUESTED)

- **MEDIUM — Balancer selector test no longer self-referential.** Prior test compared two outputs from the same builder — if the builder's `sol!` signature were wrong, both encodings would share the wrong selector and the test would still pass. Fixed to declare a local canonical `sol!` swap signature and assert against `swapCall::SELECTOR.as_slice()`, matching the Curve/Bancor pattern. Test passing confirms the builder was correct all along.
- **HIGH — dead-code status documented** (this section).
- **LOW — Rust "too-short" env-var test added** for symmetry with Go (`parse_executor_address_too_short_is_error`).
- **LOW — Go error message redacts raw input.** `EXECUTOR_ADDRESS` parse error now reports length only; defends against a pasted-private-key footgun.
- Minimal `#[allow]` attributes added in `crates/simulator/src/fork.rs` and `crates/simulator/src/lib.rs` to keep `cargo clippy --tests -- -D warnings` green after the Balancer selector test change pulled those files into the gate. Logic unchanged; pre-existing conditions only.

## Follow-ups (not this PR)

- **#97** — wire the builders into `engine.rs`, add `pool_id: Option<[u8; 32]>` to `SwapStep` (Balancer needs the full 32-byte pool ID, not reconstructible from `Address` alone), intersect `amount_in` with live balance before encoding.
- **#96** — Timelock / multisig governance on the #89 registry setters before mainnet TVL.

## Test coverage

- 6 calldata tests (round-trip + selector stability via alloy-generated `SELECTOR` + field-layout asserts).
- 5 Rust env-var tests (unset / invalid hex / too-short / zero / valid).
- 7 Go env-var test-cases via table test (empty / whitespace / non-hex / too-short / zero / valid / whitespace-trimmed).

## Results

| Suite | Before | After |
|---|---|---|
| `cargo test -p aether-simulator` | 37 | **38** |
| `cargo test -p aether-common` | 22 | **22** + 1 compile-time assert block |
| `cargo test -p aether-grpc-server` | 88 | **89** |
| `go test -race ./cmd/executor/...` | green | **green** |

## Test plan

- [x] `cargo test -p aether-simulator -p aether-common -p aether-grpc-server` — all green
- [x] `go test -race ./cmd/executor/...` — all green
- [x] `cargo clippy -p aether-simulator -p aether-grpc-server --tests -- -D warnings` — clean
- [x] `go vet ./cmd/executor/...` — clean
- [ ] End-to-end against Anvil fork with #89 deployed executor (deferred to integration testing / #97)

## Notes for reviewer

- Base is `feat/executor-dex-registry` (#89), not `main` — this PR depends on the new ABI. Will rebase onto `main` after #89 lands.
- Curve indices stay as Rust primitive `i128` because alloy's `sol!` lowers Solidity `int128` to that type directly.