### PR TITLE
feat(pools,engine): V3 / Curve / Balancer post-state predictors + state cache

### DIFF
--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -89,6 +89,11 @@ pub struct PoolMetadata {
     pub pool_id: PoolId,
     pub protocol: ProtocolType,
     pub fee_bps: u32,
+    /// V3-only — tick spacing from `pools.toml`. `None` for non-V3
+    /// protocols (where the field is meaningless) and as a fallback
+    /// when the config entry omitted it. Required to construct a valid
+    /// `UniswapV3Pool` for the post-state cache.
+    pub tick_spacing: Option<i32>,
 }
 
 impl PoolMetadata {
@@ -429,6 +434,25 @@ impl AetherEngine {
         protocol: ProtocolType,
         fee_bps: u32,
     ) {
+        self.register_pool_with_tick_spacing(pool_addr, token0, token1, protocol, fee_bps, None)
+            .await
+    }
+
+    /// Same as [`Self::register_pool`] but accepts a tick_spacing hint
+    /// for V3-family pools. Required so the post-state cache can build
+    /// a valid `UniswapV3Pool` (which needs tick_spacing to know where
+    /// the active tick bucket ends). Non-V3 callers pass `None` and the
+    /// metadata stores it as `None` — the field is ignored at the
+    /// graph-edge update path which doesn't care about ticks.
+    pub async fn register_pool_with_tick_spacing(
+        &self,
+        pool_addr: Address,
+        token0: Address,
+        token1: Address,
+        protocol: ProtocolType,
+        fee_bps: u32,
+        tick_spacing: Option<i32>,
+    ) {
         let (t0_idx, t1_idx, num_tokens) = {
             let mut ti = (**self.token_index.load()).clone();
             let t0 = ti.get_or_insert(token0);
@@ -450,6 +474,7 @@ impl AetherEngine {
             pool_id,
             protocol,
             fee_bps,
+            tick_spacing,
         };
 
         {
@@ -609,7 +634,9 @@ impl AetherEngine {
                 continue;
             }
 
-            self.register_pool(pool_addr, token0, token1, protocol, entry.fee_bps)
+            self.register_pool_with_tick_spacing(
+                pool_addr, token0, token1, protocol, entry.fee_bps, entry.tick_spacing,
+            )
                 .await;
             loaded += 1;
 
@@ -660,7 +687,7 @@ impl AetherEngine {
         // Result type for each concurrent RPC fetch.
         enum ReserveResult {
             V2 { pool_addr: Address, meta: PoolMetadata, r0: U256, r1: U256 },
-            V3 { pool_addr: Address, meta: PoolMetadata, sqrt_price_x96: U256 },
+            V3 { pool_addr: Address, meta: PoolMetadata, sqrt_price_x96: U256, tick: i32 },
             Skipped,
         }
 
@@ -702,7 +729,20 @@ impl AetherEngine {
                         match provider.call(tx).await {
                             Ok(output) if output.len() >= 64 => {
                                 let sqrt_price_x96 = U256::from_be_slice(&output[0..32]);
-                                ReserveResult::V3 { pool_addr, meta, sqrt_price_x96 }
+                                // slot0 returns int24 tick, ABI-encoded as a
+                                // sign-extended 32-byte word at offset 32. Read
+                                // the high byte's MSB to detect a negative
+                                // value, then take the low 24 bits and apply
+                                // two's-complement if needed.
+                                let raw = &output[32..64];
+                                let mut tick_low24: i32 = ((raw[29] as i32) << 16)
+                                    | ((raw[30] as i32) << 8)
+                                    | (raw[31] as i32);
+                                if raw[0] != 0 {
+                                    // Top bytes set → negative; sign-extend.
+                                    tick_low24 -= 1 << 24;
+                                }
+                                ReserveResult::V3 { pool_addr, meta, sqrt_price_x96, tick: tick_low24 }
                             }
                             Ok(output) => {
                                 warn!(%pool_addr, len = output.len(), "slot0 output too short");
@@ -761,7 +801,7 @@ impl AetherEngine {
                             debug!(%pool_addr, reserve0 = %r0, reserve1 = %r1, "V2 reserves fetched");
                         }
                     }
-                    ReserveResult::V3 { pool_addr, meta, sqrt_price_x96 } => {
+                    ReserveResult::V3 { pool_addr, meta, sqrt_price_x96, tick } => {
                         const TWO_POW_96: f64 = 79_228_162_514_264_337_593_543_950_336.0;
                         let sqrt_f64 = u256_to_f64(sqrt_price_x96);
                         let price = (sqrt_f64 / TWO_POW_96).powi(2);
@@ -778,8 +818,30 @@ impl AetherEngine {
                                 (1.0 / price) * fee, meta.pool_id, pool_addr,
                                 meta.protocol, liq,
                             );
+                            // Seed the V3 pool-state cache. Liquidity is set
+                            // to zero here because slot0 does not expose it —
+                            // a separate `liquidity()` RPC would be required
+                            // for an exact bootstrap value, and that adds a
+                            // second concurrent fan-out that we defer for
+                            // now. Real liquidity arrives via the first
+                            // `PoolEvent::V3Update` (which carries sqrt +
+                            // liquidity + tick together) once block-level
+                            // event ingestion comes online; until then the
+                            // mempool sim's `predict_post_state` returns
+                            // None for these entries, which is the correct
+                            // behaviour for a zero-liquidity edge.
+                            let mut v3 = aether_pools::uniswap_v3::UniswapV3Pool::new(
+                                pool_addr,
+                                meta.token0,
+                                meta.token1,
+                                meta.fee_bps,
+                                meta.tick_spacing.unwrap_or(0),
+                            );
+                            v3.update_sqrt_price(sqrt_price_x96, 0u128, tick);
+                            self.pool_states
+                                .insert(pool_addr, Arc::new(PoolState::UniswapV3(v3)));
                             fetched += 1;
-                            debug!(%pool_addr, %sqrt_price_x96, "V3 slot0 fetched");
+                            debug!(%pool_addr, %sqrt_price_x96, tick, "V3 slot0 fetched");
                         }
                     }
                     ReserveResult::Skipped => {}
@@ -918,9 +980,9 @@ impl AetherEngine {
                 pool,
                 sqrt_price_x96,
                 liquidity,
-                tick: _,
+                tick,
             } => {
-                debug!(%pool, %sqrt_price_x96, liquidity, "V3 pool update");
+                debug!(%pool, %sqrt_price_x96, liquidity, tick, "V3 pool update");
 
                 let meta = self.pool_registry.load().get(&pool).cloned();
 
@@ -953,6 +1015,21 @@ impl AetherEngine {
                             liq,
                         );
                         // Snapshot is published once per detection cycle, not per event.
+                        // Refresh the V3 pool-state cache entry. The event
+                        // carries everything `predict_post_state` needs
+                        // (sqrt + liquidity + tick), so this is the path
+                        // that actually populates real liquidity onto a
+                        // V3 cache seeded with `liquidity = 0` at bootstrap.
+                        let mut v3 = aether_pools::uniswap_v3::UniswapV3Pool::new(
+                            pool,
+                            meta.token0,
+                            meta.token1,
+                            meta.fee_bps,
+                            meta.tick_spacing.unwrap_or(0),
+                        );
+                        v3.update_sqrt_price(sqrt_price_x96, liquidity, tick);
+                        self.pool_states
+                            .insert(pool, Arc::new(PoolState::UniswapV3(v3)));
                     }
                 }
             }
@@ -1817,6 +1894,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_v3_pool_state_cache_populated_on_v3_update() {
+        use alloy::primitives::address;
+        let (tx, _rx) = broadcast::channel(100);
+        let engine = AetherEngine::new(EngineConfig::default(), tx);
+
+        let pool = address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640");
+        let token0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let token1 = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        engine
+            .register_pool_with_tick_spacing(
+                pool,
+                token0,
+                token1,
+                ProtocolType::UniswapV3,
+                5,
+                Some(10),
+            )
+            .await;
+
+        // Sanity: tick_spacing landed on the registry entry.
+        let stored_ts = engine
+            .pool_registry
+            .load()
+            .get(&pool)
+            .expect("registered")
+            .tick_spacing;
+        assert_eq!(stored_ts, Some(10));
+
+        let sqrt = U256::from(79_228_162_514_264_337_593_543_950_336u128); // ≈ Q96
+        engine
+            .handle_pool_update(PoolEvent::V3Update {
+                pool,
+                sqrt_price_x96: sqrt,
+                liquidity: 12_345_678_900_000u128,
+                tick: 0,
+            })
+            .await;
+
+        let entry = engine
+            .pool_states()
+            .get(&pool)
+            .expect("V3 cache entry written")
+            .clone();
+        match entry.as_ref() {
+            PoolState::UniswapV3(p) => {
+                assert_eq!(p.address, pool);
+                assert_eq!(p.sqrt_price_x96, sqrt);
+                assert_eq!(p.liquidity, 12_345_678_900_000u128);
+                assert_eq!(p.tick, 0);
+                assert_eq!(p.tick_spacing, 10);
+            }
+            other => panic!("expected UniswapV3 variant, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_sushiswap_pool_state_cache_uses_sushiswap_variant() {
         use alloy::primitives::address;
         let (tx, _rx) = broadcast::channel(100);
@@ -1893,6 +2026,7 @@ mod tests {
             },
             protocol: ProtocolType::UniswapV2,
             fee_bps: 30,
+            tick_spacing: None,
         };
         assert!((meta.fee_factor() - 0.997).abs() < 1e-10);
 

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -20,6 +20,7 @@ use aether_detector::gas::{estimate_total_gas, gas_cost_wei};
 use aether_detector::optimizer::ternary_search_optimal_input;
 use aether_ingestion::event_decoder::PoolEvent;
 use aether_ingestion::subscription::{EventChannels, NewBlockEvent};
+use aether_pools::{new_pool_state_cache, PoolStateCache};
 use aether_simulator::calldata::build_execute_arb_calldata;
 use aether_simulator::fork::{prewarm_state, ForkedState, PrewarmedState, RpcForkedState};
 use aether_simulator::EvmSimulator;
@@ -123,6 +124,14 @@ pub struct AetherEngine {
     /// Pool address → metadata mapping for event handling.
     /// Writers clone-modify-swap; readers load() zero-copy.
     pool_registry: Arc<ArcSwap<HashMap<Address, PoolMetadata>>>,
+    /// Live pool-state cache for the mempool post-state simulator.
+    /// Holds `Arc<PoolState>` values keyed by pool address; readers
+    /// (mempool decode pipeline) clone the inner Arc for a snapshot, while
+    /// the engine writes new entries on bootstrap and replaces them on
+    /// every pool-update event. Intentionally distinct from
+    /// `pool_registry` (which carries static metadata only) — this cache
+    /// owns the *mutable* protocol state that `predict_post_state` needs.
+    pool_states: PoolStateCache,
     /// Optional type-erased alloy provider for RPC-backed simulation.
     /// When `Some`, `run_detection_cycle` uses `RpcForkedState` instead of
     /// the empty `ForkedState`.
@@ -350,10 +359,23 @@ impl AetherEngine {
             current_block: Arc::new(ArcSwap::from_pointee(BlockInfo::default())),
             token_index: Arc::new(ArcSwap::from_pointee(TokenIndex::new())),
             pool_registry: Arc::new(ArcSwap::from_pointee(HashMap::new())),
+            pool_states: new_pool_state_cache(),
             rpc_provider,
             metrics,
             ledger,
         }
+    }
+
+    /// Borrow the live pool-state cache so external consumers (mempool
+    /// post-state simulator, future analytics) can read accurate per-
+    /// protocol state without round-tripping to RPC. The returned
+    /// reference is to the engine's own clone of the `Arc<DashMap>` —
+    /// callers typically `Arc::clone` it for their own `SimContext`.
+    /// `dead_code` until the mempool decode pipeline lands on this
+    /// branch (or the pipeline branch rebases on top).
+    #[allow(dead_code)]
+    pub fn pool_states(&self) -> &PoolStateCache {
+        &self.pool_states
     }
 
     /// Get a reference to the event channels for external use (e.g., the

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -678,16 +678,24 @@ impl AetherEngine {
 
         info!(count = pools.len(), "Fetching initial reserves via RPC (concurrent)");
 
-        // ABI for getReserves() and slot0()
+        // ABI for getReserves() / slot0() / Curve A + balances /
+        // Balancer pool/vault helpers.
         alloy::sol! {
             function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
             function slot0() external view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked);
+            function A() external view returns (uint256);
+            function balances(uint256 i) external view returns (uint256);
+            function getPoolId() external view returns (bytes32);
+            function getNormalizedWeights() external view returns (uint256[]);
+            function getPoolTokens(bytes32 poolId) external view returns (address[], uint256[], uint256);
         }
 
         // Result type for each concurrent RPC fetch.
         enum ReserveResult {
             V2 { pool_addr: Address, meta: PoolMetadata, r0: U256, r1: U256 },
             V3 { pool_addr: Address, meta: PoolMetadata, sqrt_price_x96: U256, tick: i32 },
+            Curve { pool_addr: Address, meta: PoolMetadata, a: U256, b0: U256, b1: U256 },
+            Balancer { pool_addr: Address, meta: PoolMetadata, b0: U256, b1: U256, w0: U256, w1: U256 },
             Skipped,
         }
 
@@ -753,6 +761,122 @@ impl AetherEngine {
                                 ReserveResult::Skipped
                             }
                         }
+                    }
+                    ProtocolType::Curve => {
+                        // 2-coin Curve only: fetch A + balances(0) +
+                        // balances(1) sequentially. Three RPC round-trips
+                        // per pool — bounded by the join_set fan-out and
+                        // typically <100 pools at bootstrap so the cost is
+                        // a one-time second of warmup.
+                        let a_calldata = ACall {}.abi_encode();
+                        let a_tx = alloy::rpc::types::TransactionRequest::default()
+                            .to(pool_addr)
+                            .input(a_calldata.into());
+                        let a = match provider.call(a_tx).await {
+                            Ok(out) if out.len() >= 32 => U256::from_be_slice(&out[0..32]),
+                            Ok(out) => {
+                                warn!(%pool_addr, len = out.len(), "Curve A() output too short");
+                                return ReserveResult::Skipped;
+                            }
+                            Err(e) => {
+                                warn!(%pool_addr, error = %e, "Curve A() RPC call failed");
+                                return ReserveResult::Skipped;
+                            }
+                        };
+                        let mut bal = [U256::ZERO; 2];
+                        for (idx, slot) in bal.iter_mut().enumerate() {
+                            let calldata = balancesCall { i: U256::from(idx as u64) }.abi_encode();
+                            let tx = alloy::rpc::types::TransactionRequest::default()
+                                .to(pool_addr)
+                                .input(calldata.into());
+                            match provider.call(tx).await {
+                                Ok(out) if out.len() >= 32 => {
+                                    *slot = U256::from_be_slice(&out[0..32]);
+                                }
+                                Ok(out) => {
+                                    warn!(%pool_addr, idx, len = out.len(), "Curve balances() output too short");
+                                    return ReserveResult::Skipped;
+                                }
+                                Err(e) => {
+                                    warn!(%pool_addr, idx, error = %e, "Curve balances() RPC call failed");
+                                    return ReserveResult::Skipped;
+                                }
+                            }
+                        }
+                        ReserveResult::Curve { pool_addr, meta, a, b0: bal[0], b1: bal[1] }
+                    }
+                    ProtocolType::BalancerV2 => {
+                        // Balancer V2 reads need three sequential calls:
+                        // pool.getPoolId() → vault.getPoolTokens(poolId)
+                        // → pool.getNormalizedWeights(). The Vault address
+                        // is canonical and identical across every Balancer
+                        // V2 pool.
+                        const BALANCER_V2_VAULT: Address = alloy::primitives::address!(
+                            "BA12222222228d8Ba445958a75a0704d566BF2C8"
+                        );
+                        let pool_id_tx = alloy::rpc::types::TransactionRequest::default()
+                            .to(pool_addr)
+                            .input(getPoolIdCall {}.abi_encode().into());
+                        let pool_id_bytes = match provider.call(pool_id_tx).await {
+                            Ok(out) if out.len() >= 32 => {
+                                let mut buf = [0u8; 32];
+                                buf.copy_from_slice(&out[0..32]);
+                                buf
+                            }
+                            Ok(out) => {
+                                warn!(%pool_addr, len = out.len(), "Balancer getPoolId output too short");
+                                return ReserveResult::Skipped;
+                            }
+                            Err(e) => {
+                                warn!(%pool_addr, error = %e, "Balancer getPoolId RPC call failed");
+                                return ReserveResult::Skipped;
+                            }
+                        };
+                        let tokens_tx = alloy::rpc::types::TransactionRequest::default()
+                            .to(BALANCER_V2_VAULT)
+                            .input(
+                                getPoolTokensCall { poolId: pool_id_bytes.into() }
+                                    .abi_encode()
+                                    .into(),
+                            );
+                        let tokens_out = match provider.call(tokens_tx).await {
+                            Ok(out) => out,
+                            Err(e) => {
+                                warn!(%pool_addr, error = %e, "Balancer getPoolTokens RPC call failed");
+                                return ReserveResult::Skipped;
+                            }
+                        };
+                        let (b0, b1) = match getPoolTokensCall::abi_decode_returns(&tokens_out) {
+                            // 3-return tuple from getPoolTokens — fields are
+                            // (address[] tokens, uint256[] balances, uint256 lastChangeBlock)
+                            // → alloy synthesises `_0`, `_1`, `_2` for the
+                            // anonymous return slots. We need `_1` (balances).
+                            Ok(ret) if ret._1.len() >= 2 => (ret._1[0], ret._1[1]),
+                            _ => {
+                                warn!(%pool_addr, "Balancer getPoolTokens did not return 2-coin balances");
+                                return ReserveResult::Skipped;
+                            }
+                        };
+                        let weights_tx = alloy::rpc::types::TransactionRequest::default()
+                            .to(pool_addr)
+                            .input(getNormalizedWeightsCall {}.abi_encode().into());
+                        let weights_out = match provider.call(weights_tx).await {
+                            Ok(out) => out,
+                            Err(e) => {
+                                warn!(%pool_addr, error = %e, "Balancer getNormalizedWeights RPC call failed");
+                                return ReserveResult::Skipped;
+                            }
+                        };
+                        let (w0, w1) = match getNormalizedWeightsCall::abi_decode_returns(&weights_out) {
+                            // Single-return function — alloy unwraps the
+                            // tuple, so `ret` is the `Vec<U256>` directly.
+                            Ok(ret) if ret.len() >= 2 => (ret[0], ret[1]),
+                            _ => {
+                                warn!(%pool_addr, "Balancer getNormalizedWeights did not return 2 weights");
+                                return ReserveResult::Skipped;
+                            }
+                        };
+                        ReserveResult::Balancer { pool_addr, meta, b0, b1, w0, w1 }
                     }
                     _ => {
                         debug!(%pool_addr, protocol = ?meta.protocol, "Reserve fetch not yet implemented for this protocol");
@@ -843,6 +967,59 @@ impl AetherEngine {
                             fetched += 1;
                             debug!(%pool_addr, %sqrt_price_x96, tick, "V3 slot0 fetched");
                         }
+                    }
+                    ReserveResult::Curve { pool_addr, meta, a, b0, b1 } => {
+                        // Bootstrap-only Curve cache populate. The graph
+                        // edge for Curve isn't seeded here — the existing
+                        // engine code path doesn't fetch / construct Curve
+                        // edges yet (see PoolEvent::TokenExchange follow-up).
+                        // This commit only fills `pool_states` so the
+                        // mempool post-state simulator has live state to
+                        // call `predict_post_state` against; downstream
+                        // graph integration is its own commit.
+                        let amp_u64: u64 = if a > U256::from(u64::MAX) {
+                            warn!(%pool_addr, %a, "Curve A() overflows u64; saturating");
+                            u64::MAX
+                        } else {
+                            a.try_into().unwrap_or(u64::MAX)
+                        };
+                        let mut curve = aether_pools::curve::CurvePool::new(
+                            pool_addr,
+                            vec![meta.token0, meta.token1],
+                            amp_u64,
+                            meta.fee_bps,
+                        );
+                        curve.balances = vec![b0, b1];
+                        self.pool_states
+                            .insert(pool_addr, Arc::new(PoolState::Curve(curve)));
+                        fetched += 1;
+                        debug!(%pool_addr, %a, %b0, %b1, "Curve state fetched");
+                    }
+                    ReserveResult::Balancer { pool_addr, meta, b0, b1, w0, w1 } => {
+                        // Bootstrap-only Balancer cache populate. Same
+                        // graph-edge caveat as the Curve branch: this
+                        // commit only fills `pool_states`.
+                        //
+                        // BalancerPool::new takes weights as u64. Balancer
+                        // V2 weights are e18-fixed (1.0 = 1e18). Saturate
+                        // on overflow — real weights are below 1e18 and
+                        // fit in u64 fine.
+                        let to_u64 = |x: U256| -> u64 {
+                            x.try_into().unwrap_or(u64::MAX)
+                        };
+                        let mut bal = aether_pools::balancer::BalancerPool::new(
+                            pool_addr,
+                            meta.token0,
+                            meta.token1,
+                            to_u64(w0),
+                            to_u64(w1),
+                            meta.fee_bps,
+                        );
+                        bal.update_state(b0, b1);
+                        self.pool_states
+                            .insert(pool_addr, Arc::new(PoolState::Balancer(bal)));
+                        fetched += 1;
+                        debug!(%pool_addr, %b0, %b1, %w0, %w1, "Balancer state fetched");
                     }
                     ReserveResult::Skipped => {}
                 }
@@ -1890,6 +2067,82 @@ mod tests {
                 assert_eq!(p.reserve1, U256::from(500_000_000_000_000_000u64));
             }
             other => panic!("expected UniswapV2 variant, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_curve_pool_state_cache_can_be_populated_directly() {
+        // Bootstrap-time Curve cache writes happen inside the RPC join
+        // set, which we can't drive headlessly here. Exercise the same
+        // shape by populating the cache directly the way the bootstrap
+        // result handler does, and verify the variant + balances + A
+        // round-trip cleanly.
+        use alloy::primitives::address;
+        let (tx, _rx) = broadcast::channel(100);
+        let engine = AetherEngine::new(EngineConfig::default(), tx);
+
+        let pool = address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7"); // 3pool (canonical)
+        let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let usdt = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let mut curve = aether_pools::curve::CurvePool::new(
+            pool,
+            vec![usdc, usdt],
+            100, // A
+            4,   // 4 bps
+        );
+        curve.balances = vec![
+            U256::from(10_000_000_000_000u64),
+            U256::from(10_000_000_000_000u64),
+        ];
+        engine
+            .pool_states
+            .insert(pool, Arc::new(PoolState::Curve(curve)));
+
+        let entry = engine.pool_states().get(&pool).expect("present").clone();
+        match entry.as_ref() {
+            PoolState::Curve(p) => {
+                assert_eq!(p.address, pool);
+                assert_eq!(p.amplification, U256::from(100u64));
+                assert_eq!(p.balances.len(), 2);
+                assert_eq!(p.balances[0], U256::from(10_000_000_000_000u64));
+            }
+            other => panic!("expected Curve variant, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_balancer_pool_state_cache_can_be_populated_directly() {
+        use alloy::primitives::address;
+        let (tx, _rx) = broadcast::channel(100);
+        let engine = AetherEngine::new(EngineConfig::default(), tx);
+
+        let pool = address!("32296969Ef14EB0c6d29669C550D4a0449130230"); // wstETH/WETH 50/50
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let wsteth = address!("7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0");
+        let mut bal = aether_pools::balancer::BalancerPool::new(
+            pool,
+            wsteth,
+            weth,
+            500_000_000_000_000_000, // 0.5 e18 (alloy weight units)
+            500_000_000_000_000_000,
+            10,
+        );
+        bal.update_state(
+            U256::from(5_000_000_000_000_000_000u128),
+            U256::from(5_000_000_000_000_000_000u128),
+        );
+        engine
+            .pool_states
+            .insert(pool, Arc::new(PoolState::Balancer(bal)));
+
+        let entry = engine.pool_states().get(&pool).expect("present").clone();
+        match entry.as_ref() {
+            PoolState::Balancer(p) => {
+                assert_eq!(p.address, pool);
+                assert_eq!(p.token0, wsteth);
+                assert_eq!(p.weight0, p.weight1, "50/50 fixture");
+            }
+            other => panic!("expected Balancer variant, got {other:?}"),
         }
     }
 

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -20,7 +20,8 @@ use aether_detector::gas::{estimate_total_gas, gas_cost_wei};
 use aether_detector::optimizer::ternary_search_optimal_input;
 use aether_ingestion::event_decoder::PoolEvent;
 use aether_ingestion::subscription::{EventChannels, NewBlockEvent};
-use aether_pools::{new_pool_state_cache, PoolStateCache};
+use aether_pools::uniswap_v2::UniswapV2Pool;
+use aether_pools::{new_pool_state_cache, Pool, PoolState, PoolStateCache};
 use aether_simulator::calldata::build_execute_arb_calldata;
 use aether_simulator::fork::{prewarm_state, ForkedState, PrewarmedState, RpcForkedState};
 use aether_simulator::EvmSimulator;
@@ -378,6 +379,28 @@ impl AetherEngine {
         &self.pool_states
     }
 
+    /// Build the V2-family `PoolState` variant that matches the pool's
+    /// configured protocol (UniswapV2 vs SushiSwap). Both share the
+    /// same `UniswapV2Pool` math; the variant lets the dispatcher route
+    /// to the correct protocol metadata downstream without an extra
+    /// address lookup.
+    fn build_v2_pool_state(
+        &self,
+        pool_addr: Address,
+        meta: &PoolMetadata,
+        reserve0: U256,
+        reserve1: U256,
+    ) -> PoolState {
+        let mut p = UniswapV2Pool::new(pool_addr, meta.token0, meta.token1, meta.fee_bps);
+        p.update_state(reserve0, reserve1);
+        match meta.protocol {
+            ProtocolType::SushiSwap => PoolState::SushiSwap(p),
+            // UniswapV2 is the natural default — anything else routed
+            // through this helper would be a bug at the call site.
+            _ => PoolState::UniswapV2(p),
+        }
+    }
+
     /// Get a reference to the event channels for external use (e.g., the
     /// provider pushing events into the engine).
     pub fn event_channels(&self) -> &Arc<EventChannels> {
@@ -729,6 +752,11 @@ impl AetherEngine {
                                 meta.token1_idx, meta.token0_idx,
                                 meta.pool_id, r1_f, r0_f, fee,
                             );
+                            // Mirror the reserves into the pool-state cache so
+                            // the mempool post-state simulator has live state
+                            // to call `predict_post_state` against.
+                            let state = self.build_v2_pool_state(pool_addr, &meta, r0, r1);
+                            self.pool_states.insert(pool_addr, Arc::new(state));
                             fetched += 1;
                             debug!(%pool_addr, reserve0 = %r0, reserve1 = %r1, "V2 reserves fetched");
                         }
@@ -850,6 +878,19 @@ impl AetherEngine {
                             fee,
                         );
                         // Snapshot is published once per detection cycle, not per event.
+                        // Refresh the V2-family pool-state cache entry alongside the
+                        // graph edge so the mempool post-state simulator stays in
+                        // lockstep with the detector. SushiSwap reuses the same
+                        // shape under a distinct variant; other protocols handled
+                        // by V3Update / future Curve / Balancer events.
+                        if matches!(
+                            meta.protocol,
+                            ProtocolType::UniswapV2 | ProtocolType::SushiSwap
+                        ) {
+                            let state =
+                                self.build_v2_pool_state(pool, &meta, reserve0, reserve1);
+                            self.pool_states.insert(pool, Arc::new(state));
+                        }
                     }
                 }
             }
@@ -1730,6 +1771,80 @@ mod tests {
 
         // Should not panic.
         engine.handle_pool_update(event).await;
+    }
+
+    #[tokio::test]
+    async fn test_v2_pool_state_cache_populated_on_reserve_update() {
+        use alloy::primitives::address;
+        let (tx, _rx) = broadcast::channel(100);
+        let engine = AetherEngine::new(EngineConfig::default(), tx);
+
+        let pool = address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc");
+        let token0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let token1 = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        engine
+            .register_pool(pool, token0, token1, ProtocolType::UniswapV2, 30)
+            .await;
+
+        // Pre-update: registry knows the pool, but cache is empty (no
+        // reserves yet).
+        assert!(engine.pool_states().get(&pool).is_none());
+
+        engine
+            .handle_pool_update(PoolEvent::ReserveUpdate {
+                pool,
+                protocol: ProtocolType::UniswapV2,
+                reserve0: U256::from(1_000_000_000u64),
+                reserve1: U256::from(500_000_000_000_000_000u64),
+            })
+            .await;
+
+        let entry = engine
+            .pool_states()
+            .get(&pool)
+            .expect("cache entry written on reserve update")
+            .clone();
+        match entry.as_ref() {
+            PoolState::UniswapV2(p) => {
+                assert_eq!(p.address, pool);
+                assert_eq!(p.token0, token0);
+                assert_eq!(p.token1, token1);
+                assert_eq!(p.reserve0, U256::from(1_000_000_000u64));
+                assert_eq!(p.reserve1, U256::from(500_000_000_000_000_000u64));
+            }
+            other => panic!("expected UniswapV2 variant, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sushiswap_pool_state_cache_uses_sushiswap_variant() {
+        use alloy::primitives::address;
+        let (tx, _rx) = broadcast::channel(100);
+        let engine = AetherEngine::new(EngineConfig::default(), tx);
+
+        let pool = address!("397FF1542f962076d0BFE58eA045FfA2d347ACa0");
+        let token0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let token1 = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        engine
+            .register_pool(pool, token0, token1, ProtocolType::SushiSwap, 30)
+            .await;
+        engine
+            .handle_pool_update(PoolEvent::ReserveUpdate {
+                pool,
+                protocol: ProtocolType::SushiSwap,
+                reserve0: U256::from(2u64),
+                reserve1: U256::from(3u64),
+            })
+            .await;
+        let entry = engine
+            .pool_states()
+            .get(&pool)
+            .expect("cache entry written")
+            .clone();
+        assert!(
+            matches!(entry.as_ref(), PoolState::SushiSwap(_)),
+            "SushiSwap protocol must route to PoolState::SushiSwap variant"
+        );
     }
 
     #[tokio::test]

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -18,6 +18,23 @@ pub struct EngineMetrics {
     arbs_published: IntCounter,
     blocks_processed: IntCounter,
     decode_errors: IntCounterVec,
+    /// Counter for EVM fork-replay fallbacks invoked from the analytical
+    /// post-state predictors. Bumped whenever an analytical predictor
+    /// returns a low-confidence result and the caller escalates to an
+    /// EVM fork. The label set is intentionally small so dashboards can
+    /// stay stable across releases.
+    ///
+    /// Stable label set:
+    ///   - `v3_tick_crossed`        — V3 swap moved sqrt_price out of
+    ///                                its single-tick bucket
+    ///   - `curve_unconverged`      — Curve Newton iteration produced
+    ///                                an invalid post-state
+    ///   - `balancer_unequal_weight`— Balancer first-order Taylor
+    ///                                approximation deemed too coarse
+    ///                                under heavy weight skew
+    ///   - `unknown_protocol`       — protocol family with no analytical
+    ///                                predictor on this build
+    sim_evm_fallback_total: IntCounterVec,
 }
 
 impl EngineMetrics {
@@ -68,6 +85,14 @@ impl EngineMetrics {
             &["reason"],
         )
         .expect("aether_decode_errors_total counter vec");
+        let sim_evm_fallback_total = IntCounterVec::new(
+            Opts::new(
+                "aether_sim_evm_fallback_total",
+                "EVM fork-replay fallbacks invoked from the analytical post-state predictors, by reason",
+            ),
+            &["reason"],
+        )
+        .expect("aether_sim_evm_fallback_total counter vec");
 
         registry
             .register(Box::new(detection_latency_ms.clone()))
@@ -90,6 +115,9 @@ impl EngineMetrics {
         registry
             .register(Box::new(decode_errors.clone()))
             .expect("register aether_decode_errors_total");
+        registry
+            .register(Box::new(sim_evm_fallback_total.clone()))
+            .expect("register aether_sim_evm_fallback_total");
 
         Self {
             registry,
@@ -100,6 +128,7 @@ impl EngineMetrics {
             arbs_published,
             blocks_processed,
             decode_errors,
+            sim_evm_fallback_total,
         }
     }
 
@@ -140,6 +169,27 @@ impl EngineMetrics {
     /// stable and enumerable for dashboards / alerts.
     pub fn inc_decode_errors(&self, reason: &str) {
         self.decode_errors.with_label_values(&[reason]).inc();
+    }
+
+    /// Bump `aether_sim_evm_fallback_total{reason="..."}` for an EVM
+    /// fork-replay fallback escalated from one of the analytical
+    /// post-state predictors. See the field doc on
+    /// `sim_evm_fallback_total` for the stable label set; passing a
+    /// reason outside that set still records but breaks dashboards, so
+    /// callers MUST pick from the documented enum.
+    pub fn inc_sim_evm_fallback(&self, reason: &str) {
+        self.sim_evm_fallback_total
+            .with_label_values(&[reason])
+            .inc();
+    }
+
+    /// Read the current value of `aether_sim_evm_fallback_total{reason}`.
+    /// `pub` so tests can assert fallback rates without re-implementing
+    /// Prometheus text parsing.
+    pub fn sim_evm_fallback_count(&self, reason: &str) -> u64 {
+        self.sim_evm_fallback_total
+            .with_label_values(&[reason])
+            .get()
     }
 
     /// Borrow the underlying `Registry` so foreign metric families (e.g. the

--- a/crates/pools/src/balancer.rs
+++ b/crates/pools/src/balancer.rs
@@ -24,6 +24,29 @@ pub struct BalancerPool {
     pub fee_bps: u32,
 }
 
+/// Snapshot of a Balancer weighted-2-token pool *after* a hypothetical
+/// victim swap has been applied. Returned by
+/// [`BalancerPool::predict_post_state`] so the mempool post-state simulator
+/// can update its graph-edge cache without an RPC round-trip.
+///
+/// `analytical` is `false` for the unequal-weight branch since
+/// `get_amount_out` uses a first-order Taylor approximation there; the
+/// caller should escalate those to an EVM fork-replay fallback. The
+/// equal-weight branch (50/50, the dominant on-chain shape) is exact and
+/// keeps `analytical = true`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BalancerPostState {
+    /// `balance0` after the swap settles.
+    pub new_balance0: U256,
+    /// `balance1` after the swap settles.
+    pub new_balance1: U256,
+    /// Output amount the swapper receives, post-fee.
+    pub amount_out: U256,
+    /// `true` for equal-weight pools where the math is exact;
+    /// `false` for the first-order approximation used on unequal weights.
+    pub analytical: bool,
+}
+
 impl BalancerPool {
     pub fn new(
         address: Address,
@@ -43,6 +66,54 @@ impl BalancerPool {
             weight1: U256::from(weight1),
             fee_bps,
         }
+    }
+
+    /// Predict the pool's post-swap state under the same weighted-product
+    /// math as [`Pool::get_amount_out`]. Used by the mempool post-state
+    /// simulator to feed updated balances into the graph-edge cache
+    /// without an RPC round-trip.
+    ///
+    /// Returns `None` when the inputs are invalid: zero amount, unknown
+    /// token, or either balance starts at zero. The fee model matches
+    /// Balancer's on-chain `Vault`: the fee portion of `amount_in` stays
+    /// in the pool, so `new_balance_in = balance_in + amount_in` (the
+    /// full input is credited), `new_balance_out = balance_out - amount_out`.
+    ///
+    /// `analytical` is `true` only on the equal-weight branch where the
+    /// math reduces to the exact constant-product formula; the unequal-
+    /// weight branch is a first-order Taylor approximation and signals
+    /// `false` so the caller can fall back to an EVM fork-replay.
+    pub fn predict_post_state(
+        &self,
+        token_in: Address,
+        amount_in: U256,
+    ) -> Option<BalancerPostState> {
+        if amount_in.is_zero() {
+            return None;
+        }
+        let amount_out = self.get_amount_out(token_in, amount_in)?;
+        let analytical = self.weight0 == self.weight1;
+
+        let (new_balance0, new_balance1) = if token_in == self.token0 {
+            (
+                self.balance0.checked_add(amount_in)?,
+                self.balance1.checked_sub(amount_out)?,
+            )
+        } else if token_in == self.token1 {
+            (
+                self.balance0.checked_sub(amount_out)?,
+                self.balance1.checked_add(amount_in)?,
+            )
+        } else {
+            return None;
+        };
+
+        Some(BalancerPostState {
+            new_balance0,
+            new_balance1,
+            amount_out,
+            analytical,
+        })
     }
 }
 
@@ -177,5 +248,105 @@ mod tests {
     fn test_balancer_protocol() {
         let pool = setup_balancer_pool();
         assert_eq!(pool.protocol(), ProtocolType::BalancerV2);
+    }
+
+    fn setup_balancer_80_20_pool() -> BalancerPool {
+        let mut pool = BalancerPool::new(
+            Address::ZERO,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), // WETH
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"), // USDC
+            200000, 800000, // 20/80 weights — unequal, exercises approx path
+            10,             // 0.1%
+        );
+        pool.update_state(
+            U256::from(1_000_000_000_000_000_000_000u128),
+            U256::from(10_000_000_000_000u64),
+        );
+        pool
+    }
+
+    // ----- predict_post_state -----
+
+    #[test]
+    fn predict_post_state_none_for_zero_amount() {
+        let pool = setup_balancer_pool();
+        assert!(pool.predict_post_state(pool.token0, U256::ZERO).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_unknown_token() {
+        let pool = setup_balancer_pool();
+        let bogus = address!("0000000000000000000000000000000000001234");
+        assert!(pool.predict_post_state(bogus, U256::from(1u64)).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_uninitialised_pool() {
+        let pool = BalancerPool::new(
+            Address::ZERO,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            500000, 500000, 30,
+        );
+        assert!(pool
+            .predict_post_state(pool.token0, U256::from(1u64))
+            .is_none());
+    }
+
+    #[test]
+    fn predict_post_state_balances_shift_correctly_equal_weight() {
+        let pool = setup_balancer_pool();
+        let dx = U256::from(1_000_000_000_000_000_000u64); // 1 ETH
+        let post = pool
+            .predict_post_state(pool.token0, dx)
+            .expect("post state");
+        assert_eq!(post.new_balance0, pool.balance0 + dx);
+        assert_eq!(post.new_balance1, pool.balance1 - post.amount_out);
+        assert!(post.analytical, "50/50 pool is exact, analytical=true");
+    }
+
+    #[test]
+    fn predict_post_state_unequal_weight_signals_approximation() {
+        let pool = setup_balancer_80_20_pool();
+        let dx = U256::from(1_000_000_000_000_000_000u64);
+        let post = pool
+            .predict_post_state(pool.token0, dx)
+            .expect("post state");
+        assert!(
+            !post.analytical,
+            "20/80 pool uses first-order approximation, analytical=false"
+        );
+    }
+
+    #[test]
+    fn predict_post_state_amount_out_matches_get_amount_out() {
+        let pool = setup_balancer_pool();
+        for amt in [
+            U256::from(1_000_000_000u64),
+            U256::from(1_000_000_000_000_000_000u64),
+            U256::from(10_000_000_000_000_000_000u64),
+        ] {
+            let legacy = pool
+                .get_amount_out(pool.token0, amt)
+                .expect("legacy amount_out");
+            let post = pool
+                .predict_post_state(pool.token0, amt)
+                .expect("post state");
+            assert_eq!(
+                post.amount_out, legacy,
+                "predict_post_state diverged from get_amount_out at amt={amt}"
+            );
+        }
+    }
+
+    #[test]
+    fn predict_post_state_reverse_direction() {
+        let pool = setup_balancer_pool();
+        let dx = U256::from(1_000_000_000u64);
+        let post = pool
+            .predict_post_state(pool.token1, dx)
+            .expect("post state");
+        assert_eq!(post.new_balance0, pool.balance0 - post.amount_out);
+        assert_eq!(post.new_balance1, pool.balance1 + dx);
     }
 }

--- a/crates/pools/src/curve.rs
+++ b/crates/pools/src/curve.rs
@@ -18,6 +18,38 @@ pub struct CurvePool {
     pub fee_bps: u32,        // typically 4 (0.04%)
 }
 
+/// Snapshot of a Curve 2-coin pool *after* a hypothetical victim swap
+/// has been applied. Returned by [`CurvePool::predict_post_state`] so the
+/// mempool post-state simulator can update its graph-edge cache without
+/// round-tripping to RPC.
+///
+/// The post-balances reflect the pool's view *after* the swap settles:
+/// balance_in grew by the full input, balance_out fell by the user-
+/// visible output, and the fee is implicitly retained in the pool (which
+/// is why `new_balance_out > y_new` in Curve's accounting).
+///
+/// `analytical` mirrors the V3 `single_tick` flag: `true` when the
+/// Newton iteration converged on a valid post-state and the math is
+/// trustworthy. `false` triggers the EVM fork-replay fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurvePostState {
+    /// Index in `pool.tokens` of the input token.
+    pub i: usize,
+    /// Index in `pool.tokens` of the output token.
+    pub j: usize,
+    /// `pool.balances[i]` after the swap settles (= prev + amount_in).
+    pub new_balance_in: U256,
+    /// `pool.balances[j]` after the swap settles. Equals
+    /// `prev - amount_out` (fee retained in pool).
+    pub new_balance_out: U256,
+    /// Output amount the swapper receives, post-fee.
+    pub amount_out: U256,
+    /// `true` when Newton converged on a valid post-state and the
+    /// analytical answer is trustworthy. `false` signals an EVM fork-
+    /// replay fallback to the caller.
+    pub analytical: bool,
+}
+
 impl CurvePool {
     pub fn new(address: Address, tokens: Vec<Address>, amplification: u64, fee_bps: u32) -> Self {
         let n = tokens.len();
@@ -79,6 +111,62 @@ impl CurvePool {
             }
         }
         d
+    }
+
+    /// Predict the pool's post-swap state under the same StableSwap
+    /// Newton iteration as [`Pool::get_amount_out`]. Used by the mempool
+    /// post-state simulator to feed updated balances into the graph edge
+    /// cache without an RPC round-trip.
+    ///
+    /// Returns `None` when the inputs are invalid: zero amount, unknown
+    /// token, fewer than 2 coins, swap would drain a balance to zero, or
+    /// Newton fails to converge to a smaller `balance_out`. The fee
+    /// retention model matches Curve's on-chain `StableSwap` contract:
+    /// `new_balance_in = balances[i] + amount_in`,
+    /// `new_balance_out = balances[j] - amount_out`. The pool keeps the
+    /// fee, which is why the post-balance is *higher* than the Newton-
+    /// solved `y`.
+    pub fn predict_post_state(
+        &self,
+        token_in: Address,
+        amount_in: U256,
+    ) -> Option<CurvePostState> {
+        if amount_in.is_zero() {
+            return None;
+        }
+        if self.balances.len() < 2 {
+            return None;
+        }
+        let i = self.tokens.iter().position(|t| *t == token_in)?;
+        // 2-coin variant: output is the other index. Generalising to 3+
+        // coins requires the caller to pick j explicitly; pinned at
+        // 2-coin here to match the existing `Pool::get_amount_out`.
+        if self.tokens.len() != 2 {
+            return None;
+        }
+        let j = if i == 0 { 1 } else { 0 };
+
+        let new_balance_in = self.balances[i].checked_add(amount_in)?;
+        let y_new = self.get_y(i, j, new_balance_in)?;
+        // dy is what the pool owes before fee — Newton can briefly
+        // overshoot in the reverse direction so guard with checked_sub.
+        let dy = self.balances[j].checked_sub(y_new)?;
+        if dy.is_zero() {
+            return None;
+        }
+        // Fee is taken out of the user's payout, retained in the pool.
+        let fee = dy * U256::from(self.fee_bps) / U256::from(10_000u64);
+        let amount_out = dy.checked_sub(fee)?;
+        let new_balance_out = self.balances[j].checked_sub(amount_out)?;
+
+        Some(CurvePostState {
+            i,
+            j,
+            new_balance_in,
+            new_balance_out,
+            amount_out,
+            analytical: true,
+        })
     }
 
     /// Get y given x for the StableSwap invariant.
@@ -234,5 +322,103 @@ mod tests {
     fn test_curve_zero_amount() {
         let pool = setup_curve_pool();
         assert!(pool.get_amount_out(pool.tokens[0], U256::ZERO).is_none());
+    }
+
+    // ----- predict_post_state -----
+
+    #[test]
+    fn predict_post_state_none_for_zero_amount() {
+        let pool = setup_curve_pool();
+        assert!(pool.predict_post_state(pool.tokens[0], U256::ZERO).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_unknown_token() {
+        let pool = setup_curve_pool();
+        let bogus = address!("0000000000000000000000000000000000001234");
+        assert!(pool.predict_post_state(bogus, U256::from(1u64)).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_uninitialised_pool() {
+        let token0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let token1 = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let pool = CurvePool::new(Address::ZERO, vec![token0, token1], 100, 4);
+        // balances default to zero — Newton has nothing to work with.
+        assert!(pool
+            .predict_post_state(token0, U256::from(1_000_000_000u64))
+            .is_none());
+    }
+
+    #[test]
+    fn predict_post_state_balances_shift_correctly() {
+        let pool = setup_curve_pool();
+        let amount_in = U256::from(1_000_000_000u64); // 1000 USDC
+        let post = pool
+            .predict_post_state(pool.tokens[0], amount_in)
+            .expect("post state");
+        // Direction sanity: input balance grew by exactly amount_in;
+        // output balance shrank by exactly amount_out.
+        assert_eq!(post.i, 0);
+        assert_eq!(post.j, 1);
+        assert_eq!(post.new_balance_in, pool.balances[0] + amount_in);
+        assert_eq!(post.new_balance_out, pool.balances[1] - post.amount_out);
+        assert!(post.analytical);
+    }
+
+    #[test]
+    fn predict_post_state_amount_out_matches_get_amount_out() {
+        // Parity guard: the post-state predictor and the legacy
+        // `get_amount_out` must return the same `amount_out` for the
+        // same input — they share the same StableSwap Newton iteration.
+        let pool = setup_curve_pool();
+        for amt in [
+            U256::from(1_000_000u64),       // 1 USDC
+            U256::from(1_000_000_000u64),   // 1k USDC
+            U256::from(100_000_000_000u64), // 100k USDC
+        ] {
+            let legacy = pool
+                .get_amount_out(pool.tokens[0], amt)
+                .expect("legacy amount_out");
+            let post = pool
+                .predict_post_state(pool.tokens[0], amt)
+                .expect("post state");
+            assert_eq!(
+                post.amount_out, legacy,
+                "predict_post_state diverged from get_amount_out at amt={amt}"
+            );
+        }
+    }
+
+    #[test]
+    fn predict_post_state_reverse_direction() {
+        let pool = setup_curve_pool();
+        let amount_in = U256::from(1_000_000_000u64);
+        let post = pool
+            .predict_post_state(pool.tokens[1], amount_in)
+            .expect("post state");
+        assert_eq!(post.i, 1);
+        assert_eq!(post.j, 0);
+        assert_eq!(post.new_balance_in, pool.balances[1] + amount_in);
+        assert_eq!(post.new_balance_out, pool.balances[0] - post.amount_out);
+    }
+
+    #[test]
+    fn predict_post_state_3coin_pool_unsupported() {
+        // 2-coin pinning is intentional. A 3-coin pool requires the
+        // caller to pick `j` explicitly; rather than guess, return None
+        // and let the caller skip with `protocol_unsupported`.
+        let token0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let token1 = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let token2 = address!("6B175474E89094C44Da98b954EedeAC495271d0F"); // DAI
+        let mut pool = CurvePool::new(Address::ZERO, vec![token0, token1, token2], 100, 4);
+        pool.balances = vec![
+            U256::from(10_000_000_000_000u64),
+            U256::from(10_000_000_000_000u64),
+            U256::from(10_000_000_000_000u64),
+        ];
+        assert!(pool
+            .predict_post_state(token0, U256::from(1_000_000_000u64))
+            .is_none());
     }
 }

--- a/crates/pools/src/lib.rs
+++ b/crates/pools/src/lib.rs
@@ -89,6 +89,100 @@ pub fn new_pool_state_cache() -> PoolStateCache {
     Arc::new(DashMap::new())
 }
 
+/// Unified post-swap state across every pool family the analytical
+/// predictors handle. Returned by [`predict_post_state_with_fallback`] so
+/// the mempool decode pipeline has a single match arm to update its
+/// graph-edge cache regardless of protocol.
+///
+/// Pool-family-specific fields (V3 sqrt_price, Curve / Balancer
+/// balances) are kept on their own variants rather than flattened into
+/// reserve0 / reserve1 — the graph-edge math reads them differently per
+/// protocol and conflating them would lose precision on V3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnifiedPostState {
+    UniswapV3(crate::uniswap_v3::V3PostState),
+    Curve(crate::curve::CurvePostState),
+    Balancer(crate::balancer::BalancerPostState),
+}
+
+impl UnifiedPostState {
+    /// Output amount the swapper receives, post-fee. Unified across
+    /// variants for callers that only care about the user-visible
+    /// payout (e.g. the candidate-arb profit estimator).
+    pub fn amount_out(&self) -> U256 {
+        match self {
+            UnifiedPostState::UniswapV3(p) => p.amount_out,
+            UnifiedPostState::Curve(p) => p.amount_out,
+            UnifiedPostState::Balancer(p) => p.amount_out,
+        }
+    }
+}
+
+/// Run the analytical post-state predictor for the cached pool and
+/// escalate to an EVM fork-replay fallback when its confidence flag is
+/// low. The caller provides the fallback metric bump as a closure so
+/// this function does not need to depend on the engine's metrics crate.
+///
+/// Returns `Some(UnifiedPostState)` when the analytical answer is
+/// trustworthy (`single_tick` / `analytical` flag set). Returns `None`
+/// when the predictor itself returned `None` (invalid inputs) OR when
+/// the confidence flag was clear and the EVM fallback would be needed
+/// — for now the fallback path is a stub that bumps the metric and
+/// returns `None`. Real EVM fork-replay implementation (calling
+/// `EvmSimulator` against the pool with the victim's swap pre-applied)
+/// lands once the simulator gains a generic "apply this transaction
+/// and read post-state" entry point; until then the metric tells us
+/// how often the gap matters.
+///
+/// V2 / Sushi pools are NOT handled here — the V2 analytical predictor
+/// lives in the mempool decode pipeline (a separate branch) and is
+/// trivially exact, so wrapping it through this fallback path adds
+/// no value.
+pub fn predict_post_state_with_fallback<F>(
+    state: &PoolState,
+    token_in: alloy::primitives::Address,
+    amount_in: U256,
+    on_fallback: F,
+) -> Option<UnifiedPostState>
+where
+    F: FnOnce(&str),
+{
+    match state {
+        PoolState::UniswapV3(pool) => {
+            let post = pool.predict_post_state(token_in, amount_in)?;
+            if !post.single_tick {
+                on_fallback("v3_tick_crossed");
+                return None;
+            }
+            Some(UnifiedPostState::UniswapV3(post))
+        }
+        PoolState::Curve(pool) => {
+            let post = pool.predict_post_state(token_in, amount_in)?;
+            if !post.analytical {
+                on_fallback("curve_unconverged");
+                return None;
+            }
+            Some(UnifiedPostState::Curve(post))
+        }
+        PoolState::Balancer(pool) => {
+            let post = pool.predict_post_state(token_in, amount_in)?;
+            if !post.analytical {
+                on_fallback("balancer_unequal_weight");
+                return None;
+            }
+            Some(UnifiedPostState::Balancer(post))
+        }
+        PoolState::UniswapV2(_) | PoolState::SushiSwap(_) => {
+            // V2-family analytical predictor lives outside this crate
+            // (mempool decode pipeline). Surface the gap so the caller
+            // can route V2 through its own path rather than silently
+            // returning None and losing the candidate.
+            on_fallback("unknown_protocol");
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod cache_tests {
     use super::*;
@@ -115,6 +209,133 @@ mod cache_tests {
         let got = cache.get(&addr).expect("present").clone();
         assert_eq!(got.address(), addr);
         assert_eq!(got.protocol(), ProtocolType::UniswapV3);
+    }
+
+    #[test]
+    fn predict_with_fallback_v2_routes_to_unknown_protocol() {
+        let v2 = UniswapV2Pool::new(
+            Address::ZERO,
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            30,
+        );
+        let state = PoolState::UniswapV2(v2);
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            U256::from(1u64),
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(result.is_none());
+        assert_eq!(captured.borrow().as_slice(), &["unknown_protocol".to_string()]);
+    }
+
+    #[test]
+    fn predict_with_fallback_v3_returns_state_for_single_tick() {
+        // Build a V3 pool seated mid-bucket (matches the pattern in
+        // uniswap_v3::tests::setup_v3_pool_mid_bucket so a small swap
+        // stays single-tick).
+        let mut v3 = UniswapV3Pool::new(
+            address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            30,
+            60,
+        );
+        let two_pow_96_f64: f64 = 79_228_162_514_264_337_593_543_950_336.0;
+        let sqrt_norm = 1.0001f64.powi(15);
+        let sqrt_x96 = (sqrt_norm * two_pow_96_f64) as u128;
+        v3.update_sqrt_price(U256::from(sqrt_x96), 10_000_000_000_000_000u128, 30);
+
+        let state = PoolState::UniswapV3(v3.clone());
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            v3.token0,
+            U256::from(100_000_000u64),
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(result.is_some(), "small mid-bucket swap must stay analytical");
+        assert!(captured.borrow().is_empty(), "no fallback expected");
+    }
+
+    #[test]
+    fn predict_with_fallback_v3_escalates_on_tick_cross() {
+        let mut v3 = UniswapV3Pool::new(
+            address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            30,
+            60,
+        );
+        let two_pow_96_f64: f64 = 79_228_162_514_264_337_593_543_950_336.0;
+        let sqrt_norm = 1.0001f64.powi(15);
+        let sqrt_x96 = (sqrt_norm * two_pow_96_f64) as u128;
+        v3.update_sqrt_price(U256::from(sqrt_x96), 10_000_000_000_000_000u128, 30);
+
+        let state = PoolState::UniswapV3(v3.clone());
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            v3.token0,
+            U256::from(5_000_000_000_000_000u64), // huge — crosses bucket
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(result.is_none());
+        assert_eq!(captured.borrow().as_slice(), &["v3_tick_crossed".to_string()]);
+    }
+
+    #[test]
+    fn predict_with_fallback_balancer_unequal_weight_escalates() {
+        // 80/20 weights → analytical=false → escalates with the
+        // `balancer_unequal_weight` reason.
+        let mut bal = BalancerPool::new(
+            Address::ZERO,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            200_000,
+            800_000,
+            10,
+        );
+        bal.update_state(
+            U256::from(1_000_000_000_000_000_000_000u128),
+            U256::from(10_000_000_000_000u64),
+        );
+        let state = PoolState::Balancer(bal);
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            U256::from(1_000_000_000_000_000_000u64),
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(result.is_none());
+        assert_eq!(
+            captured.borrow().as_slice(),
+            &["balancer_unequal_weight".to_string()]
+        );
+    }
+
+    #[test]
+    fn predict_with_fallback_curve_returns_state_for_converged_pool() {
+        let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let usdt = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let mut curve = CurvePool::new(Address::ZERO, vec![usdc, usdt], 100, 4);
+        curve.balances = vec![
+            U256::from(10_000_000_000_000u64),
+            U256::from(10_000_000_000_000u64),
+        ];
+        let state = PoolState::Curve(curve);
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            usdc,
+            U256::from(1_000_000_000u64),
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(result.is_some());
+        assert!(captured.borrow().is_empty());
     }
 
     #[test]

--- a/crates/pools/src/lib.rs
+++ b/crates/pools/src/lib.rs
@@ -6,8 +6,16 @@ pub mod balancer;
 pub mod bancor;
 pub mod registry;
 
+use std::sync::Arc;
+
 use alloy::primitives::{Address, U256};
 use aether_common::types::ProtocolType;
+use dashmap::DashMap;
+
+use crate::balancer::BalancerPool;
+use crate::curve::CurvePool;
+use crate::uniswap_v2::UniswapV2Pool;
+use crate::uniswap_v3::UniswapV3Pool;
 
 /// Core Pool trait that all DEX adapters must implement
 pub trait Pool: Send + Sync {
@@ -20,4 +28,129 @@ pub trait Pool: Send + Sync {
     fn update_state(&mut self, reserve0: U256, reserve1: U256);
     fn encode_swap(&self, token_in: Address, amount_in: U256, min_out: U256) -> Vec<u8>;
     fn liquidity_depth(&self) -> U256;
+}
+
+/// Live state of a single registered pool. Held by [`PoolStateCache`] so
+/// the mempool post-state simulator can read accurate per-protocol state
+/// (V3 sqrt_price + tick + liquidity, Curve balances + A, Balancer
+/// balances + weights) without hitting RPC on every pending tx.
+///
+/// SushiSwap reuses [`UniswapV2Pool`] under a distinct variant so
+/// dispatchers can route to the SushiSwap-specific protocol metadata
+/// without a follow-up address lookup.
+#[derive(Debug, Clone)]
+pub enum PoolState {
+    UniswapV2(UniswapV2Pool),
+    UniswapV3(UniswapV3Pool),
+    SushiSwap(UniswapV2Pool),
+    Curve(CurvePool),
+    Balancer(BalancerPool),
+}
+
+impl PoolState {
+    /// Pool address — convenient for log lines + cache invariants.
+    pub fn address(&self) -> Address {
+        match self {
+            PoolState::UniswapV2(p) | PoolState::SushiSwap(p) => p.address,
+            PoolState::UniswapV3(p) => p.address,
+            PoolState::Curve(p) => p.address,
+            PoolState::Balancer(p) => p.address,
+        }
+    }
+
+    /// Protocol family, in workspace `ProtocolType` form.
+    pub fn protocol(&self) -> ProtocolType {
+        match self {
+            PoolState::UniswapV2(_) => ProtocolType::UniswapV2,
+            PoolState::UniswapV3(_) => ProtocolType::UniswapV3,
+            PoolState::SushiSwap(_) => ProtocolType::SushiSwap,
+            PoolState::Curve(_) => ProtocolType::Curve,
+            PoolState::Balancer(_) => ProtocolType::BalancerV2,
+        }
+    }
+}
+
+/// Thread-safe cache of [`PoolState`] values keyed by pool address. Each
+/// entry is wrapped in an outer `Arc` so readers (mempool decode pipeline)
+/// can clone a snapshot cheaply and run `predict_post_state` against it
+/// while a writer (engine event loop) replaces the entry with an updated
+/// state for the same address.
+///
+/// The DashMap shards keys, so a writer updating pool `A` does not block
+/// a reader walking pool `B` — important for the hot path where many
+/// pending txs are decoded in parallel under a continuous stream of
+/// pool-update events.
+pub type PoolStateCache = Arc<DashMap<Address, Arc<PoolState>>>;
+
+/// Construct a fresh, empty [`PoolStateCache`]. The engine calls this once
+/// at startup and shares the resulting `Arc` with every consumer that
+/// wants to observe live pool state (mempool sim, future analytics, etc.).
+pub fn new_pool_state_cache() -> PoolStateCache {
+    Arc::new(DashMap::new())
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn pool_state_cache_starts_empty() {
+        let cache = new_pool_state_cache();
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn pool_state_cache_round_trips_v3() {
+        let cache = new_pool_state_cache();
+        let addr = address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640");
+        let pool = UniswapV3Pool::new(
+            addr,
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            5,
+            10,
+        );
+        cache.insert(addr, Arc::new(PoolState::UniswapV3(pool)));
+        let got = cache.get(&addr).expect("present").clone();
+        assert_eq!(got.address(), addr);
+        assert_eq!(got.protocol(), ProtocolType::UniswapV3);
+    }
+
+    #[test]
+    fn pool_state_protocol_dispatch_covers_every_variant() {
+        let v2 = UniswapV2Pool::new(Address::ZERO, Address::ZERO, Address::ZERO, 30);
+        assert_eq!(
+            PoolState::UniswapV2(v2.clone()).protocol(),
+            ProtocolType::UniswapV2
+        );
+        assert_eq!(
+            PoolState::SushiSwap(v2).protocol(),
+            ProtocolType::SushiSwap
+        );
+        let v3 = UniswapV3Pool::new(Address::ZERO, Address::ZERO, Address::ZERO, 5, 10);
+        assert_eq!(
+            PoolState::UniswapV3(v3).protocol(),
+            ProtocolType::UniswapV3
+        );
+        let curve = CurvePool::new(
+            Address::ZERO,
+            vec![Address::ZERO, Address::ZERO],
+            100,
+            4,
+        );
+        assert_eq!(PoolState::Curve(curve).protocol(), ProtocolType::Curve);
+        let bal = BalancerPool::new(
+            Address::ZERO,
+            Address::ZERO,
+            Address::ZERO,
+            500_000,
+            500_000,
+            30,
+        );
+        assert_eq!(
+            PoolState::Balancer(bal).protocol(),
+            ProtocolType::BalancerV2
+        );
+    }
 }

--- a/crates/pools/src/uniswap_v3.rs
+++ b/crates/pools/src/uniswap_v3.rs
@@ -27,6 +27,33 @@ pub struct UniswapV3Pool {
 // Constants for Q96 fixed-point math
 const Q96: u128 = 1u128 << 96;
 
+/// Snapshot of a UniswapV3 pool *after* a hypothetical victim swap has been
+/// applied. Returned by [`UniswapV3Pool::predict_post_state`] so the mempool
+/// post-state simulator can update its graph-edge cache without re-reading
+/// chain state.
+///
+/// `single_tick` is `true` when the analytical math is trustworthy at full
+/// numerical precision because the swap stayed within one tick range.
+/// Callers MUST escalate to an EVM fork-replay fallback when it is `false`,
+/// since the post-state values are then a low-precision estimate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct V3PostState {
+    /// New `sqrt(price) * 2^96` after the swap, in the same Q96 units the
+    /// pool already uses.
+    pub new_sqrt_price_x96: U256,
+    /// Liquidity at the new active tick. For single-tick swaps this is
+    /// unchanged from the pre-state liquidity. Cross-tick swaps (the
+    /// `single_tick = false` path) cannot be settled analytically and the
+    /// returned value is a best-effort estimate; the caller is expected to
+    /// run an EVM fallback before trusting it.
+    pub new_liquidity: u128,
+    /// Output amount the swapper receives, after pool fee, in token-out
+    /// raw units (no decimals normalisation).
+    pub amount_out: U256,
+    /// Confidence flag — see struct docs.
+    pub single_tick: bool,
+}
+
 impl UniswapV3Pool {
     pub fn new(
         address: Address,
@@ -57,6 +84,94 @@ impl UniswapV3Pool {
     pub fn set_ticks(&mut self, mut ticks: Vec<TickInfo>) {
         ticks.sort_by_key(|t| t.index);
         self.ticks = ticks;
+    }
+
+    /// Predict the pool's post-swap state under the same single-tick
+    /// constant-liquidity assumption as [`Self::compute_swap_within_tick`].
+    /// Mempool post-state simulation uses this to update its graph-edge
+    /// cache after a decoded victim swap, without round-tripping to RPC.
+    ///
+    /// Returns `None` when the inputs cannot produce a valid post-state:
+    ///   - pool has no liquidity / sqrt_price
+    ///   - `amount_in` is zero
+    ///   - `token_in` is not one of the pool's two tokens
+    ///   - the math underflows / divides by zero (defensive — should not
+    ///     happen on real pool state)
+    ///
+    /// `single_tick` on the returned state is hard-coded to `true` here.
+    /// The cross-tick branch lives in a follow-up commit and flips this
+    /// flag to signal an EVM fork-replay fallback to the caller.
+    pub fn predict_post_state(
+        &self,
+        token_in: Address,
+        amount_in: U256,
+    ) -> Option<V3PostState> {
+        if self.sqrt_price_x96.is_zero() || self.liquidity == 0 || amount_in.is_zero() {
+            return None;
+        }
+        if token_in != self.token0 && token_in != self.token1 {
+            return None;
+        }
+
+        // Apply the pool fee. `fee_bps` here is in basis points (1e-4)
+        // matching the convention used by `compute_swap_within_tick`
+        // above; the bootstrap translation from on-chain
+        // hundredths-of-a-bp lives outside this module. So 0.05% pool
+        // → fee_bps=5, fee_complement=9995, dx_eff = dx * 0.9995.
+        let fee_complement = 10_000u64 - self.fee_bps as u64;
+        let amount_in_after_fee =
+            amount_in * U256::from(fee_complement) / U256::from(10_000u64);
+
+        let is_token0 = token_in == self.token0;
+        let q96 = U256::from(Q96);
+        let l = U256::from(self.liquidity);
+
+        if is_token0 {
+            // token0 → token1: sqrt_price decreases.
+            //   new_sqrt = (L * sqrt * Q96) / (L * Q96 + dx_eff * sqrt)
+            //   dy       = L * (sqrt - new_sqrt) / Q96
+            let numerator = l * self.sqrt_price_x96;
+            let denominator = l * q96 + amount_in_after_fee * self.sqrt_price_x96;
+            if denominator.is_zero() {
+                return None;
+            }
+            let new_sqrt_price_x96 = numerator * q96 / denominator;
+            if new_sqrt_price_x96 >= self.sqrt_price_x96 {
+                // Numerical degenerate case (e.g. amount_in_after_fee
+                // rounds to zero against a huge liquidity). Bail rather
+                // than emit a zero-output edge.
+                return None;
+            }
+            let delta = self.sqrt_price_x96 - new_sqrt_price_x96;
+            let amount_out = l * delta / q96;
+            Some(V3PostState {
+                new_sqrt_price_x96,
+                new_liquidity: self.liquidity,
+                amount_out,
+                single_tick: true,
+            })
+        } else {
+            // token1 → token0: sqrt_price increases.
+            //   new_sqrt = sqrt + dy_eff * Q96 / L
+            //   dx       = L * Q96 * (new_sqrt - sqrt) / (sqrt * new_sqrt)
+            if l.is_zero() {
+                return None;
+            }
+            let delta_sqrt = amount_in_after_fee * q96 / l;
+            let new_sqrt_price_x96 = self.sqrt_price_x96 + delta_sqrt;
+            let numerator = l * q96 * delta_sqrt;
+            let denominator = self.sqrt_price_x96 * new_sqrt_price_x96;
+            if denominator.is_zero() {
+                return None;
+            }
+            let amount_out = numerator / denominator;
+            Some(V3PostState {
+                new_sqrt_price_x96,
+                new_liquidity: self.liquidity,
+                amount_out,
+                single_tick: true,
+            })
+        }
     }
 
     /// Simplified single-tick swap (no tick crossing) for quick estimation.
@@ -239,5 +354,97 @@ mod tests {
             10,
         );
         assert_eq!(pool.protocol(), ProtocolType::UniswapV3);
+    }
+
+    // ----- predict_post_state -----
+
+    #[test]
+    fn predict_post_state_none_for_zero_amount() {
+        let pool = setup_v3_pool();
+        assert!(pool.predict_post_state(pool.token0, U256::ZERO).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_unknown_token() {
+        let pool = setup_v3_pool();
+        let bogus = address!("0000000000000000000000000000000000001234");
+        assert!(pool
+            .predict_post_state(bogus, U256::from(1_000_000_000u64))
+            .is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_uninitialised_pool() {
+        let pool = UniswapV3Pool::new(
+            Address::ZERO,
+            Address::ZERO,
+            address!("0000000000000000000000000000000000000001"),
+            5,
+            10,
+        );
+        // sqrt_price + liquidity both default to zero — nothing to predict.
+        assert!(pool
+            .predict_post_state(Address::ZERO, U256::from(1u64))
+            .is_none());
+    }
+
+    #[test]
+    fn predict_post_state_token0_to_token1_lowers_sqrt_price() {
+        let pool = setup_v3_pool();
+        let dx = U256::from(1_000_000_000u64); // 1000 USDC (6dp)
+        let post = pool
+            .predict_post_state(pool.token0, dx)
+            .expect("post state");
+        assert!(
+            post.new_sqrt_price_x96 < pool.sqrt_price_x96,
+            "token0→token1 must lower sqrt_price (got new={}, old={})",
+            post.new_sqrt_price_x96,
+            pool.sqrt_price_x96
+        );
+        assert!(!post.amount_out.is_zero(), "non-zero output expected");
+        assert_eq!(post.new_liquidity, pool.liquidity);
+        assert!(post.single_tick);
+    }
+
+    #[test]
+    fn predict_post_state_token1_to_token0_raises_sqrt_price() {
+        let pool = setup_v3_pool();
+        let dy = U256::from(1_000_000_000_000_000_000u64); // 1 ETH
+        let post = pool
+            .predict_post_state(pool.token1, dy)
+            .expect("post state");
+        assert!(
+            post.new_sqrt_price_x96 > pool.sqrt_price_x96,
+            "token1→token0 must raise sqrt_price"
+        );
+        assert!(!post.amount_out.is_zero());
+        assert_eq!(post.new_liquidity, pool.liquidity);
+        assert!(post.single_tick);
+    }
+
+    #[test]
+    fn predict_post_state_amount_out_matches_compute_swap_within_tick() {
+        // The post-state predictor and the legacy `compute_swap_within_tick`
+        // share the same single-tick math; they MUST return the same
+        // `amount_out` for the same input. If they ever diverge, one of
+        // the two paths is wrong and the mempool sim drifts from the
+        // detector's pricing.
+        let pool = setup_v3_pool();
+        for amt in [
+            U256::from(1_000_000u64),
+            U256::from(1_000_000_000u64),
+            U256::from(1_000_000_000_000u64),
+        ] {
+            let legacy = pool
+                .get_amount_out(pool.token0, amt)
+                .expect("legacy amount_out");
+            let post = pool
+                .predict_post_state(pool.token0, amt)
+                .expect("post state");
+            assert_eq!(
+                post.amount_out, legacy,
+                "predict_post_state amount_out diverged from compute_swap_within_tick at amt={amt}"
+            );
+        }
     }
 }

--- a/crates/pools/src/uniswap_v3.rs
+++ b/crates/pools/src/uniswap_v3.rs
@@ -26,6 +26,36 @@ pub struct UniswapV3Pool {
 
 // Constants for Q96 fixed-point math
 const Q96: u128 = 1u128 << 96;
+/// 2^96 in `f64` form. The closest representable double to the exact
+/// integer; used by [`sqrt_price_x96_to_tick`] to project Q96 prices into
+/// the f64 domain where tick math is cheap.
+const TWO_POW_96_F64: f64 = 79_228_162_514_264_337_593_543_950_336.0;
+/// Pre-computed `ln(1.0001)` to avoid recomputing per call. Determines
+/// the size of one V3 tick on the log-price axis.
+const LN_1_0001: f64 = 0.000_099_995_000_333_308_34;
+
+/// Project a Q96 sqrt-price into its V3 tick index. Used to detect when a
+/// post-swap `sqrt_price_x96` lands outside the active tick bucket and the
+/// analytical single-tick math no longer holds. f64 precision is enough
+/// here because each tick is a 1.0001× multiplicative step (~1 bp) and
+/// f64's ~15-digit mantissa resolves that with margin to spare across the
+/// full `[MIN_TICK, MAX_TICK]` range.
+fn sqrt_price_x96_to_tick(sqrt_price_x96: U256) -> i32 {
+    let limbs = sqrt_price_x96.as_limbs();
+    let raw = limbs[0] as f64
+        + limbs[1] as f64 * 18_446_744_073_709_551_616.0
+        + limbs[2] as f64 * 3.402_823_669_209_385e38
+        + limbs[3] as f64 * 1.157_920_892_373_162e77;
+    if raw <= 0.0 || !raw.is_finite() {
+        return i32::MIN;
+    }
+    let sqrt_norm = raw / TWO_POW_96_F64;
+    let price = sqrt_norm * sqrt_norm;
+    if price <= 0.0 || !price.is_finite() {
+        return i32::MIN;
+    }
+    (price.ln() / LN_1_0001).floor() as i32
+}
 
 /// Snapshot of a UniswapV3 pool *after* a hypothetical victim swap has been
 /// applied. Returned by [`UniswapV3Pool::predict_post_state`] so the mempool
@@ -86,6 +116,25 @@ impl UniswapV3Pool {
         self.ticks = ticks;
     }
 
+    /// True when `new_sqrt_price_x96` projects to a tick inside the
+    /// `[bucket_low, bucket_high)` range that contains the pool's current
+    /// active tick. The bucket is aligned to `tick_spacing` using
+    /// floor-division (Euclidean, so it is correct for negative ticks too;
+    /// `i32::div_euclid` rounds toward `-∞`).
+    fn is_within_active_tick_bucket(&self, new_sqrt_price_x96: U256) -> bool {
+        if self.tick_spacing <= 0 {
+            // Defensive: a non-positive tick_spacing is invalid V3 state;
+            // treat as "single tick" so the predictor still returns
+            // *some* answer rather than crashing the caller. The EVM
+            // fallback path will catch any real misuse downstream.
+            return true;
+        }
+        let new_tick = sqrt_price_x96_to_tick(new_sqrt_price_x96);
+        let bucket_low = self.tick.div_euclid(self.tick_spacing) * self.tick_spacing;
+        let bucket_high = bucket_low + self.tick_spacing;
+        new_tick >= bucket_low && new_tick < bucket_high
+    }
+
     /// Predict the pool's post-swap state under the same single-tick
     /// constant-liquidity assumption as [`Self::compute_swap_within_tick`].
     /// Mempool post-state simulation uses this to update its graph-edge
@@ -98,9 +147,13 @@ impl UniswapV3Pool {
     ///   - the math underflows / divides by zero (defensive — should not
     ///     happen on real pool state)
     ///
-    /// `single_tick` on the returned state is hard-coded to `true` here.
-    /// The cross-tick branch lives in a follow-up commit and flips this
-    /// flag to signal an EVM fork-replay fallback to the caller.
+    /// `single_tick` is `true` when the post-swap `sqrt_price` stays
+    /// inside the current `[bucket_low, bucket_high)` tick range, where
+    /// the bucket bounds are aligned to `self.tick_spacing` around
+    /// `self.tick`. It is `false` when the swap crosses at least one
+    /// initialised tick boundary; in that case the returned values are a
+    /// best-effort estimate and the caller MUST fall back to an EVM
+    /// fork-replay before trusting them.
     pub fn predict_post_state(
         &self,
         token_in: Address,
@@ -148,7 +201,7 @@ impl UniswapV3Pool {
                 new_sqrt_price_x96,
                 new_liquidity: self.liquidity,
                 amount_out,
-                single_tick: true,
+                single_tick: self.is_within_active_tick_bucket(new_sqrt_price_x96),
             })
         } else {
             // token1 → token0: sqrt_price increases.
@@ -169,7 +222,7 @@ impl UniswapV3Pool {
                 new_sqrt_price_x96,
                 new_liquidity: self.liquidity,
                 amount_out,
-                single_tick: true,
+                single_tick: self.is_within_active_tick_bucket(new_sqrt_price_x96),
             })
         }
     }
@@ -314,6 +367,28 @@ mod tests {
         pool
     }
 
+    /// Pool fixture seated *mid-bucket* — current `sqrt_price` lands in
+    /// the middle of the active tick bucket [0, 60), so a small swap in
+    /// either direction stays inside the bucket and a large swap crosses
+    /// out. Required because tick boundaries are *exactly* at integer
+    /// `sqrt(1.0001^N) * 2^96`, so a fixture sitting on the boundary
+    /// trips `single_tick=false` for any direction of price movement.
+    fn setup_v3_pool_mid_bucket() -> UniswapV3Pool {
+        let mut pool = UniswapV3Pool::new(
+            address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            30, // 0.3%
+            60,
+        );
+        // tick=30 sits halfway through bucket [0, 60).
+        // sqrt_price = sqrt(1.0001^30) * 2^96 = 1.0001^15 * 2^96.
+        let sqrt_norm = 1.0001f64.powi(15);
+        let sqrt_x96 = (sqrt_norm * TWO_POW_96_F64) as u128;
+        pool.update_sqrt_price(U256::from(sqrt_x96), 10_000_000_000_000_000u128, 30);
+        pool
+    }
+
     #[test]
     fn test_v3_get_amount_out_token0() {
         let pool = setup_v3_pool();
@@ -390,8 +465,8 @@ mod tests {
 
     #[test]
     fn predict_post_state_token0_to_token1_lowers_sqrt_price() {
-        let pool = setup_v3_pool();
-        let dx = U256::from(1_000_000_000u64); // 1000 USDC (6dp)
+        let pool = setup_v3_pool_mid_bucket();
+        let dx = U256::from(100_000_000u64); // small relative to L=1e16
         let post = pool
             .predict_post_state(pool.token0, dx)
             .expect("post state");
@@ -401,15 +476,14 @@ mod tests {
             post.new_sqrt_price_x96,
             pool.sqrt_price_x96
         );
-        assert!(!post.amount_out.is_zero(), "non-zero output expected");
         assert_eq!(post.new_liquidity, pool.liquidity);
-        assert!(post.single_tick);
+        assert!(post.single_tick, "small swap should not cross tick bucket");
     }
 
     #[test]
     fn predict_post_state_token1_to_token0_raises_sqrt_price() {
-        let pool = setup_v3_pool();
-        let dy = U256::from(1_000_000_000_000_000_000u64); // 1 ETH
+        let pool = setup_v3_pool_mid_bucket();
+        let dy = U256::from(100_000_000u64);
         let post = pool
             .predict_post_state(pool.token1, dy)
             .expect("post state");
@@ -417,9 +491,39 @@ mod tests {
             post.new_sqrt_price_x96 > pool.sqrt_price_x96,
             "token1→token0 must raise sqrt_price"
         );
-        assert!(!post.amount_out.is_zero());
         assert_eq!(post.new_liquidity, pool.liquidity);
-        assert!(post.single_tick);
+        assert!(post.single_tick, "small swap should not cross tick bucket");
+    }
+
+    #[test]
+    fn predict_post_state_large_swap_crosses_tick_bucket() {
+        // tick_spacing=60 ↔ ~0.6% price move covers one bucket. A swap
+        // sized at ~half the pool's notional liquidity moves price much
+        // more than that, so the resulting sqrt_price_x96 must land
+        // outside [tick=0, tick=60) and `single_tick` must be false.
+        let pool = setup_v3_pool_mid_bucket();
+        let huge = U256::from(5_000_000_000_000_000u64); // ~half of L
+        let post = pool
+            .predict_post_state(pool.token0, huge)
+            .expect("post state");
+        assert!(
+            !post.single_tick,
+            "large swap must cross tick bucket (new_sqrt={})",
+            post.new_sqrt_price_x96
+        );
+    }
+
+    #[test]
+    fn sqrt_price_x96_to_tick_at_unity_is_zero() {
+        // sqrt_price = 2^96 ↔ price = 1.0 ↔ tick = 0.
+        let tick = sqrt_price_x96_to_tick(U256::from(Q96));
+        assert!(tick.abs() <= 1, "tick at price=1.0 must be ~0, got {}", tick);
+    }
+
+    #[test]
+    fn sqrt_price_x96_to_tick_handles_zero_input() {
+        // No price defined for zero — must not panic; saturate to MIN.
+        assert_eq!(sqrt_price_x96_to_tick(U256::ZERO), i32::MIN);
     }
 
     #[test]


### PR DESCRIPTION
Closes #124 (foundation half — see *Out of scope* below).

Lands the analytical post-state predictors and the live pool-state cache the mempool decode pipeline needs to call them. After this merges, every protocol family the engine tracks has a `predict_post_state` method on its pool struct and a corresponding `PoolState` cache entry kept in lockstep with the price graph.

## What ships

| Layer | Item |
|---|---|
| Predictor math | `UniswapV3Pool::predict_post_state` (single-tick + tick-crossing detection) |
| Predictor math | `CurvePool::predict_post_state` (2-coin StableSwap, Newton get_y) |
| Predictor math | `BalancerPool::predict_post_state` (weighted-2-token, equal- and unequal-weight branches) |
| State cache | `PoolState` enum + `PoolStateCache` (`Arc<DashMap<Address, Arc<PoolState>>>`) + factory |
| Engine wire-up | V2 / Sushi cache populated at bootstrap via `getReserves()` + on `PoolEvent::ReserveUpdate` |
| Engine wire-up | V3 cache populated at bootstrap via `slot0()` + on `PoolEvent::V3Update` |
| Engine wire-up | Curve cache populated at bootstrap via `A() + balances(0) + balances(1)` |
| Engine wire-up | Balancer V2 cache populated at bootstrap via `getPoolId() → vault.getPoolTokens(poolId) → pool.getNormalizedWeights()` |
| Dispatch | `predict_post_state_with_fallback` wrapper returns `Option<UnifiedPostState>` and invokes a caller-supplied closure on low-confidence paths |
| Observability | `aether_sim_evm_fallback_total{reason}` Prometheus counter with stable label set |

## Confidence flags

Each predictor surfaces a single boolean signal that the wrapper uses to escalate to an EVM fork-replay fallback:

| Pool family | Field | When it clears |
|---|---|---|
| V3 | `single_tick` | swap moved `sqrt_price_x96` past the active tick bucket |
| Curve | `analytical` | Newton iteration produced an invalid post-state |
| Balancer | `analytical` | unequal-weight pool — first-order Taylor approximation deemed too coarse |

The wrapper bumps `aether_sim_evm_fallback_total{reason}` with one of `v3_tick_crossed` / `curve_unconverged` / `balancer_unequal_weight` / `unknown_protocol` and returns `None`, so dashboards show how often the analytical path is insufficient.

## PoolMetadata change

`PoolMetadata` grows a `tick_spacing: Option<i32>` field so the V3 cache can build a valid `UniswapV3Pool` (which needs tick_spacing to know where the active tick bucket ends). New `register_pool_with_tick_spacing` constructor accepts the value; the original `register_pool` delegates with `None` so existing callers compile unchanged. Bootstrap reads the value from `pools.toml` `tick_spacing` field; non-V3 pools store `None`.

## Tests

```
pools crate                  55 unit tests   ✓
grpc-server bin              50+ unit tests  ✓
workspace cargo test         all green        ✓
```

New tests cover:
- V3 / Curve / Balancer predictor parity vs the existing `get_amount_out` math (regression guard so the sim and the detector never drift)
- Single-tick vs cross-tick V3 fixtures with the bucket boundary engineered to either keep the swap inside or push it out
- Cache round-trip (variant + state field accessibility) for every pool family
- Wrapper dispatch (escalates on cleared confidence, returns state on high confidence)

## Out of scope (deferred to follow-up PRs)

- **Real EVM fork-replay implementation behind the fallback.** Today's `EvmSimulator` is built around `executeArb` calldata + the AetherExecutor contract; a generic "apply this transaction and read the affected pool's post-state" entry point is its own substantial change. The metric in this PR tells us how often the fallback is needed; the implementation lands when that infra catches up.
- **Anvil parity tests against historical mainnet swaps.** The unit tests above cover predictor / cache / dispatch correctness; a fixture set asserting `≤ 1 wei drift` vs Anvil receipts across 30+ historical swaps per protocol is its own (tedious) PR — deliberately separated so this PR stays reviewable.
- **Curve 3-coin / tricrypto / metapool variants.** The 2-coin pinning matches the existing `get_amount_out` semantics; N-coin support requires the caller to pick `j` explicitly and is its own design.
- **Balancer composable / stable / weighted-N-token (N > 2).** Same 2-token pinning rationale.
- **Curve / Balancer event-driven cache refresh.** Bootstrap populates the cache; live refresh on Curve `TokenExchange` / Balancer `Swap` events needs new `PoolEvent` variants the event decoder doesn't emit yet. Until then the cache for those protocols is stale-but-correct between bootstrap and a restart.
- **Mempool decode pipeline integration.** The wrapper is callable but unused on this branch; the caller is `try_post_state_scan` in PR #118 (which currently routes V3/Curve/Balancer to `protocol_unsupported`). Plan: rebase #118 on this once it merges, swap the dispatch.