### PR TITLE
fix(simulator): rewrite wss/ws RPC URL to https/http for fork backend

### DIFF
--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -35,6 +35,26 @@ use aether_grpc_server::EngineMetrics;
 use crate::pipeline;
 use crate::service::aether_proto::ValidatedArb as ProtoValidatedArb;
 
+/// Rewrite a `wss://` / `ws://` URL into the corresponding `https://` /
+/// `http://` URL so the revm fork backend (HTTP-only `eth_getStorageAt`
+/// requests via AlloyDB) can talk to the same provider the streaming
+/// subscription uses. Returns the input unchanged if the scheme is
+/// already HTTP(S) or anything else — the URL parser downstream will
+/// surface a clear error in the unknown-scheme case.
+///
+/// Only the scheme portion is rewritten; host, path, and query string
+/// are left intact, so Alchemy / Infura / QuickNode endpoints that share
+/// the same hostname across transports map cleanly.
+fn normalize_to_http_scheme(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("wss://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = url.strip_prefix("ws://") {
+        format!("http://{rest}")
+    } else {
+        url.to_string()
+    }
+}
+
 /// Configuration for the AetherEngine.
 pub struct EngineConfig {
     /// Maximum hops in arbitrage path.
@@ -336,8 +356,22 @@ impl AetherEngine {
         let simulator = EvmSimulator::with_defaults();
 
         // Build the RPC provider when an RPC URL is configured.
+        //
+        // `ETH_RPC_URL` is shared with the streaming subscription path (newHeads,
+        // logs, pending tx) which requires a `wss://` or `ws://` scheme for the
+        // persistent connection. The revm-backed fork backend, by contrast,
+        // issues one-shot `eth_getStorageAt` / `eth_getBalance` requests and
+        // only speaks `http(s)`. Without normalisation, a wss URL is rejected
+        // by `connect_http` and every detected cycle fails to simulate with
+        // `Transport error: builder error for url (wss://...)`.
+        //
+        // Major providers (Alchemy, Infura, QuickNode) expose both transports
+        // on the same hostname + path differing only in scheme, so a literal
+        // scheme rewrite produces the correct HTTP endpoint without forcing
+        // operators to maintain a second env var.
         let rpc_provider = config.rpc_url.as_ref().and_then(|url_str| {
-            let parsed: url::Url = match url_str.parse() {
+            let http_url = normalize_to_http_scheme(url_str);
+            let parsed: url::Url = match http_url.parse() {
                 Ok(u) => u,
                 Err(e) => {
                     tracing::warn!(error = %e, url = %url_str, "Invalid RPC URL, falling back to empty state");
@@ -345,7 +379,11 @@ impl AetherEngine {
                 }
             };
             let provider = alloy::providers::ProviderBuilder::new().connect_http(parsed);
-            info!(url = %url_str, "RPC provider created for fork simulation");
+            info!(
+                original = %url_str,
+                fork_url = %http_url,
+                "RPC provider created for fork simulation"
+            );
             Some(provider.erased())
         });
 
@@ -1865,6 +1903,50 @@ mod tests {
         assert_eq!(config.min_profit_threshold_wei, 1_000_000_000_000_000);
         assert!((config.gas_price_gwei - 30.0).abs() < f64::EPSILON);
         assert_eq!(config.tip_bps, 9000);
+    }
+
+    #[test]
+    fn normalize_to_http_rewrites_wss_to_https() {
+        assert_eq!(
+            normalize_to_http_scheme("wss://eth-mainnet.g.alchemy.com/v2/abc"),
+            "https://eth-mainnet.g.alchemy.com/v2/abc"
+        );
+    }
+
+    #[test]
+    fn normalize_to_http_rewrites_ws_to_http() {
+        assert_eq!(
+            normalize_to_http_scheme("ws://127.0.0.1:8545/"),
+            "http://127.0.0.1:8545/"
+        );
+    }
+
+    #[test]
+    fn normalize_to_http_passes_https_unchanged() {
+        let url = "https://eth-mainnet.g.alchemy.com/v2/abc";
+        assert_eq!(normalize_to_http_scheme(url), url);
+    }
+
+    #[test]
+    fn normalize_to_http_passes_http_unchanged() {
+        let url = "http://127.0.0.1:8545/";
+        assert_eq!(normalize_to_http_scheme(url), url);
+    }
+
+    #[test]
+    fn normalize_to_http_passes_unknown_scheme_unchanged() {
+        // IPC paths, file URLs, anything not ws(s) — leave for the downstream
+        // parser to either accept or reject with a clear error.
+        let url = "ipc:///tmp/reth.ipc";
+        assert_eq!(normalize_to_http_scheme(url), url);
+    }
+
+    #[test]
+    fn normalize_to_http_preserves_query_string_and_path() {
+        assert_eq!(
+            normalize_to_http_scheme("wss://example.com/ws/v2?key=secret&foo=bar"),
+            "https://example.com/ws/v2?key=secret&foo=bar"
+        );
     }
 
     #[test]

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -25,15 +25,14 @@ pub struct EngineMetrics {
     /// stay stable across releases.
     ///
     /// Stable label set:
-    ///   - `v3_tick_crossed`        — V3 swap moved sqrt_price out of
-    ///                                its single-tick bucket
-    ///   - `curve_unconverged`      — Curve Newton iteration produced
-    ///                                an invalid post-state
-    ///   - `balancer_unequal_weight`— Balancer first-order Taylor
-    ///                                approximation deemed too coarse
-    ///                                under heavy weight skew
-    ///   - `unknown_protocol`       — protocol family with no analytical
-    ///                                predictor on this build
+    ///   - `v3_tick_crossed` — V3 swap moved sqrt_price out of its
+    ///     single-tick bucket
+    ///   - `curve_unconverged` — Curve Newton iteration produced an
+    ///     invalid post-state
+    ///   - `balancer_unequal_weight` — Balancer first-order Taylor
+    ///     approximation deemed too coarse under heavy weight skew
+    ///   - `unknown_protocol` — protocol family with no analytical
+    ///     predictor on this build
     sim_evm_fallback_total: IntCounterVec,
 }
 


### PR DESCRIPTION
## Problem

The revm-backed fork backend issues one-shot `eth_getStorageAt` / `eth_getBalance` requests via AlloyDB's HTTP transport. `ETH_RPC_URL`, however, is shared with the streaming subscription path (newHeads, logs, pending tx) which requires a `wss://` / `ws://` scheme for the persistent connection.

Without normalisation, `ProviderBuilder::new().connect_http(parsed)` on a wss URL fails every detected cycle with:

```
ERROR aether_simulator: RPC EVM transact error error=database error: Transport error: builder error for url (wss://eth-mainnet.g.alchemy.com/v2/<key>)
```

Floods the log on every block (10-50 errors/sec when detection is active). Mempool tracking (analytical predictors) is unaffected, but the regular block-by-block arb validation path is silently broken.

This surfaced after `ETH_RPC_URL` was flipped from https to wss to engage Alchemy `alchemy_pendingTransactions` + `newHeads` over WebSocket for the PR #118 mempool work. Pre-existing bug — was lurking the whole time, only visible once the env var changed scheme.

## Fix

Add `normalize_to_http_scheme(url: &str) -> String` which rewrites `wss://` -> `https://` and `ws://` -> `http://` literally, leaving host / path / query intact. Apply at the boundary between `config.rpc_url` and the `ProviderBuilder::connect_http` call in `AetherEngine::new`.

```rust
let http_url = normalize_to_http_scheme(url_str);
let parsed: url::Url = http_url.parse()?;
let provider = ProviderBuilder::new().connect_http(parsed);
```

### Why HTTP, not WS-backed fork

revm itself is transport-agnostic — it consumes a `Database` trait and AlloyDB wraps any alloy `Provider`. WS-backed fork *works*, but isn't preferred:

| Aspect | HTTP fork | WS-backed fork |
|---|---|---|
| Concurrent reads | Native parallel | Multiplexed through one socket |
| Per-sim latency (50-200 slot fetches) | ~50ms | ~150-300ms |
| Rate limits | Separate from subscription budget | Shares budget with streaming |
| Connection state | Stateless, retries cheap | Persistent, needs reconnect plumbing |
| revm convention | Canonical (Foundry, Anvil, every tutorial) | Atypical |
| Anvil compatibility | Native | Some versions wonky |

Scheme rewrite gives operators a single `ETH_RPC_URL` env var while routing each consumer to the transport it actually wants.

### Why a literal rewrite

Alchemy, Infura, and QuickNode all expose both transports on the same hostname + path differing only in scheme:

- `wss://eth-mainnet.g.alchemy.com/v2/<key>`
- `https://eth-mainnet.g.alchemy.com/v2/<key>`

No new env var, no config-file changes, no operator coordination required.

### Unknown schemes

IPC paths (`ipc:///tmp/reth.ipc`), file URLs, anything not `ws(s)` — pass through unchanged. Downstream parser surfaces a clear error rather than silently miscast.

## Side-effect: clippy fix

Develop's `crates/grpc-server/src/metrics.rs` doc-list continuation lines under `sim_evm_fallback_total` were indented to 24 spaces. Rust 1.94's `clippy::doc_overindented_list_items` lint rejects them under `-D warnings`. Dedented to 4 spaces — required to keep `cargo clippy --workspace -- -D warnings` green for the new tests.

## Tests

6 unit tests covering all scheme cases:
- `wss://` -> `https://`
- `ws://` -> `http://`
- `https://` unchanged
- `http://` unchanged
- `ipc://` (unknown scheme) unchanged
- Query string + path preservation

488 workspace tests pass. `cargo clippy --workspace -- -D warnings` clean.

## Impact

- Unblocks main-detection EVM sim when operator sets `ETH_RPC_URL=wss://...`
- No behaviour change when `ETH_RPC_URL` is already `https://...`
- No env var changes, no config-file changes
- Mempool tracking pipeline unaffected (uses analytical predictors, never touched the fork)

## Verification

Before (capture log on PR #118 branch):
```
ERROR aether_simulator: RPC EVM transact error error=database error: Transport error: builder error for url (wss://...)
```
... repeated 10-50 times/sec.

After (with this fix on `ETH_RPC_URL=wss://...`):
```
INFO aether_rust::engine: RPC provider created for fork simulation original=wss://eth-mainnet.g.alchemy.com/v2/<key> fork_url=https://eth-mainnet.g.alchemy.com/v2/<key>
```
No `Transport error` lines.