### PR TITLE
docs: add mermaid architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,39 +27,64 @@ Sub-millisecond opportunity detection across Uniswap V2/V3, SushiSwap, Curve, Ba
 
 The system is organized into **7 distinct layers** with clear ownership boundaries:
 
-```
-Eth Nodes (WS/IPC)
-    │
-    ▼
-┌─────────────────── RUST CORE (Latency-Critical) ──────────────────┐
-│  Data Ingestion → DEX Pool Registry → State Management            │
-│       → Arbitrage Detection (Bellman-Ford) → EVM Simulator (revm) │
-└──────────────────────────┬────────────────────────────────────────-┘
-                           │ gRPC over UDS (<1μs)
-┌──────────────────────────▼────────────────────────────────────────-┐
-│               GO EXECUTION LAYER (Coordination)                    │
-│  Bundle Constructor → Multi-Builder Submitter                      │
-│  Risk Manager & Circuit Breakers → Monitoring & Observability      │
-└──────────────────────────┬─────────────────────────────────────────┘
-                           │ eth_sendBundle
-                           ▼
-              Flashbots Relay / Block Builders
-                           │
-                           ▼
-┌──────────────────── ON-CHAIN (Solidity) ──────────────────────────┐
-│  AetherExecutor.sol → Aave V3 Flash Loans → DEX Swaps            │
-└───────────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    ETH["Eth Nodes (WS/IPC)"]
+
+    subgraph RUST["Rust Core — Latency-Critical"]
+        direction LR
+        IG["Ingestion"] --> PR["Pool Registry"] --> SM["State + Price Graph"]
+        SM --> DT["Detector<br/>Bellman-Ford"] --> SIM["Simulator<br/>revm"]
+    end
+
+    subgraph GO["Go Execution Layer — Coordination"]
+        direction LR
+        EX["Bundle Builder"] --> SUB["Multi-Builder Submitter"]
+        RM["Risk Manager"] -.->|preflight| EX
+        MN["Monitor"] -.->|metrics| RM
+    end
+
+    BUILDERS["Flashbots · Titan · Beaver · rsync"]
+
+    subgraph CHAIN["On-Chain"]
+        AE["AetherExecutor.sol"] --> AAVE["Aave V3 Flash Loan"]
+        AAVE --> AE
+        AE --> DEXES["DEX Pools"]
+    end
+
+    ETH --> IG
+    SIM -->|gRPC / UDS <1μs| EX
+    SUB -->|eth_sendBundle| BUILDERS
+    BUILDERS --> AE
+
+    style RUST fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style GO fill:#151a20,stroke:#5ce6c7,stroke-width:2px,color:#fff
+    style CHAIN fill:#1a1815,stroke:#f5a623,stroke-width:2px,color:#fff
 ```
 
 ### Hot Path (target <15ms end-to-end)
 
-1. **Event Ingestion** (<1ms) — WebSocket `newHeads`/`logs`/`pendingTx` → ABI decode via `alloy`
-2. **State Update** — Update pool reserves → recompute affected edges in price graph
-3. **Detection** (<3ms) — Bellman-Ford negative cycle scan on affected subgraph
-4. **Simulation** (<5ms) — Fork latest block state in `revm`, execute calldata, verify profit
-5. **gRPC Handoff** (<1ms) — `ValidatedArb` sent to Go executor over UDS
-6. **Bundle Build + Sign** (<2ms) — EIP-1559 tx + tip tx, sign with searcher key
-7. **Submission** — Fan-out `eth_sendBundle` to Flashbots, Titan, Beaver, rsync builders
+```mermaid
+sequenceDiagram
+    participant Node as Eth Node
+    participant Rust as Rust Core
+    participant Go as Go Executor
+    participant B as Block Builders
+
+    Node->>Rust: WS log (Swap/Sync)
+    Note over Rust: decode + state update<br/><1ms
+    Note over Rust: Bellman-Ford SPFA<br/><3ms
+    Note over Rust: revm fork + execute<br/><5ms
+    Rust->>Go: ValidatedArb (gRPC/UDS <1μs)
+    Note over Go: build + sign bundle<br/><2ms
+    par fan-out
+        Go->>B: eth_sendBundle (Flashbots)
+    and
+        Go->>B: eth_sendBundle (Titan)
+    and
+        Go->>B: eth_sendBundle (Beaver)
+    end
+```
 
 ---
 
@@ -266,7 +291,19 @@ The system enforces automatic circuit breakers:
 | Node latency >500ms | **DEGRADE** |
 | Bundle miss rate >80% in 1h | **ALERT** |
 
-System states: `Running → Degraded → Paused → Halted` (manual reset required from Halted).
+System state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running
+    Running --> Degraded: node latency >500ms
+    Running --> Paused: 3 reverts in 10min
+    Running --> Halted: gas >300gwei<br/>daily loss >0.5 ETH<br/>balance <0.1 ETH
+    Degraded --> Running: latency recovers
+    Degraded --> Halted: breaker trips
+    Paused --> Running: manual resume
+    Halted --> Running: manual reset only
+```
 
 ---
 

--- a/docs-site/architecture/design-decisions.md
+++ b/docs-site/architecture/design-decisions.md
@@ -52,6 +52,36 @@ SLF further optimizes by inserting nodes with shorter labels at the front of the
 
 **Tradeoff:** Higher memory usage (multiple graph versions in flight). In practice, only 2-3 versions exist simultaneously, and the graph is small enough (~5K nodes, ~20K edges) that this is negligible.
 
+```mermaid
+sequenceDiagram
+    participant W as Writer (Ingestion)
+    participant A as ArcSwap
+    participant R1 as Reader A (Detector)
+    participant R2 as Reader B (Simulator)
+
+    Note over A: v1 active
+
+    R1->>A: load()
+    A-->>R1: Arc<v1>
+    activate R1
+
+    W->>W: clone v1 → mutate → v2
+    W->>A: store(v2)
+    Note over A: v2 active
+    Note over R1: still holds v1<br/>no block
+
+    R2->>A: load()
+    A-->>R2: Arc<v2>
+    activate R2
+
+    R1-->>R1: release Arc<v1>
+    deactivate R1
+    Note over A: v1 dropped<br/>(refcount 0)
+
+    R2-->>R2: release Arc<v2>
+    deactivate R2
+```
+
 ## Flash Loan Execution (Zero Capital at Risk)
 
 **Decision:** All arbitrage trades use Aave V3 flash loans. The bot holds no trading capital.
@@ -62,6 +92,29 @@ SLF further optimizes by inserting nodes with shorter labels at the front of the
 3. **Larger trade sizes** — Can execute trades up to the flash loan pool depth (millions of dollars), far more than any capital the bot could hold.
 
 **Tradeoff:** Flash loan premium (0.05% on Aave V3) reduces profit margins. For most arbitrage opportunities, this is negligible compared to the profit.
+
+```mermaid
+sequenceDiagram
+    participant EOA as Searcher EOA
+    participant Exec as AetherExecutor
+    participant Aave as Aave V3
+    participant DEX as DEX Pools
+
+    EOA->>Exec: executeArb(steps, token, amount)
+    Exec->>Aave: flashLoanSimple(amount)
+    Aave->>Exec: transfer + executeOperation()
+    loop each swap step
+        Exec->>DEX: swap
+        DEX-->>Exec: amountOut
+    end
+    Note over Exec: check profit ≥ minProfitOut
+    alt profitable
+        Exec->>Aave: approve + repay (amount + premium)
+        Exec->>EOA: transfer profit
+    else slippage / unprofitable
+        Exec-->>Aave: revert — full rollback, zero capital lost
+    end
+```
 
 ## Multi-Builder Bundle Submission
 

--- a/docs-site/architecture/grpc-protocol.md
+++ b/docs-site/architecture/grpc-protocol.md
@@ -29,6 +29,58 @@ service ArbService {
 
 **`StreamArbs`** — Server-side streaming. Go subscribes to a stream of opportunities from Rust, optionally filtered by minimum profit threshold.
 
+#### SubmitArb — call sequence
+
+```mermaid
+sequenceDiagram
+    participant Rust as Rust (grpc-server)
+    participant Go as Go (executor)
+    participant Risk as Risk Manager
+    participant Builder as Block Builders
+
+    Rust->>Go: SubmitArb(ValidatedArb)
+    activate Go
+    Go->>Risk: PreflightCheck
+    alt breaker tripped
+        Risk-->>Go: REJECTED
+        Go-->>Rust: SubmitArbResponse{accepted=false, reason}
+    else allowed
+        Risk-->>Go: OK
+        Go->>Go: build bundle (arb_tx + tip_tx)
+        Go->>Go: sign with searcher key
+        par fan-out
+            Go->>Builder: eth_sendBundle (Flashbots)
+        and
+            Go->>Builder: eth_sendBundle (Titan)
+        and
+            Go->>Builder: eth_sendBundle (Beaver)
+        end
+        Go-->>Rust: SubmitArbResponse{accepted=true, bundle_hash}
+    end
+    deactivate Go
+```
+
+#### StreamArbs — server-side stream
+
+```mermaid
+sequenceDiagram
+    participant Go as Go (executor)
+    participant Rust as Rust (grpc-server)
+    participant Det as Detector
+
+    Go->>Rust: StreamArbs(min_profit_eth)
+    activate Rust
+    loop per detection cycle
+        Det->>Rust: new ArbOpportunity
+        alt profit ≥ min_profit
+            Rust-->>Go: ValidatedArb chunk
+        else below threshold
+            Note over Rust: filtered out
+        end
+    end
+    deactivate Rust
+```
+
 ### HealthService
 
 Health checks from Go to Rust.
@@ -84,6 +136,27 @@ enum SystemState {
     PAUSED = 3;
     HALTED = 4;
 }
+```
+
+#### State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> RUNNING
+    RUNNING --> DEGRADED: node latency >500ms
+    RUNNING --> PAUSED: 3 consecutive reverts / 10m
+    RUNNING --> HALTED: gas >300gwei<br/>daily loss >0.5 ETH<br/>balance <0.1 ETH
+    DEGRADED --> RUNNING: latency recovers
+    DEGRADED --> HALTED: breaker trips
+    PAUSED --> RUNNING: manual resume
+    PAUSED --> HALTED: further failures
+    HALTED --> RUNNING: manual reset only
+    HALTED --> [*]: operator shutdown
+
+    note right of HALTED
+        terminal until manual reset
+        no automatic recovery
+    end note
 ```
 
 ## Messages

--- a/docs-site/architecture/overview.md
+++ b/docs-site/architecture/overview.md
@@ -169,6 +169,25 @@ EIP-1559 transactions constructed and signed (arb_tx + tip_tx)
   </TimelineItem>
 </Timeline>
 
+### End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    participant Node as Eth Node
+    participant Rust as Rust Core
+    participant Go as Go Executor
+    participant B as Builders
+
+    Node->>Rust: Swap / Sync log
+    Note over Rust: decode + state update (<1ms)
+    Note over Rust: Bellman-Ford SPFA (<3ms)
+    Note over Rust: revm fork + execute (<5ms)
+    Rust->>Go: ValidatedArb via gRPC/UDS
+    Note over Go: risk preflight + build + sign (<3ms)
+    Go->>B: eth_sendBundle fan-out
+    Note over B: Flashbots · Titan · Beaver · rsync
+```
+
 ## Inter-Service Communication
 
 Rust and Go communicate via **gRPC over Unix Domain Sockets** — sub-microsecond transport.

--- a/docs-site/architecture/rust-core.md
+++ b/docs-site/architecture/rust-core.md
@@ -4,11 +4,56 @@ The Rust core handles all latency-critical work — from ingesting Ethereum even
 
 ## Crate Dependency Graph
 
-```
-common ← ingestion ← pools ← state ← detector ← simulator ← grpc-server
+```mermaid
+graph LR
+    COMMON["common<br/><i>shared types</i>"]
+    INGEST["ingestion<br/><i>WS + ABI decode</i>"]
+    POOLS["pools<br/><i>6 DEX adapters</i>"]
+    STATE["state<br/><i>price graph, MVCC</i>"]
+    DETECT["detector<br/><i>SPFA Bellman-Ford</i>"]
+    SIM["simulator<br/><i>revm fork</i>"]
+    GRPC["grpc-server<br/><i>binary entrypoint</i>"]
+
+    COMMON --> INGEST --> POOLS --> STATE --> DETECT --> SIM --> GRPC
+    COMMON --> POOLS
+    COMMON --> STATE
+    COMMON --> DETECT
+    COMMON --> SIM
+    COMMON --> GRPC
+
+    style COMMON fill:#15151c,stroke:#888,stroke-width:1px,color:#fff
+    style INGEST fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style POOLS fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style STATE fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style DETECT fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style SIM fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style GRPC fill:#1a1815,stroke:#f5a623,stroke-width:2px,color:#fff
 ```
 
-`grpc-server` is the binary entry point that wires everything together.
+`grpc-server` is the binary entry point that wires everything together. `common` is a leaf dependency used by every other crate.
+
+## Hot Path — Per-Event Flow
+
+```mermaid
+flowchart LR
+    NODE([Eth Node<br/>WS / IPC])
+    ING["Ingestion<br/><i>ABI decode &lt;200ns</i>"]
+    POOL["Pool Registry<br/><i>update reserves</i>"]
+    STATE["Price Graph<br/><i>mark dirty edges</i>"]
+    DET["Detector<br/><i>SPFA &lt;3ms</i>"]
+    SIM["Simulator<br/><i>revm fork &lt;5ms</i>"]
+    GRPC([gRPC / UDS])
+
+    NODE --> ING --> POOL --> STATE --> DET --> SIM --> GRPC
+
+    style NODE fill:#15151c,stroke:#888,color:#fff
+    style ING fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style POOL fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style STATE fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style DET fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style SIM fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style GRPC fill:#1a1815,stroke:#f5a623,stroke-width:2px,color:#fff
+```
 
 ## `crates/common/` — Shared Types
 
@@ -154,6 +199,42 @@ The detection engine uses a modified Bellman-Ford algorithm — specifically the
 - Detects negative cycles by checking if a node is relaxed N times (where N = number of nodes)
 - **Early exit** on first negative cycle found
 - Only scans the subgraph affected by recent state updates (dirty nodes)
+
+```mermaid
+flowchart TB
+    START([state update arrives])
+    DIRTY{"dirty subgraph<br/>non-empty?"}
+    INIT["initialize dist[v] = 0 for each dirty node<br/>enqueue dirty nodes"]
+    POP["pop node u from deque<br/>(front if SLF short-label)"]
+    RELAX["for each edge u→v:<br/>new = dist[u] + weight(u,v)"]
+    IMPROVED{"new &lt; dist[v]?"}
+    COUNT{"relaxed ≥ N times?<br/>(N = node count)"}
+    CYCLE["negative cycle found<br/>→ extract hop sequence"]
+    PUSH["dist[v] = new<br/>enqueue v"]
+    EMPTY{"deque empty?"}
+    DONE([return top-K arbs])
+    OPT["ternary search optimal input<br/>estimate gas cost<br/>compute net profit"]
+
+    START --> DIRTY
+    DIRTY -->|no| DONE
+    DIRTY -->|yes| INIT
+    INIT --> POP
+    POP --> RELAX
+    RELAX --> IMPROVED
+    IMPROVED -->|no| EMPTY
+    IMPROVED -->|yes| COUNT
+    COUNT -->|yes| CYCLE
+    COUNT -->|no| PUSH
+    PUSH --> EMPTY
+    EMPTY -->|no| POP
+    EMPTY -->|yes| DONE
+    CYCLE --> OPT
+    OPT --> DONE
+
+    style CYCLE fill:#1a3520,stroke:#5ce6c7,stroke-width:2px,color:#fff
+    style DONE fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
+    style START fill:#15151c,stroke:#888,color:#fff
+```
 
 ### Input Optimizer
 

--- a/docs-site/architecture/smart-contract.md
+++ b/docs-site/architecture/smart-contract.md
@@ -14,28 +14,18 @@ The `AetherExecutor.sol` contract is the on-chain component that receives flash 
 sequenceDiagram
     participant EOA as Searcher EOA
     participant EX as AetherExecutor
-    participant AAVE as Aave V3 Pool
-    participant DEX1 as DEX Pool 1
-    participant DEX2 as DEX Pool 2
-    participant DEXN as DEX Pool N
+    participant AAVE as Aave V3
+    participant DEX as DEX Pools
 
-    EOA->>EX: executeArb(steps, token, amount, deadline, minProfitOut, tipBps)
+    EOA->>EX: executeArb(steps, token, amount, ...)
     EX->>AAVE: flashLoanSimple(token, amount)
-    AAVE->>EX: Transfer loan amount
-    AAVE->>EX: executeOperation() callback
-
-    rect rgba(149, 128, 255, 0.08)
-        Note over EX,DEXN: Swap Loop
-        EX->>DEX1: _executeSwap(step[0])
-        DEX1-->>EX: tokens received
-        EX->>DEX2: _executeSwap(step[1])
-        DEX2-->>EX: tokens received
-        EX->>DEXN: _executeSwap(step[N])
-        DEXN-->>EX: tokens received
+    AAVE->>EX: transfer + executeOperation()
+    loop each swap step
+        EX->>DEX: _executeSwap(step[i])
+        DEX-->>EX: tokens received
     end
-
-    EX->>AAVE: Repay amount + 0.05% premium
-    EX->>EOA: Transfer profit
+    EX->>AAVE: repay (amount + 0.05% premium)
+    EX->>EOA: transfer profit
 ```
 
 ## Entry Point: `executeArb()`


### PR DESCRIPTION
## Summary

- README: system topology, hot-path sequence, risk state machine (replaces existing ASCII + numbered list, net +1 diagram)
- docs-site: new / cleaned-up diagrams across overview, rust-core, grpc-protocol, design-decisions, smart-contract
- All rendered + validated via `vitepress build` (mermaid plugin, dark theme)

## Files Changed

| File | Change |
|---|---|
| `README.md` | ASCII → mermaid system topology; numbered list → hot-path sequence; added risk state machine |
| `docs-site/architecture/overview.md` | simplified end-to-end sequence (4 lanes) |
| `docs-site/architecture/rust-core.md` | crate dependency graph, hot-path flowchart, SPFA detection flowchart |
| `docs-site/architecture/grpc-protocol.md` | SubmitArb + StreamArbs sequences; SystemState transitions |
| `docs-site/architecture/design-decisions.md` | MVCC snapshot swap sequence; flash-loan atomicity sequence |
| `docs-site/architecture/smart-contract.md` | contract flow simplified from 6 lanes to 4 + loop |

## Acceptance Criteria

- [x] `npm run build` in docs-site passes with no mermaid errors
- [x] All diagrams render correctly on GitHub blob view
- [x] README retains same length (two replacements + one small addition)
- [x] No behavior changes outside documentation

## Test plan

- [x] Ran `cd docs-site && npm run build` — `build complete in 10.64s`, no errors
- [x] Dev server (`npm run dev`) — all 4 architecture pages load, diagrams render in dark theme
- [x] Pushed branch, verified GitHub blob-view rendering of all README + docs-site diagrams
- [x] Cross-checked wide-diagram fixes: overview end-to-end, rust-core hot-path, smart-contract flow, design-decisions flash-loan — all render without horizontal overflow