### PR TITLE
fix(replay): deploy AetherExecutor to Anvil fork in e2e script

### DIFF
--- a/scripts/historical_replay_e2e.sh
+++ b/scripts/historical_replay_e2e.sh
@@ -14,18 +14,31 @@ set -euo pipefail
 #
 # Usage:
 #   ./scripts/historical_replay_e2e.sh --block 24643151
+#   ./scripts/historical_replay_e2e.sh --blocks 24643151,24643160,24643170
+#   ./scripts/historical_replay_e2e.sh --blocks-file /tmp/blocks.txt
 #   KEEP_RUNNING=1 ./scripts/historical_replay_e2e.sh --block 24643151
 #       (leaves pipeline up after replay so you can open Grafana)
+#
+# Batch mode: each block runs through its own Anvil fork + fresh stack;
+# preflight and build run once. A combined summary table prints at the end.
 #
 # Requires: anvil, cargo, go, curl, ETH_RPC_URL set in .env or environment.
 
 # ── Args ────────────────────────────────────────────────────────────────
 
-BLOCK=""
+BLOCKS=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --block) BLOCK="$2"; shift 2 ;;
-        --block=*) BLOCK="${1#*=}"; shift ;;
+        --block)       BLOCKS+=("$2"); shift 2 ;;
+        --block=*)     BLOCKS+=("${1#*=}"); shift ;;
+        --blocks)      IFS=',' read -ra _b <<< "$2"; BLOCKS+=("${_b[@]}"); shift 2 ;;
+        --blocks=*)    IFS=',' read -ra _b <<< "${1#*=}"; BLOCKS+=("${_b[@]}"); shift ;;
+        --blocks-file)
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+                BLOCKS+=("$(echo "$line" | tr -d '[:space:]')")
+            done < "$2"
+            shift 2 ;;
         -h|--help)
             grep -E '^#( |$)' "$0" | sed 's/^# \?//' | head -30
             exit 0
@@ -34,8 +47,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [ -z "$BLOCK" ]; then
-    echo "Missing --block N" >&2
+if [ ${#BLOCKS[@]} -eq 0 ]; then
+    echo "Missing --block N, --blocks N,N,N, or --blocks-file PATH" >&2
     exit 2
 fi
 
@@ -207,6 +220,33 @@ for bin in "$AETHER_RUST" "$AETHER_REPLAY" "$AETHER_EXECUTOR"; do
         exit 1
     fi
 done
+
+# ── Per-block loop ──────────────────────────────────────────────────────
+#
+# Each block needs its own Anvil fork at `block-1`; we cannot share state
+# across blocks because `anvil_reset` would jump aether-rust's subscribed
+# chain head backwards, which aether-rust has no reorg-rewind for. Between
+# blocks we tear down Anvil / rust / executor and stand them back up.
+
+ALL_BLOCKS=(); ALL_CYCLES=(); ALL_SIMS=(); ALL_ARBS=(); ALL_SHADOW=(); ALL_RISK=()
+ALL_DURATION=(); ALL_DETECT=(); ALL_SIM_MEAN=(); ALL_E2E=(); ALL_GROUND=(); ALL_HIT=()
+
+kill_stack() {
+    for pid in $EXECUTOR_PID $RUST_PID $ANVIL_PID; do
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+        fi
+    done
+    wait 2>/dev/null || true
+    for port in $ANVIL_PORT $GRPC_PORT $RUST_METRICS_PORT $GO_METRICS_PORT $DASHBOARD_PORT; do
+        kill_port "$port"
+    done
+    ANVIL_PID=""; RUST_PID=""; EXECUTOR_PID=""
+}
+
+for BLOCK in "${BLOCKS[@]}"; do
+
+log_step "Block $BLOCK — starting stack"
 
 # ── Phase 2: Spawn Anvil at block-1 ─────────────────────────────────────
 
@@ -555,3 +595,60 @@ print("  Inspect any bundle:  jq . {}/<arb_id>.json".format(bundles_dir))
 PY
 
 log_ok "E2E replay completed successfully (shadow mode held; no real submissions)"
+
+# Capture per-block totals for the batch summary before tearing down.
+ALL_BLOCKS+=("$BLOCK")
+ALL_CYCLES+=("$PEAK_CYCLES")
+ALL_SIMS+=("$PEAK_SIMS")
+ALL_ARBS+=("$PEAK_ARBS")
+ALL_SHADOW+=("$PEAK_SHADOW")
+ALL_RISK+=("$PEAK_RISK_REJ")
+ALL_DURATION+=("$DURATION")
+ALL_DETECT+=("$DETECT_MEAN")
+ALL_SIM_MEAN+=("$SIM_MEAN")
+ALL_E2E+=("$E2E_MEAN")
+
+# Stand down this block's stack before the next iteration. On the last
+# block the cleanup trap at EXIT would do it anyway, but running it here
+# explicitly keeps KEEP_RUNNING=1 honoring "leave the *last* block's stack
+# up for Grafana inspection" rather than every block's.
+# Note: ${BLOCKS[${#BLOCKS[@]}-1]} not ${BLOCKS[-1]} because macOS ships
+# bash 3.2, which doesn't support negative array subscripts.
+LAST_IDX=$(( ${#BLOCKS[@]} - 1 ))
+if [ "$BLOCK" != "${BLOCKS[$LAST_IDX]}" ]; then
+    log_warn "Block $BLOCK done — tearing down stack before next block"
+    kill_stack
+    sleep 2
+fi
+
+done  # ── end per-block loop ─────────────────────────────────────────────
+
+# ── Batch summary ───────────────────────────────────────────────────────
+
+if [ ${#ALL_BLOCKS[@]} -gt 1 ]; then
+    echo ""
+    echo -e "${BOLD}====================================================================${NC}"
+    echo -e "${BOLD}  BATCH SUMMARY — ${#ALL_BLOCKS[@]} blocks                              ${NC}"
+    echo -e "${BOLD}====================================================================${NC}"
+    printf "  %-12s %7s %6s %6s %7s %7s %7s %7s %8s\n" \
+        "Block" "Dur(s)" "Cycles" "Sims" "Arbs" "Shadow" "Det(ms)" "Sim(ms)" "E2E(ms)"
+    for i in "${!ALL_BLOCKS[@]}"; do
+        printf "  %-12s %7s %6s %6s %7s %7s %7s %7s %8s\n" \
+            "${ALL_BLOCKS[$i]}" "${ALL_DURATION[$i]}" "${ALL_CYCLES[$i]}" \
+            "${ALL_SIMS[$i]}" "${ALL_ARBS[$i]}" "${ALL_SHADOW[$i]}" \
+            "${ALL_DETECT[$i]}" "${ALL_SIM_MEAN[$i]}" "${ALL_E2E[$i]}"
+    done
+    # Column totals (duration / cycles / sims / arbs / shadow). Latencies
+    # aren't summed — they're per-block means.
+    TOTAL_DUR=0; TOTAL_CYC=0; TOTAL_SIM=0; TOTAL_ARB=0; TOTAL_SHAD=0
+    for i in "${!ALL_BLOCKS[@]}"; do
+        TOTAL_DUR=$((TOTAL_DUR + ALL_DURATION[i]))
+        TOTAL_CYC=$((TOTAL_CYC + ALL_CYCLES[i]))
+        TOTAL_SIM=$((TOTAL_SIM + ALL_SIMS[i]))
+        TOTAL_ARB=$((TOTAL_ARB + ALL_ARBS[i]))
+        TOTAL_SHAD=$((TOTAL_SHAD + ALL_SHADOW[i]))
+    done
+    printf "  %-12s %7s %6s %6s %7s %7s\n" "TOTAL" "$TOTAL_DUR" \
+        "$TOTAL_CYC" "$TOTAL_SIM" "$TOTAL_ARB" "$TOTAL_SHAD"
+    echo -e "${BOLD}====================================================================${NC}"
+fi

--- a/scripts/historical_replay_e2e.sh
+++ b/scripts/historical_replay_e2e.sh
@@ -167,7 +167,7 @@ if [ -z "${ETH_RPC_URL:-}" ]; then
     exit 1
 fi
 
-for cmd in anvil cargo go curl lsof; do
+for cmd in anvil cargo go curl lsof forge cast; do
     if ! command -v "$cmd" &>/dev/null; then
         log_error "Missing tool: $cmd"
         exit 1
@@ -253,6 +253,73 @@ wait_for_port "$GRPC_PORT" "Rust gRPC" 30
 wait_for_port "$RUST_METRICS_PORT" "Rust metrics" 15
 log_ok "aether-rust running (PID $RUST_PID)"
 
+# ── Phase 3.5: Deploy AetherExecutor to the Anvil fork ──────────────────
+#
+# The Go executor's startup validation (executor.yaml) requires
+# AETHER_EXECUTOR_ADDRESS to point at a contract with real bytecode on the
+# connected node. Our node here is Anvil forked at BLOCK-1, so the mainnet
+# deployment doesn't exist yet on this fork. Deploy a fresh copy using the
+# deployer account (STAGING_KEY — Anvil account 0) so the address is
+# deterministic across runs of the same fork block.
+
+log_step "Phase 3.5: Deploy AetherExecutor to Anvil fork"
+
+# The STAGING_KEY address takes on its real mainnet balance when Anvil forks,
+# which is effectively zero. Top it up to 10,000 ETH via anvil_setBalance so
+# forge script can actually broadcast the deploy.
+STAGING_ADDR=$(cast wallet address --private-key "$STAGING_KEY")
+curl -sf -X POST -H "Content-Type: application/json" \
+    --data "{\"jsonrpc\":\"2.0\",\"method\":\"anvil_setBalance\",\"params\":[\"$STAGING_ADDR\",\"0x21e19e0c9bab2400000\"],\"id\":1}" \
+    "$ANVIL_RPC" > /dev/null || {
+        log_error "anvil_setBalance RPC call failed"
+        exit 1
+    }
+log_info "Funded $STAGING_ADDR with 10000 ETH on the fork"
+
+DEPLOY_LOG="$LOG_DIR/deploy.log"
+(
+    cd "$PROJECT_ROOT/contracts"
+    forge script script/Deploy.s.sol \
+        --rpc-url "$ANVIL_RPC" \
+        --private-key "$STAGING_KEY" \
+        --broadcast \
+        > "$DEPLOY_LOG" 2>&1
+) || true
+
+AETHER_EXECUTOR_ADDRESS=$(grep "AetherExecutor deployed at:" "$DEPLOY_LOG" | awk '{print $NF}' | tail -1)
+if [ -z "$AETHER_EXECUTOR_ADDRESS" ]; then
+    log_warn "forge script did not print an address; falling back to forge create"
+    FALLBACK_LOG="$LOG_DIR/deploy_fallback.log"
+    (
+        cd "$PROJECT_ROOT/contracts"
+        forge create \
+            --rpc-url "$ANVIL_RPC" \
+            --private-key "$STAGING_KEY" \
+            --broadcast \
+            "src/AetherExecutor.sol:AetherExecutor" \
+            --constructor-args \
+                "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2" \
+                "0xBA12222222228d8Ba445958a75a0704d566BF2C8" \
+                "0xeEF417e1D5CC832e619ae18D2F140De2999dD4fB" \
+            > "$FALLBACK_LOG" 2>&1
+    ) || true
+    AETHER_EXECUTOR_ADDRESS=$(grep -E "Deployed to:" "$FALLBACK_LOG" | awk '{print $3}')
+fi
+
+if [ -z "$AETHER_EXECUTOR_ADDRESS" ]; then
+    log_error "Failed to deploy AetherExecutor (see $DEPLOY_LOG)"
+    tail -30 "$DEPLOY_LOG"
+    exit 1
+fi
+
+DEPLOYED_CODE=$(cast code "$AETHER_EXECUTOR_ADDRESS" --rpc-url "$ANVIL_RPC" 2>/dev/null || echo "0x")
+if [ "$DEPLOYED_CODE" = "0x" ] || [ -z "$DEPLOYED_CODE" ]; then
+    log_error "Deployed contract at $AETHER_EXECUTOR_ADDRESS has no bytecode on the fork"
+    exit 1
+fi
+log_ok "AetherExecutor deployed at $AETHER_EXECUTOR_ADDRESS"
+export AETHER_EXECUTOR_ADDRESS
+
 # ── Phase 4: Start Go executor in SHADOW mode ───────────────────────────
 
 log_step "Phase 4: Start aether-executor (AETHER_SHADOW=1)"
@@ -268,6 +335,7 @@ METRICS_PORT="$GO_METRICS_PORT" \
 DASHBOARD_PORT="$DASHBOARD_PORT" \
 AETHER_SHADOW="1" \
 AETHER_SHADOW_DUMP_DIR="$BUNDLE_DUMP_DIR" \
+AETHER_EXECUTOR_ADDRESS="$AETHER_EXECUTOR_ADDRESS" \
     "$AETHER_EXECUTOR" > "$LOG_DIR/executor.log" 2>&1 &
 EXECUTOR_PID=$!
 


### PR DESCRIPTION
## Summary

- `scripts/historical_replay_e2e.sh` (from PR #88) couldn't complete after PR #83 merged because the Go executor now refuses to start unless `AETHER_EXECUTOR_ADDRESS` points at a contract with real bytecode on the connected node.
- Anvil forks at `BLOCK-1` don't contain any later mainnet deploy, so no pre-existing address will ever pass the check.
- This PR adds a Phase 3.5 step that funds the deployer on the fork and deploys `AetherExecutor` via `forge script`, then exports the resulting address for the executor process.

## Files Changed

| File | Change |
|------|--------|
| `scripts/historical_replay_e2e.sh` | +69 / -1 — new Phase 3.5 deploy + `anvil_setBalance` top-up; `forge`/`cast` added to preflight |

## Acceptance Criteria

- [x] Script runs to Phase 7/8 against a historical block with no manual setup
- [x] Executor startup validation (chain-id, bytecode, balance) passes
- [x] AetherExecutor address is exported into Phase 4 env
- [x] `cast code` sanity check confirms bytecode landed on the fork
- [x] Pipeline builds shadow bundles and the Phase 8 catch-rate table renders

## Test plan

- [x] `bash -n scripts/historical_replay_e2e.sh` — syntax OK
- [x] End-to-end run on block 24643151 (13s duration):
  - 1036 cycles detected, 84 sims run, 84 arbs published, **84 shadow bundles built, 0 actual submissions**
  - Detection mean 0.13 ms, simulation mean 1.61 ms, e2e mean 0.15 ms
  - Phase 8 catch-rate reports against 30 ground-truth arbs across `USDT↔WETH`, `DAI↔WETH`, `WETH↔USDC`
  - Top shadow bundle: `arb-24643176-1-3-1` on `WETH -> DAI -> WETH` at 22.71 ETH estimated profit
- [ ] Re-run on a second block (e.g. 24643160) to confirm the fix generalises
