### PR TITLE
feat(mempool): reconcile predictions against confirmed blocks

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -1,0 +1,400 @@
+// Mempool reconciler — closes the loop on persisted predictions.
+//
+// Reads `mempool_predictions` written by the Rust mempool writer (PR #133)
+// and produces one `mempool_reconciliation` row per prediction once the
+// outcome is known. Together the two tables answer "did the tx land where
+// we said it would, in the order we said it would, hitting the pool we
+// said it would?" — entirely in SQL.
+//
+// Architecture (per-block loop):
+//   1. ethclient.SubscribeNewHead → chan *types.Header
+//   2. For each new header: BlockByHash → iterate Transactions()
+//   3. Per tx: LookupPredictionByTxHash; if found, fetch receipt, write
+//      `outcome='confirmed'` with block_delta + pool_path_correct
+//   4. Every staleSweepInterval: MarkStaleAsDropped(currentHead) → bulk
+//      INSERT `outcome='dropped'` for predictions where target+12 ≤ head
+//
+// Receipt fetch is per-prediction-hit (not per-block tx) so a block of
+// 200 txs with 1 prediction hit costs one receipt RPC, not 200.
+//
+// Run with:
+//
+//   MEMPOOL_LEDGER_DSN=postgres://aether:aether@localhost:5433/aether \
+//   ETH_RPC_URL=wss://eth-mainnet.g.alchemy.com/v2/<key> \
+//   RECONCILER_METRICS_ADDR=:9094 \
+//   ./aether-reconciler
+
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/aether-arb/aether/internal/db"
+)
+
+const (
+	// staleSweepInterval is the cadence of the dropped-outcome batch
+	// query. Twice the average block time so a 24-block prediction
+	// reaches the dropped state within ~12 s of its window closing.
+	staleSweepInterval = 6 * time.Second
+
+	// receiptFetchTimeout caps how long the reconciler waits for a single
+	// `eth_getTransactionReceipt` round-trip. Sized for the p99 mainnet
+	// receipt latency from major providers (~1.5 s); if the call wedges
+	// past this, the reconciliation row lands without `pool_path_correct`
+	// rather than block the per-block loop.
+	receiptFetchTimeout = 3 * time.Second
+
+	// blockFetchTimeout caps the `eth_getBlockByHash` call. Generous
+	// because a single failure stalls every prediction in that block,
+	// not just one.
+	blockFetchTimeout = 5 * time.Second
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	rpcURL := os.Getenv("ETH_RPC_URL")
+	if rpcURL == "" {
+		slog.Error("ETH_RPC_URL not set")
+		os.Exit(1)
+	}
+	dsn := os.Getenv("MEMPOOL_LEDGER_DSN")
+	if dsn == "" {
+		slog.Error("MEMPOOL_LEDGER_DSN not set")
+		os.Exit(1)
+	}
+	metricsAddr := os.Getenv("RECONCILER_METRICS_ADDR")
+	if metricsAddr == "" {
+		metricsAddr = ":9094"
+	}
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+	installSignalHandler(rootCancel)
+
+	dialCtx, dialCancel := context.WithTimeout(rootCtx, 10*time.Second)
+	defer dialCancel()
+	ethClient, err := ethclient.DialContext(dialCtx, rpcURL)
+	if err != nil {
+		slog.Error("dial ETH_RPC_URL failed", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("connected to ethereum node")
+
+	registry := prometheus.NewRegistry()
+	dbMetrics := db.NewMempoolReconciliationMetrics(registry)
+	loopMetrics := newLoopMetrics(registry)
+
+	pgRecon, err := db.NewPgMempoolReconciliation(rootCtx, dsn, dbMetrics)
+	if err != nil {
+		slog.Error("PgMempoolReconciliation connect failed", "err", err)
+		os.Exit(1)
+	}
+	defer pgRecon.Close()
+
+	// /metrics endpoint runs on a background server so the binary is
+	// scrapeable by Prometheus without coupling to the engine's existing
+	// :9092 endpoint.
+	metricsServer := startMetricsServer(metricsAddr, registry)
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = metricsServer.Shutdown(shutdownCtx)
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		runHeaderLoop(rootCtx, ethClient, pgRecon, loopMetrics)
+	}()
+	go func() {
+		defer wg.Done()
+		runStaleSweepLoop(rootCtx, ethClient, pgRecon)
+	}()
+
+	<-rootCtx.Done()
+	slog.Info("shutdown signalled; waiting for loops to exit")
+	// Give the loops a few seconds to drain in-flight reconciliations.
+	doneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(10 * time.Second):
+		slog.Warn("loops did not exit within 10s; tearing down anyway")
+	}
+}
+
+func installSignalHandler(cancel context.CancelFunc) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		slog.Info("signal received", "sig", sig)
+		cancel()
+	}()
+}
+
+func startMetricsServer(addr string, registry *prometheus.Registry) *http.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{Registry: registry}))
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 3 * time.Second}
+	go func() {
+		slog.Info("metrics server listening", "addr", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("metrics server failed", "err", err)
+		}
+	}()
+	return srv
+}
+
+// runHeaderLoop is the hot path. SubscribeNewHead provides a steady stream
+// of *types.Header (one per ~12 s on mainnet); each header drives one
+// block-resolution pass.
+//
+// SubscribeNewHead errors trigger a single reconnect + retry. A second
+// failure exits the loop so the orchestrator (systemd / k8s) can restart
+// the binary cleanly — a long-lived subscriber that silently stalls is
+// worse than a binary that exits and gets restarted.
+func runHeaderLoop(
+	ctx context.Context,
+	client *ethclient.Client,
+	recon *db.PgMempoolReconciliation,
+	metrics *loopMetrics,
+) {
+	headers := make(chan *types.Header, 8)
+	sub, err := client.SubscribeNewHead(ctx, headers)
+	if err != nil {
+		slog.Error("SubscribeNewHead failed", "err", err)
+		return
+	}
+	defer sub.Unsubscribe()
+	slog.Info("subscribed to newHeads")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-sub.Err():
+			slog.Error("newHeads subscription error", "err", err)
+			return
+		case header := <-headers:
+			handleHeader(ctx, client, recon, metrics, header)
+		}
+	}
+}
+
+// handleHeader resolves every prediction whose pending_tx_hash appears in
+// this block. Per-block cost is one block-by-hash + one receipt-by-hash
+// per prediction hit. Predictions are the rare case (a few per block on a
+// good day) so the receipt fetches do not dominate.
+func handleHeader(
+	ctx context.Context,
+	client *ethclient.Client,
+	recon *db.PgMempoolReconciliation,
+	metrics *loopMetrics,
+	header *types.Header,
+) {
+	metrics.HeadersProcessed.Inc()
+
+	blockCtx, cancel := context.WithTimeout(ctx, blockFetchTimeout)
+	defer cancel()
+	block, err := client.BlockByHash(blockCtx, header.Hash())
+	if err != nil {
+		slog.Warn("BlockByHash failed; skipping reconciliation for this block",
+			"block_hash", header.Hash().Hex(),
+			"err", err)
+		metrics.HeaderFetchErrors.Inc()
+		return
+	}
+
+	resolvedAt := time.Now().UTC()
+	blockNumber := block.NumberU64()
+
+	for txIdx, tx := range block.Transactions() {
+		var txHash [32]byte
+		copy(txHash[:], tx.Hash().Bytes())
+
+		lookupCtx, lookupCancel := context.WithTimeout(ctx, blockFetchTimeout)
+		pred, found, err := recon.LookupPredictionByTxHash(lookupCtx, txHash)
+		lookupCancel()
+		if err != nil {
+			slog.Warn("LookupPredictionByTxHash failed",
+				"tx_hash", tx.Hash().Hex(),
+				"err", err)
+			metrics.LookupErrors.Inc()
+			continue
+		}
+		if !found {
+			continue
+		}
+
+		actualBlock := blockNumber
+		actualIdx := txIdx
+		blockDelta := int(int64(actualBlock) - int64(pred.PredictedTargetBlock))
+
+		var poolPathCorrect *bool
+		if pred.PoolAddress != nil {
+			result, err := receiptHitsPool(ctx, client, tx.Hash(), *pred.PoolAddress)
+			if err != nil {
+				// Receipt fetch failure leaves pool_path_correct NULL so
+				// the row still lands. The TransactionReceiptErrors
+				// counter is the alert signal.
+				slog.Debug("TransactionReceipt failed; pool_path_correct=NULL",
+					"tx_hash", tx.Hash().Hex(),
+					"err", err)
+				metrics.ReceiptFetchErrors.Inc()
+			} else {
+				poolPathCorrect = &result
+				metrics.PoolPathChecks.WithLabelValues(pred.Protocol, boolLabel(result)).Inc()
+			}
+		}
+
+		metrics.BlockDelta.Observe(float64(blockDelta))
+
+		recon.InsertReconciliation(db.NewReconciliation{
+			PredictionID:      pred.PredictionID,
+			ResolutionTs:      resolvedAt,
+			Outcome:           db.OutcomeConfirmed,
+			ActualTargetBlock: &actualBlock,
+			ActualTxIndex:     &actualIdx,
+			BlockDelta:        &blockDelta,
+			PoolPathCorrect:   poolPathCorrect,
+		})
+	}
+}
+
+// receiptHitsPool fetches the tx's receipt and returns true iff any log
+// entry's `Address` matches `poolAddr`. The predicted swap is expected to
+// emit a `Swap`/`Sync`/`TokensTraded` event from the pool contract, so the
+// address match alone is sufficient — decoding the event topic would
+// confirm "yes it was a swap" but adds protocol-specific decode tables
+// without changing the answer to "did we route to the pool we expected".
+func receiptHitsPool(
+	ctx context.Context,
+	client *ethclient.Client,
+	txHash common.Hash,
+	poolAddr [20]byte,
+) (bool, error) {
+	receiptCtx, cancel := context.WithTimeout(ctx, receiptFetchTimeout)
+	defer cancel()
+	receipt, err := client.TransactionReceipt(receiptCtx, txHash)
+	if err != nil {
+		return false, err
+	}
+	want := common.BytesToAddress(poolAddr[:])
+	for _, log := range receipt.Logs {
+		if log.Address == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// runStaleSweepLoop runs the periodic dropped-outcome batch. Reads the
+// chain head from the eth client on every tick (rather than caching the
+// header from runHeaderLoop) so the two loops stay independent — a stalled
+// WS subscription does not freeze the dropped sweep.
+func runStaleSweepLoop(
+	ctx context.Context,
+	client *ethclient.Client,
+	recon *db.PgMempoolReconciliation,
+) {
+	ticker := time.NewTicker(staleSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			headCtx, cancel := context.WithTimeout(ctx, blockFetchTimeout)
+			head, err := client.BlockNumber(headCtx)
+			cancel()
+			if err != nil {
+				slog.Warn("BlockNumber failed; skipping stale sweep", "err", err)
+				continue
+			}
+			rows, err := recon.MarkStaleAsDropped(ctx, head)
+			if err != nil {
+				slog.Warn("MarkStaleAsDropped failed", "err", err)
+				continue
+			}
+			if rows > 0 {
+				slog.Info("stale sweep marked predictions as dropped",
+					"rows", rows, "head", head)
+			}
+		}
+	}
+}
+
+func boolLabel(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// loopMetrics groups the per-loop Prometheus families that are computed
+// in-process by the header / sweep loops. The DB-layer metrics live with
+// PgMempoolReconciliation.
+type loopMetrics struct {
+	HeadersProcessed   prometheus.Counter
+	HeaderFetchErrors  prometheus.Counter
+	LookupErrors       prometheus.Counter
+	ReceiptFetchErrors prometheus.Counter
+	BlockDelta         prometheus.Histogram
+	PoolPathChecks     *prometheus.CounterVec
+}
+
+func newLoopMetrics(reg prometheus.Registerer) *loopMetrics {
+	m := &loopMetrics{
+		HeadersProcessed: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_reconciler_headers_processed_total",
+			Help: "Block headers received from the WS newHeads subscription and processed",
+		}),
+		HeaderFetchErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_reconciler_header_fetch_errors_total",
+			Help: "BlockByHash failures (per-header)",
+		}),
+		LookupErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_reconciler_lookup_errors_total",
+			Help: "LookupPredictionByTxHash failures (per-tx)",
+		}),
+		ReceiptFetchErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_reconciler_receipt_fetch_errors_total",
+			Help: "TransactionReceipt failures; reconciliation row still lands with pool_path_correct=NULL",
+		}),
+		BlockDelta: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "aether_mempool_block_delta",
+			Help:    "Confirmed prediction's actual_target_block minus predicted_target_block. PromQL: 1h-window accuracy = histogram_quantile(0.5, …) over time.",
+			Buckets: []float64{-2, -1, 0, 1, 2, 3, 5, 8, 12, 20},
+		}),
+		PoolPathChecks: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "aether_mempool_pool_path_total",
+			Help: "Confirmed predictions whose receipt logs were checked against the predicted pool, by protocol and correctness",
+		}, []string{"protocol", "correct"}),
+	}
+	reg.MustRegister(
+		m.HeadersProcessed, m.HeaderFetchErrors, m.LookupErrors,
+		m.ReceiptFetchErrors, m.BlockDelta, m.PoolPathChecks,
+	)
+	return m
+}

--- a/crates/grpc-server/Cargo.toml
+++ b/crates/grpc-server/Cargo.toml
@@ -48,6 +48,8 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 sha2 = "0.10"
+sqlx = { workspace = true }
+bigdecimal = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true }
 prost-build = { workspace = true }

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -14,6 +14,7 @@ use tokio_stream::wrappers::UnixListenerStream;
 mod cycle_gating;
 mod engine;
 mod mempool_pipeline;
+mod mempool_writer;
 mod pipeline;
 mod service;
 mod tracing_init;
@@ -146,6 +147,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // the engine's BellmanFord config so the analytical scan
             // honours the same hop / latency budget as the main path.
             let engine_cfg = EngineConfig::default();
+            // Mempool prediction writer: optional persistence to a separate
+            // Postgres DSN. MEMPOOL_LEDGER_DSN unset → NoopMempoolSink, no
+            // DB writes, behaviour identical to today. Distinct from the
+            // trade ledger's DATABASE_URL so an operator can enable mempool
+            // observability without provisioning the executor schema.
+            let writer_metrics =
+                mempool_writer::MempoolWriterMetrics::register(metrics.registry());
+            let prediction_sink = mempool_writer::mempool_writer_from_env(writer_metrics).await;
+            let engine_git_sha = std::env::var("AETHER_GIT_SHA").ok();
             let sim_ctx = Arc::new(mempool_pipeline::SimContext::new(
                 Arc::clone(engine.pool_registry()),
                 Arc::clone(engine.token_index()),
@@ -155,6 +165,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     engine_cfg.detection_time_budget_us,
                 ),
                 Arc::clone(engine.pool_states()),
+                prediction_sink,
+                engine_git_sha,
             ));
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -32,10 +32,16 @@ use aether_state::snapshot::SnapshotManager;
 use aether_state::token_index::TokenIndex;
 use alloy::primitives::{Address, U256};
 use arc_swap::ArcSwap;
+use chrono::Utc;
 use tokio::sync::watch;
 use tracing::{debug, info, warn};
+use uuid::Uuid;
 
 use crate::engine::PoolMetadata;
+use crate::mempool_writer::{
+    MempoolPredictionSink, NewMempoolPrediction, PredictedPostState, PROTOCOL_BALANCER,
+    PROTOCOL_SUSHI, PROTOCOL_UNI_V2, PROTOCOL_UNI_V3,
+};
 use crate::EngineMetrics;
 
 /// Pair-keyed pool index built from the live pool registry. Lookup is O(1)
@@ -80,6 +86,15 @@ pub struct SimContext {
     /// Balancer mempool sim path to call `predict_post_state_with_fallback`
     /// without round-tripping through the pool registry RPC.
     pub pool_states: PoolStateCache,
+    /// Optional persistence sink for mempool predictions. `Arc<NoopMempoolSink>`
+    /// when `MEMPOOL_LEDGER_DSN` is unset (no DB writes, no behaviour
+    /// change); `Arc<PgMempoolWriter>` when set. Always present so the
+    /// post-state path can call `insert_prediction` unconditionally.
+    pub prediction_sink: Arc<dyn MempoolPredictionSink>,
+    /// Engine build's git sha, copied onto every persisted prediction so
+    /// the reconciler / scorer can correlate row outcomes with the engine
+    /// version that produced them. `None` when the env var is unset.
+    pub engine_git_sha: Option<String>,
     /// Cached `(registry_ptr, PairIndex)` so the second and following pending
     /// swaps under the same registry generation lookup in O(1). The Mutex
     /// guards rebuild only — the steady-state path is `lock + ptr_eq + read`.
@@ -87,12 +102,15 @@ pub struct SimContext {
 }
 
 impl SimContext {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool_registry: Arc<ArcSwap<HashMap<Address, PoolMetadata>>>,
         token_index: Arc<ArcSwap<TokenIndex>>,
         snapshot_manager: Arc<SnapshotManager>,
         detector: BellmanFord,
         pool_states: PoolStateCache,
+        prediction_sink: Arc<dyn MempoolPredictionSink>,
+        engine_git_sha: Option<String>,
     ) -> Self {
         Self {
             pool_registry,
@@ -100,6 +118,8 @@ impl SimContext {
             snapshot_manager,
             detector,
             pool_states,
+            prediction_sink,
+            engine_git_sha,
             pair_index_cache: Mutex::new(None),
         }
     }
@@ -215,8 +235,9 @@ fn handle_event(
                 let ctx = Arc::clone(ctx);
                 let swap = swap.clone();
                 let router_label = router_label.clone();
+                let tx_hash = event.tx_hash;
                 tokio::task::spawn_blocking(move || {
-                    try_post_state_scan(&metrics, &ctx, &router_label, &swap);
+                    try_post_state_scan(&metrics, &ctx, &router_label, &swap, tx_hash, to);
                 });
             }
         }
@@ -352,6 +373,8 @@ fn try_post_state_scan(
     ctx: &SimContext,
     router_label: &str,
     swap: &DecodedSwap,
+    event_tx_hash: alloy::primitives::B256,
+    event_to: Address,
 ) {
     let target_protocol = match swap.protocol {
         Protocol::UniswapV2 => ProtocolType::UniswapV2,
@@ -453,6 +476,47 @@ fn try_post_state_scan(
         .detect_from_affected(&graph, &[in_idx, out_idx]);
     let profitable: Vec<_> = cycles.into_iter().filter(|c| c.is_profitable()).collect();
 
+    // Persist the prediction unconditionally — both profitable and
+    // unprofitable swaps are useful signal for the reconciler (issue #131
+    // Go half), which needs the full population of decoded mempool swaps
+    // to compute block / ordering / pool-path accuracy. The
+    // `profit_factor_predicted` column is the SQL signal that the engine
+    // would have considered acting on the swap.
+    let post_state_json = match swap.protocol {
+        Protocol::UniswapV2 | Protocol::SushiSwap => PredictedPostState::V2 {
+            reserve_in: post_in,
+            reserve_out: post_out,
+        },
+        Protocol::UniswapV3 => PredictedPostState::V3 {
+            reserve_in: post_in,
+            reserve_out: post_out,
+        },
+        Protocol::BalancerV2 => PredictedPostState::Balancer {
+            reserve_in: post_in,
+            reserve_out: post_out,
+        },
+    }
+    .into_json();
+    let prediction = NewMempoolPrediction {
+        prediction_id: Uuid::new_v4(),
+        decoded_at: Utc::now(),
+        pending_tx_hash: event_tx_hash,
+        router_address: event_to,
+        protocol: decoder_protocol_label(swap.protocol),
+        token_in: swap.token_in,
+        token_out: swap.token_out,
+        amount_in: swap.amount_in,
+        pool_address: Some(meta.pool_id.address),
+        predicted_target_block: snapshot.block_number.saturating_add(1),
+        predicted_post_state: post_state_json,
+        profit_factor_predicted: profitable.first().map(|c| c.profit_factor()),
+        // Reserved for the MEV-Share SSE path; Alchemy WS pendings carry
+        // no builder-side timestamp today.
+        detection_lead_ms: None,
+        engine_git_sha: ctx.engine_git_sha.clone(),
+    };
+    ctx.prediction_sink.insert_prediction(prediction);
+
     if profitable.is_empty() {
         metrics.inc_pending_arb_sim_skipped("no_profitable_cycle");
         return;
@@ -474,6 +538,18 @@ fn try_post_state_scan(
         best_profit_bps = (profitable[0].profit_factor() * 10_000.0) as i64,
         "MEMPOOL ARB CANDIDATE"
     );
+}
+
+/// Wire label for the `protocol` column on `mempool_predictions`. Pinned to
+/// the strings declared in [`crate::mempool_writer`] so the writer and the
+/// pipeline cannot drift. Matches issue #131's schema body.
+fn decoder_protocol_label(p: Protocol) -> &'static str {
+    match p {
+        Protocol::UniswapV2 => PROTOCOL_UNI_V2,
+        Protocol::SushiSwap => PROTOCOL_SUSHI,
+        Protocol::UniswapV3 => PROTOCOL_UNI_V3,
+        Protocol::BalancerV2 => PROTOCOL_BALANCER,
+    }
 }
 
 /// Map a V3 / Balancer post-state into the (post_in, post_out) reserves the
@@ -758,6 +834,7 @@ mod tests {
     /// empty, snapshot has a zero-vertex graph. Any `lookup_pool` returns
     /// `None`, which is what the `not_in_registry` test wants anyway.
     fn empty_sim_ctx() -> Arc<SimContext> {
+        use crate::mempool_writer::NoopMempoolSink;
         use aether_pools::new_pool_state_cache;
         use aether_state::price_graph::PriceGraph;
         Arc::new(SimContext::new(
@@ -766,6 +843,8 @@ mod tests {
             Arc::new(SnapshotManager::new(PriceGraph::new(0))),
             BellmanFord::new(3, 1_000),
             new_pool_state_cache(),
+            Arc::new(NoopMempoolSink::new()),
+            None,
         ))
     }
 

--- a/crates/grpc-server/src/mempool_writer.rs
+++ b/crates/grpc-server/src/mempool_writer.rs
@@ -1,0 +1,584 @@
+//! Mempool prediction writer.
+//!
+//! Sibling pattern to `aether_common::db::PgLedger`: the hot path enqueues
+//! a [`NewMempoolPrediction`] onto a bounded mpsc and returns; a dedicated
+//! writer task drains the channel and runs `INSERT`s through `sqlx::PgPool`.
+//! Channel saturation drops the row (with metric) so a slow Postgres can
+//! never exert unbounded backpressure on the mempool decode pipeline.
+//!
+//! Independent of the trade ledger by design — distinct DSN
+//! (`MEMPOOL_LEDGER_DSN` vs `DATABASE_URL`), distinct connection pool,
+//! distinct metric namespace. An operator can enable mempool observability
+//! without provisioning the executor schema and vice versa.
+//!
+//! Observability surface (registered against the engine's
+//! `prometheus::Registry` so a single `/metrics` endpoint emits everything):
+//!
+//! | Metric | Type | Labels |
+//! |---|---|---|
+//! | `aether_mempool_predictions_persisted_total` | Counter | `protocol` |
+//! | `aether_mempool_writer_drops_total` | Counter | — |
+//! | `aether_mempool_writer_queue_depth` | Gauge | — |
+//! | `aether_mempool_writer_write_latency_ms` | Histogram | `result` (`ok`/`err`) |
+//!
+//! See `migrations/0003_mempool_predictions.sql` for the schema.
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use alloy::primitives::{Address, B256, U256};
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, Utc};
+use prometheus::{HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+/// Channel depth between the decode pipeline and the writer task. Sized for
+/// ~5 s of bursty pending-tx decodes at peak rate (~100 swaps/s sustained
+/// during high mempool activity → 512 / 100 ≈ 5 s). Breached only when
+/// Postgres stalls; the drops counter is the alert signal.
+const WRITER_CHANNEL_CAPACITY: usize = 512;
+
+/// sqlx connection pool size for the mempool writer. Sized below the trade
+/// ledger's pool (4 vs 8) because the prediction insert is a smaller, fixed
+/// shape with no per-arb cross-table writes — four connections saturate the
+/// writer task without leaving the pool idle.
+const WRITER_POOL_SIZE: u32 = 4;
+
+/// Wire labels for the `protocol` column. Matches the rendering in issue
+/// #131's schema body so SQL `WHERE protocol = 'uni_v2'` works without a
+/// reverse mapping table. Kept in sync with [`decoder_protocol_label`] in
+/// `mempool_pipeline.rs` — both must produce the same string per decoded
+/// protocol.
+pub const PROTOCOL_UNI_V2: &str = "uni_v2";
+pub const PROTOCOL_SUSHI: &str = "sushi";
+pub const PROTOCOL_UNI_V3: &str = "uni_v3";
+/// Reserved for a future Curve decoder path. The router decoder rejects
+/// every Curve calldata shape with `CurveUnsupported` today, so no writer
+/// call ever lands here — but the constant documents the schema's
+/// `protocol` TEXT domain so a future decoder addition does not introduce
+/// a new wire label.
+#[allow(dead_code)]
+pub const PROTOCOL_CURVE: &str = "curve";
+pub const PROTOCOL_BALANCER: &str = "balancer";
+
+/// Insert payload for the `mempool_predictions` table. Field shapes mirror
+/// the SQL schema 1:1 so a sqlx bind is a straight enumeration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewMempoolPrediction {
+    pub prediction_id: Uuid,
+    /// Event time — when the decode pipeline accepted the pending tx.
+    /// Per the migration's clock-authority policy this is CLIENT-SET and
+    /// the writer MUST populate it; the schema's `DEFAULT now()` is a
+    /// psql-level safety net only.
+    pub decoded_at: DateTime<Utc>,
+    pub pending_tx_hash: B256,
+    pub router_address: Address,
+    /// One of [`PROTOCOL_UNI_V2`] / [`PROTOCOL_SUSHI`] / [`PROTOCOL_UNI_V3`] /
+    /// [`PROTOCOL_CURVE`] / [`PROTOCOL_BALANCER`]. Bound to `&'static str`
+    /// (not [`String`]) so callers cannot invent values the reconciler is
+    /// unprepared for.
+    pub protocol: &'static str,
+    pub token_in: Address,
+    pub token_out: Address,
+    pub amount_in: U256,
+    pub pool_address: Option<Address>,
+    pub predicted_target_block: u64,
+    /// JSONB payload describing the post-state the analytical sim produced.
+    /// Shape varies by protocol; consumers should match on `kind` first.
+    /// See [`PredictedPostState`] for the writer-side helpers.
+    pub predicted_post_state: serde_json::Value,
+    /// `Some(f)` when the post-state Bellman-Ford scan found a profitable
+    /// cycle; `None` when the scan ran but the result was unprofitable.
+    pub profit_factor_predicted: Option<f64>,
+    /// Reserved for the MEV-Share SSE path (issue #126) — Alchemy WS does
+    /// not expose a builder-side timestamp today, so this is always `None`
+    /// in the current pipeline. Kept on the payload so the schema and
+    /// writer stay forward-compatible.
+    pub detection_lead_ms: Option<i64>,
+    pub engine_git_sha: Option<String>,
+}
+
+/// Convenience builder for the `predicted_post_state` JSONB column. The
+/// reconciler (issue #131 Go half) and the profitability scorer (#132)
+/// inspect `kind` first; per-variant fields then carry the protocol-specific
+/// state. Kept here, in the writer crate, because every consumer is on the
+/// Rust side today — emitting the JSON via [`serde_json::Value`] avoids a
+/// generic enum dance on the read side.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PredictedPostState {
+    /// V2 / Sushi: constant-product post-state mapped onto graph reserves.
+    /// `reserve_in` and `reserve_out` are the post-swap reserves in the
+    /// affected pool, expressed as `f64` so the JSONB row matches what the
+    /// price graph holds — the profitability scorer pulls these directly
+    /// without unit conversion.
+    V2 {
+        reserve_in: f64,
+        reserve_out: f64,
+    },
+    /// V3: analytical predictor result mapped onto the synthetic
+    /// `(1.0, spot_price_post)` pair the price graph stores. The raw
+    /// `new_sqrt_price_x96` is reserved for the scorer (PR-3) — emitting
+    /// `reserve_in/out` matches the V2 case and keeps reconciler SQL simple.
+    V3 {
+        reserve_in: f64,
+        reserve_out: f64,
+    },
+    /// Balancer equal-weight 2-token: balances map directly to graph
+    /// reserves with the pool's fee factor applied at the graph layer.
+    Balancer {
+        reserve_in: f64,
+        reserve_out: f64,
+    },
+}
+
+impl PredictedPostState {
+    pub fn into_json(self) -> serde_json::Value {
+        serde_json::to_value(self).expect("PredictedPostState is always serialisable")
+    }
+}
+
+/// Persistence boundary for mempool predictions.
+///
+/// `Send + Sync` so a single `Arc<dyn MempoolPredictionSink>` can fan out
+/// to every decode task without further locking. Methods take `&self` and
+/// are infallible from the caller's perspective — a connection blip must
+/// never bring down the decode pipeline. Implementations log and drop.
+pub trait MempoolPredictionSink: Send + Sync {
+    fn insert_prediction(&self, prediction: NewMempoolPrediction);
+}
+
+/// Prometheus surface for the writer. Registered once at startup against
+/// the engine's shared `Registry`.
+pub struct MempoolWriterMetrics {
+    persisted_total: IntCounterVec,
+    drops_total: IntCounter,
+    queue_depth: IntGauge,
+    write_latency_ms: HistogramVec,
+}
+
+impl MempoolWriterMetrics {
+    /// Register all writer metrics on the provided `Registry`.
+    ///
+    /// Panics on duplicate registration — this is startup code and a
+    /// duplicate indicates a programmer error, not a runtime condition.
+    pub fn register(registry: &Registry) -> Arc<Self> {
+        let persisted_total = IntCounterVec::new(
+            Opts::new(
+                "aether_mempool_predictions_persisted_total",
+                "Mempool predictions accepted by the writer task and queued for insert, by protocol",
+            ),
+            &["protocol"],
+        )
+        .expect("aether_mempool_predictions_persisted_total counter vec");
+        let drops_total = IntCounter::new(
+            "aether_mempool_writer_drops_total",
+            "Mempool predictions dropped because the writer channel was full",
+        )
+        .expect("aether_mempool_writer_drops_total counter");
+        let queue_depth = IntGauge::new(
+            "aether_mempool_writer_queue_depth",
+            "Pending mempool predictions sitting in the writer-task channel",
+        )
+        .expect("aether_mempool_writer_queue_depth gauge");
+        let write_latency_ms = HistogramVec::new(
+            HistogramOpts::new(
+                "aether_mempool_writer_write_latency_ms",
+                "Per-write latency of mempool prediction inserts from dequeue to query completion",
+            )
+            .buckets(vec![0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0]),
+            &["result"],
+        )
+        .expect("aether_mempool_writer_write_latency_ms histogram vec");
+
+        registry
+            .register(Box::new(persisted_total.clone()))
+            .expect("register aether_mempool_predictions_persisted_total");
+        registry
+            .register(Box::new(drops_total.clone()))
+            .expect("register aether_mempool_writer_drops_total");
+        registry
+            .register(Box::new(queue_depth.clone()))
+            .expect("register aether_mempool_writer_queue_depth");
+        registry
+            .register(Box::new(write_latency_ms.clone()))
+            .expect("register aether_mempool_writer_write_latency_ms");
+
+        Arc::new(Self {
+            persisted_total,
+            drops_total,
+            queue_depth,
+            write_latency_ms,
+        })
+    }
+}
+
+/// Default sink: discards every prediction. Used when `MEMPOOL_LEDGER_DSN`
+/// is unset so the engine's mempool path is fully functional without
+/// Postgres. Logs once on construction so operators can grep startup output
+/// and rule out persistence as the reason rows are missing.
+pub struct NoopMempoolSink;
+
+impl NoopMempoolSink {
+    pub fn new() -> Self {
+        tracing::info!(
+            target: "aether::mempool_writer",
+            "MEMPOOL_LEDGER_DSN unset — mempool prediction writes disabled (no-op)"
+        );
+        Self
+    }
+}
+
+impl Default for NoopMempoolSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MempoolPredictionSink for NoopMempoolSink {
+    fn insert_prediction(&self, _prediction: NewMempoolPrediction) {}
+}
+
+/// Postgres-backed [`MempoolPredictionSink`].
+///
+/// The hot path enqueues onto a bounded channel; a single dedicated writer
+/// task drains and executes inserts. Channel saturation drops the row (with
+/// metric) rather than blocking the decoder. The connection pool is bounded
+/// so a slow Postgres still cannot fan out unbounded backpressure even when
+/// every connection is busy.
+#[derive(Clone)]
+pub struct PgMempoolWriter {
+    tx: mpsc::Sender<NewMempoolPrediction>,
+    metrics: Arc<MempoolWriterMetrics>,
+}
+
+impl PgMempoolWriter {
+    /// Connect to Postgres and spawn the writer task. Returns once the pool
+    /// is ready. The writer task exits when every clone of the `Sender` is
+    /// dropped (typically at process shutdown).
+    pub async fn connect(
+        database_url: &str,
+        metrics: Arc<MempoolWriterMetrics>,
+    ) -> Result<Self, sqlx::Error> {
+        let pool = PgPoolOptions::new()
+            .max_connections(WRITER_POOL_SIZE)
+            // Short acquire timeout: misconfigured DSN should fail boot in
+            // seconds, not block the decoder while we wait. The
+            // `mempool_writer_from_env` wrapper falls back to NoopSink on
+            // this error so a slow Postgres degrades gracefully.
+            .acquire_timeout(std::time::Duration::from_secs(2))
+            .connect(database_url)
+            .await?;
+
+        let (tx, rx) = mpsc::channel::<NewMempoolPrediction>(WRITER_CHANNEL_CAPACITY);
+        spawn_writer_task(pool, rx, Arc::clone(&metrics));
+
+        tracing::info!(
+            target: "aether::mempool_writer",
+            channel_capacity = WRITER_CHANNEL_CAPACITY,
+            pool_size = WRITER_POOL_SIZE,
+            "PgMempoolWriter connected — mempool prediction writes enabled"
+        );
+        Ok(Self { tx, metrics })
+    }
+}
+
+impl MempoolPredictionSink for PgMempoolWriter {
+    fn insert_prediction(&self, prediction: NewMempoolPrediction) {
+        let protocol = prediction.protocol;
+        match self.tx.try_send(prediction) {
+            Ok(()) => {
+                self.metrics.queue_depth.inc();
+                self.metrics
+                    .persisted_total
+                    .with_label_values(&[protocol])
+                    .inc();
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.metrics.drops_total.inc();
+                tracing::warn!(
+                    target: "aether::mempool_writer",
+                    capacity = WRITER_CHANNEL_CAPACITY,
+                    "mempool writer channel full — dropping prediction"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                // Writer task has exited; only happens at shutdown.
+                tracing::debug!(
+                    target: "aether::mempool_writer",
+                    "mempool writer channel closed; dropping prediction"
+                );
+            }
+        }
+    }
+}
+
+/// Build a [`MempoolPredictionSink`] from `MEMPOOL_LEDGER_DSN`. Returns
+/// [`NoopMempoolSink`] when the var is unset, empty, or the connection
+/// fails — the decoder stays runnable in dev / CI without Postgres.
+pub async fn mempool_writer_from_env(
+    metrics: Arc<MempoolWriterMetrics>,
+) -> Arc<dyn MempoolPredictionSink> {
+    match std::env::var("MEMPOOL_LEDGER_DSN") {
+        Ok(url) if !url.is_empty() => match PgMempoolWriter::connect(&url, metrics).await {
+            Ok(w) => Arc::new(w) as Arc<dyn MempoolPredictionSink>,
+            Err(e) => {
+                tracing::error!(
+                    target: "aether::mempool_writer",
+                    error = %e,
+                    "PgMempoolWriter connect failed; falling back to NoopMempoolSink"
+                );
+                Arc::new(NoopMempoolSink::new())
+            }
+        },
+        _ => Arc::new(NoopMempoolSink::new()),
+    }
+}
+
+/// Spawn the writer dispatcher. Sequential by design — the prediction
+/// insert is a single-table `ON CONFLICT DO NOTHING` and the pool's
+/// natural per-connection serialisation matches the per-pending-tx
+/// ordering, so a semaphore-fanned-out variant (like the trade ledger
+/// uses) would add machinery without throughput gain at the writer's
+/// expected rate.
+fn spawn_writer_task(
+    pool: PgPool,
+    mut rx: mpsc::Receiver<NewMempoolPrediction>,
+    metrics: Arc<MempoolWriterMetrics>,
+) {
+    tokio::spawn(async move {
+        while let Some(prediction) = rx.recv().await {
+            metrics.queue_depth.dec();
+            let timer = Instant::now();
+            let result = insert_prediction_inner(&pool, &prediction).await;
+            let elapsed_ms = timer.elapsed().as_secs_f64() * 1_000.0;
+            let label = if result.is_ok() { "ok" } else { "err" };
+            metrics
+                .write_latency_ms
+                .with_label_values(&[label])
+                .observe(elapsed_ms);
+            if let Err(e) = result {
+                tracing::warn!(
+                    target: "aether::mempool_writer",
+                    error = %e,
+                    elapsed_ms,
+                    tx_hash = %prediction.pending_tx_hash,
+                    "mempool prediction insert failed; row dropped"
+                );
+            }
+        }
+        tracing::info!(
+            target: "aether::mempool_writer",
+            "PgMempoolWriter dispatcher exiting"
+        );
+    });
+}
+
+async fn insert_prediction_inner(
+    pool: &PgPool,
+    p: &NewMempoolPrediction,
+) -> Result<(), sqlx::Error> {
+    let predicted_target_block = i64::try_from(p.predicted_target_block).unwrap_or(i64::MAX);
+    let amount_in = u256_to_decimal(p.amount_in);
+    let pool_address_bytes = p.pool_address.as_ref().map(|a| a.as_slice());
+
+    sqlx::query(
+        r#"
+        INSERT INTO mempool_predictions (
+            prediction_id, decoded_at, pending_tx_hash, router_address, protocol,
+            token_in, token_out, amount_in, pool_address,
+            predicted_target_block, predicted_post_state, profit_factor_predicted,
+            detection_lead_ms, engine_git_sha
+        ) VALUES (
+            $1, $2, $3, $4, $5,
+            $6, $7, $8, $9,
+            $10, $11, $12,
+            $13, $14
+        )
+        ON CONFLICT (pending_tx_hash) DO NOTHING
+        "#,
+    )
+    .bind(p.prediction_id)
+    .bind(p.decoded_at)
+    .bind(p.pending_tx_hash.as_slice())
+    .bind(p.router_address.as_slice())
+    .bind(p.protocol)
+    .bind(p.token_in.as_slice())
+    .bind(p.token_out.as_slice())
+    .bind(&amount_in)
+    .bind(pool_address_bytes)
+    .bind(predicted_target_block)
+    .bind(&p.predicted_post_state)
+    .bind(p.profit_factor_predicted)
+    .bind(p.detection_lead_ms)
+    .bind(p.engine_git_sha.as_deref())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Map a U256 to the `NUMERIC(78,0)` representation sqlx accepts via
+/// [`BigDecimal`]. Identical to the trade-ledger helper; pinned here to
+/// keep the writer self-contained.
+fn u256_to_decimal(v: U256) -> BigDecimal {
+    let s = v.to_string();
+    BigDecimal::from_str(&s)
+        .expect("U256::to_string is always a valid base-10 BigDecimal input")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// In-memory sink used by the pipeline test to assert that a row was
+    /// produced without standing up Postgres.
+    pub(crate) struct CapturingSink {
+        pub seen: Mutex<Vec<NewMempoolPrediction>>,
+    }
+
+    impl CapturingSink {
+        pub fn new() -> Self {
+            Self {
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl MempoolPredictionSink for CapturingSink {
+        fn insert_prediction(&self, prediction: NewMempoolPrediction) {
+            self.seen.lock().expect("capturing sink poisoned").push(prediction);
+        }
+    }
+
+    fn sample_prediction() -> NewMempoolPrediction {
+        NewMempoolPrediction {
+            prediction_id: Uuid::new_v4(),
+            decoded_at: Utc::now(),
+            pending_tx_hash: B256::ZERO,
+            router_address: Address::ZERO,
+            protocol: PROTOCOL_UNI_V2,
+            token_in: Address::ZERO,
+            token_out: Address::ZERO,
+            amount_in: U256::from(1_000_000u64),
+            pool_address: Some(Address::ZERO),
+            predicted_target_block: 19_000_001,
+            predicted_post_state: PredictedPostState::V2 {
+                reserve_in: 1_000.0,
+                reserve_out: 2_000.0,
+            }
+            .into_json(),
+            profit_factor_predicted: Some(0.0042),
+            detection_lead_ms: None,
+            engine_git_sha: Some("deadbeef".to_string()),
+        }
+    }
+
+    #[test]
+    fn noop_sink_accepts_writes_silently() {
+        let sink = NoopMempoolSink::new();
+        sink.insert_prediction(sample_prediction());
+    }
+
+    #[test]
+    fn noop_sink_is_object_safe() {
+        let _: Box<dyn MempoolPredictionSink> = Box::new(NoopMempoolSink::new());
+    }
+
+    #[test]
+    fn predicted_post_state_round_trips_through_json() {
+        for original in [
+            PredictedPostState::V2 {
+                reserve_in: 1.5,
+                reserve_out: 2.5,
+            },
+            PredictedPostState::V3 {
+                reserve_in: 1.0,
+                reserve_out: 1.234e18,
+            },
+            PredictedPostState::Balancer {
+                reserve_in: 10.0,
+                reserve_out: 20.0,
+            },
+        ] {
+            let json = serde_json::to_value(&original).expect("serialize");
+            let kind = json.get("kind").and_then(|v| v.as_str()).expect("kind present");
+            // `kind` lives under `#[serde(rename_all = "snake_case")]` so a
+            // future refactor that drops the rename surfaces here.
+            assert!(
+                ["v2", "v3", "balancer"].contains(&kind),
+                "unexpected kind {kind}"
+            );
+            let parsed: PredictedPostState = serde_json::from_value(json).expect("deserialize");
+            // Re-serialise both and compare strings — partial_eq via f64 is
+            // brittle but the JSON form is stable.
+            assert_eq!(
+                serde_json::to_string(&parsed).expect("re-serialize"),
+                serde_json::to_string(&original).expect("re-serialize-original"),
+            );
+        }
+    }
+
+    #[test]
+    fn capturing_sink_records_every_insert() {
+        let sink = CapturingSink::new();
+        sink.insert_prediction(sample_prediction());
+        sink.insert_prediction(sample_prediction());
+        assert_eq!(sink.seen.lock().expect("capturing sink poisoned").len(), 2);
+    }
+
+    #[test]
+    fn metrics_register_round_trips() {
+        let registry = Registry::new();
+        let m = MempoolWriterMetrics::register(&registry);
+        m.persisted_total.with_label_values(&[PROTOCOL_UNI_V2]).inc();
+        m.drops_total.inc();
+        m.queue_depth.set(3);
+        m.write_latency_ms.with_label_values(&["ok"]).observe(1.5);
+
+        let names: Vec<_> = registry
+            .gather()
+            .iter()
+            .map(|f| f.get_name().to_string())
+            .collect();
+        for required in [
+            "aether_mempool_predictions_persisted_total",
+            "aether_mempool_writer_drops_total",
+            "aether_mempool_writer_queue_depth",
+            "aether_mempool_writer_write_latency_ms",
+        ] {
+            assert!(
+                names.iter().any(|n| n == required),
+                "missing metric family {required}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mempool_writer_from_env_falls_back_when_dsn_unset() {
+        // Save/restore so the test does not leak state into siblings.
+        let prev = std::env::var("MEMPOOL_LEDGER_DSN").ok();
+        // SAFETY: tests in this crate run single-threaded against
+        // `MEMPOOL_LEDGER_DSN`; no concurrent reader can observe the unset.
+        unsafe {
+            std::env::remove_var("MEMPOOL_LEDGER_DSN");
+        }
+
+        let registry = Registry::new();
+        let metrics = MempoolWriterMetrics::register(&registry);
+        let sink = mempool_writer_from_env(metrics).await;
+        // Should not panic; should not write.
+        sink.insert_prediction(sample_prediction());
+
+        if let Some(v) = prev {
+            // SAFETY: restored in the same single-threaded test scope.
+            unsafe {
+                std::env::set_var("MEMPOOL_LEDGER_DSN", v);
+            }
+        }
+    }
+}

--- a/internal/db/mempool_reconciliation_metrics.go
+++ b/internal/db/mempool_reconciliation_metrics.go
@@ -1,0 +1,61 @@
+// Prometheus surface for the mempool reconciliation writer.
+//
+// Kept in the `db` package alongside LedgerMetrics so the two reconciliation
+// halves (DB + reconciler binary) can register their counters against a
+// single shared registry. The reconciler-loop metrics (`block_accuracy`,
+// `pool_path_accuracy`) live with the binary in `cmd/reconciler/` because
+// they are computed from in-process counters and never touch the DB.
+
+package db
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// MempoolReconciliationMetrics groups the families the
+// PgMempoolReconciliation writer goroutine updates. Names mirror the
+// `aether_ledger_*` namespace shape (`aether_mempool_reconciler_*`) so
+// dashboards can apply a single template.
+type MempoolReconciliationMetrics struct {
+	// Bumped on every successful reconciliation insert (or on every row
+	// returned by MarkStaleAsDropped). `outcome` is one of the
+	// OutcomeConfirmed / OutcomeDropped / OutcomeReplaced /
+	// OutcomeStillPending constants.
+	ReconciledTotal *prometheus.CounterVec
+	// Reconciliation writes the bounded channel rejected because it was
+	// full. Single-labelled (no `op`) because this writer only does one
+	// kind of insert.
+	DropsTotal      prometheus.Counter
+	QueueDepth      prometheus.Gauge
+	// Per-write latency from dequeue to query completion. `result` =
+	// "ok"|"err" so an alert can fire on a sudden `err` spike.
+	WriteLatencyMs  *prometheus.HistogramVec
+}
+
+// NewMempoolReconciliationMetrics constructs the families and registers
+// them with the supplied Prometheus registerer. A separate registerer
+// argument (vs the default `prometheus.MustRegister`) makes the binary's
+// /metrics endpoint composable — the reconciler can publish under its own
+// process registry while the engine publishes under its own, and a future
+// joint binary can pass the same registry to both halves.
+func NewMempoolReconciliationMetrics(reg prometheus.Registerer) *MempoolReconciliationMetrics {
+	m := &MempoolReconciliationMetrics{
+		ReconciledTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "aether_mempool_reconciled_total",
+			Help: "Mempool predictions resolved by the reconciler, by outcome",
+		}, []string{"outcome"}),
+		DropsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_reconciler_drops_total",
+			Help: "Reconciliation writes dropped because the bounded channel was full",
+		}),
+		QueueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "aether_mempool_reconciler_queue_depth",
+			Help: "Pending reconciliation writes sitting in the writer-goroutine channel",
+		}),
+		WriteLatencyMs: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "aether_mempool_reconciler_write_latency_ms",
+			Help:    "Per-write latency of reconciliation inserts from dequeue to query completion",
+			Buckets: []float64{0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0},
+		}, []string{"result"}),
+	}
+	reg.MustRegister(m.ReconciledTotal, m.DropsTotal, m.QueueDepth, m.WriteLatencyMs)
+	return m
+}

--- a/internal/db/mempool_reconciliation_pg.go
+++ b/internal/db/mempool_reconciliation_pg.go
@@ -1,0 +1,349 @@
+// Mempool reconciliation persistence layer.
+//
+// Separate from the trade-ledger PgLedger by design: distinct DSN
+// (MEMPOOL_LEDGER_DSN), distinct pgx pool. The reconciler binary is opt-in
+// (the executor and engine don't link this code path) so its DB
+// configuration must not collide with the trade-ledger's DATABASE_URL.
+//
+// API surface:
+//   - LookupPredictionByTxHash: synchronous single-row read on the
+//     `pending_tx_hash` unique index. Called once per landed block tx; the
+//     reconciler hot path stays simple by awaiting this result inline.
+//   - InsertReconciliation: fire-and-forget through the existing PgLedger
+//     pattern — bounded channel, drop-on-saturation, separate writer
+//     goroutine.
+//   - MarkStaleAsDropped: batch SQL that inserts `outcome='dropped'` rows
+//     for every prediction past its 12-block grace window without a
+//     reconciliation row.
+//
+// See migrations/0004_mempool_reconciliation.sql for the schema.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	// reconChannelCapacity bounds the writer queue. Sized smaller than the
+	// trade-ledger ledger's 1024 because reconciliation throughput equals
+	// "predictions that hit the same block" — at peak ~10/block on busy
+	// mainnet — and a 256-deep buffer gives ~25 blocks of headroom before
+	// drops at peak.
+	reconChannelCapacity = 256
+
+	// reconPoolSize sizes the underlying pgxpool. Smaller than the trade
+	// ledger (4 vs 8) because the reconciler's write rate is bounded by
+	// the per-block batch instead of the per-arb stream.
+	reconPoolSize = 4
+
+	// reconConnectTimeout fails boot fast on misconfigured
+	// MEMPOOL_LEDGER_DSN so the binary degrades cleanly to "metric-only,
+	// no DB writes" instead of stalling startup.
+	reconConnectTimeout = 2 * time.Second
+
+	// reconCloseDrainTimeout caps how long Close() waits for in-flight
+	// writes. Mirrors PgLedger's policy.
+	reconCloseDrainTimeout = 5 * time.Second
+
+	// StaleConfirmationWindow is the number of blocks the reconciler waits
+	// past a prediction's predicted_target_block before declaring it
+	// dropped. 12 ≈ Flashbots' empirical "tx never landed" heuristic
+	// (one epoch on post-merge Ethereum); shorter windows surface false
+	// drops on busy fee markets where pendings wait several blocks for
+	// inclusion.
+	StaleConfirmationWindow = 12
+)
+
+// PendingPrediction is the subset of `mempool_predictions` columns the
+// reconciler needs to score an outcome. Returned by LookupPredictionByTxHash.
+// Kept tight on purpose — adding columns means widening the read path's hot
+// SELECT and is gated by an actual reconciler-side use.
+type PendingPrediction struct {
+	PredictionID         uuid.UUID
+	Protocol             string
+	PoolAddress          *[20]byte // nil when registry miss recorded NULL
+	PredictedTargetBlock uint64
+}
+
+// NewReconciliation is the insert payload for `mempool_reconciliation`. The
+// outcome enum is constrained at the SQL CHECK level, but mirrored here as
+// public constants so callers can switch on a stable identifier instead of
+// re-typing the literal each time.
+type NewReconciliation struct {
+	PredictionID       uuid.UUID
+	ResolutionTs       time.Time
+	Outcome            string
+	ActualTargetBlock  *uint64
+	ActualTxIndex      *int
+	BlockDelta         *int
+	OrderingCorrect    *bool
+	PoolPathCorrect    *bool
+	ReplacedByTxHash   *[32]byte
+	FailureReason      *string
+}
+
+const (
+	OutcomeConfirmed    = "confirmed"
+	OutcomeDropped      = "dropped"
+	OutcomeReplaced     = "replaced"
+	OutcomeStillPending = "still_pending"
+)
+
+// PgMempoolReconciliation owns the pgxpool and writer goroutine pair.
+// Functionally a sibling of PgLedger; intentionally not collapsed into the
+// same type because (a) the two run in separate process address spaces
+// (engine vs reconciler binary), and (b) collapsing would force the engine
+// to pull a pgx reconciliation-table runtime even when the reconciler is
+// not in use.
+type PgMempoolReconciliation struct {
+	pool             *pgxpool.Pool
+	ch               chan NewReconciliation
+	metrics          *MempoolReconciliationMetrics
+	wg               sync.WaitGroup
+	dispatcherCancel context.CancelFunc
+}
+
+// NewPgMempoolReconciliation connects to Postgres and spawns the dispatcher.
+// Mirrors NewPgLedger's lifecycle so a future joint shutdown coordinator
+// can call Close on both without special-casing either.
+func NewPgMempoolReconciliation(
+	ctx context.Context,
+	databaseURL string,
+	metrics *MempoolReconciliationMetrics,
+) (*PgMempoolReconciliation, error) {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse MEMPOOL_LEDGER_DSN: %w", err)
+	}
+	cfg.MaxConns = reconPoolSize
+	cfg.ConnConfig.ConnectTimeout = reconConnectTimeout
+
+	connectCtx, cancel := context.WithTimeout(ctx, reconConnectTimeout)
+	defer cancel()
+	pool, err := pgxpool.NewWithConfig(connectCtx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("connect mempool pgxpool: %w", err)
+	}
+	if err := pool.Ping(connectCtx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("ping mempool postgres: %w", err)
+	}
+
+	dispatcherCtx, dispatcherCancel := context.WithCancel(context.Background())
+	r := &PgMempoolReconciliation{
+		pool:             pool,
+		ch:               make(chan NewReconciliation, reconChannelCapacity),
+		metrics:          metrics,
+		dispatcherCancel: dispatcherCancel,
+	}
+	r.wg.Add(1)
+	go r.dispatch(dispatcherCtx)
+
+	slog.Info("PgMempoolReconciliation connected — reconciliation writes enabled",
+		"component", "reconciler",
+		"channel_capacity", reconChannelCapacity,
+		"pool_size", reconPoolSize)
+	return r, nil
+}
+
+// Close drains in-flight writes and shuts the pool down. Same bounded
+// drain policy as PgLedger.Close: a wedged Postgres cannot hang the
+// reconciler shutdown forever.
+func (r *PgMempoolReconciliation) Close() {
+	close(r.ch)
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Clean drain.
+	case <-time.After(reconCloseDrainTimeout):
+		slog.Warn("PgMempoolReconciliation Close() drain timed out",
+			"component", "reconciler",
+			"timeout", reconCloseDrainTimeout)
+		r.dispatcherCancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	}
+	r.pool.Close()
+}
+
+// LookupPredictionByTxHash returns the prediction row keyed by
+// `pending_tx_hash`. The second return is false (with nil error) when no
+// row matches — i.e. the tx hash was never a prediction. Callers MUST
+// distinguish "missing" from "error" because the per-block hot path treats
+// the two cases differently: missing is the expected dominant case (most
+// tx hashes are not predictions) and is silent.
+func (r *PgMempoolReconciliation) LookupPredictionByTxHash(
+	ctx context.Context,
+	txHash [32]byte,
+) (PendingPrediction, bool, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT prediction_id, protocol, pool_address, predicted_target_block
+		FROM mempool_predictions
+		WHERE pending_tx_hash = $1
+	`, txHash[:])
+
+	var (
+		pred       PendingPrediction
+		poolBytes  []byte
+		targetBlk  int64
+	)
+	if err := row.Scan(&pred.PredictionID, &pred.Protocol, &poolBytes, &targetBlk); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PendingPrediction{}, false, nil
+		}
+		return PendingPrediction{}, false, fmt.Errorf("lookup prediction: %w", err)
+	}
+	pred.PredictedTargetBlock = uint64(targetBlk)
+	if len(poolBytes) == 20 {
+		var arr [20]byte
+		copy(arr[:], poolBytes)
+		pred.PoolAddress = &arr
+	}
+	return pred, true, nil
+}
+
+// InsertReconciliation enqueues a write. Fire-and-forget. Saturation drops
+// the row and bumps `aether_mempool_reconciler_drops_total`.
+func (r *PgMempoolReconciliation) InsertReconciliation(rec NewReconciliation) {
+	r.metrics.QueueDepth.Inc()
+	select {
+	case r.ch <- rec:
+	default:
+		r.metrics.QueueDepth.Dec()
+		r.metrics.DropsTotal.Inc()
+		slog.Warn("reconciliation channel full — dropping row",
+			"component", "reconciler",
+			"capacity", reconChannelCapacity,
+			"outcome", rec.Outcome)
+	}
+}
+
+// MarkStaleAsDropped runs the periodic sweep that closes the loop for
+// predictions where the 12-block window elapsed without a matching landed
+// tx. Returns the number of rows inserted.
+//
+// The query is a single INSERT … SELECT with NOT EXISTS guard so multiple
+// concurrent reconcilers (e.g. blue/green deploy overlap) never produce
+// duplicate dropped rows — the prediction_id PK on
+// mempool_reconciliation makes the second writer's row a no-op via
+// ON CONFLICT DO NOTHING.
+func (r *PgMempoolReconciliation) MarkStaleAsDropped(
+	ctx context.Context,
+	currentHead uint64,
+) (int64, error) {
+	cutoff := int64(currentHead) - int64(StaleConfirmationWindow)
+	if cutoff < 0 {
+		return 0, nil
+	}
+	// The failure_reason is built in Go (rather than via SQL concat) so
+	// pgx encodes a single $1 as TEXT and a single $2 as BIGINT — the
+	// concat form pgx<->driver-encoder did not recognise the int64
+	// argument when the column context was TEXT.
+	failureReason := fmt.Sprintf("12-block window elapsed (head=%d)", currentHead)
+	tag, err := r.pool.Exec(ctx, `
+		INSERT INTO mempool_reconciliation (
+			prediction_id, resolution_ts, outcome, failure_reason
+		)
+		SELECT p.prediction_id, now(), 'dropped', $1
+		FROM mempool_predictions p
+		WHERE p.predicted_target_block <= $2
+		  AND NOT EXISTS (
+		      SELECT 1 FROM mempool_reconciliation r
+		      WHERE r.prediction_id = p.prediction_id
+		  )
+		ON CONFLICT (prediction_id) DO NOTHING
+	`, failureReason, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("mark stale dropped: %w", err)
+	}
+	rows := tag.RowsAffected()
+	if rows > 0 {
+		r.metrics.ReconciledTotal.WithLabelValues(OutcomeDropped).Add(float64(rows))
+	}
+	return rows, nil
+}
+
+func (r *PgMempoolReconciliation) dispatch(ctx context.Context) {
+	defer r.wg.Done()
+	for rec := range r.ch {
+		r.metrics.QueueDepth.Dec()
+		if ctx.Err() != nil {
+			// Drain remaining ops to keep the channel reader live; the
+			// dispatcherCancel path is reserved for the wedged-PG case.
+			continue
+		}
+		timer := time.Now()
+		err := r.insertReconciliationInner(ctx, &rec)
+		elapsedMs := float64(time.Since(timer).Microseconds()) / 1000.0
+		result := "ok"
+		if err != nil {
+			result = "err"
+			slog.Warn("reconciliation insert failed; row dropped",
+				"component", "reconciler",
+				"outcome", rec.Outcome,
+				"prediction_id", rec.PredictionID,
+				"error", err.Error())
+		} else {
+			r.metrics.ReconciledTotal.WithLabelValues(rec.Outcome).Inc()
+		}
+		r.metrics.WriteLatencyMs.WithLabelValues(result).Observe(elapsedMs)
+	}
+	slog.Info("PgMempoolReconciliation dispatcher exiting", "component", "reconciler")
+}
+
+func (r *PgMempoolReconciliation) insertReconciliationInner(
+	ctx context.Context,
+	rec *NewReconciliation,
+) error {
+	var (
+		actualBlock *int64
+		blockDelta  *int
+		replaced    []byte
+	)
+	if rec.ActualTargetBlock != nil {
+		v := int64(*rec.ActualTargetBlock)
+		actualBlock = &v
+	}
+	if rec.BlockDelta != nil {
+		blockDelta = rec.BlockDelta
+	}
+	if rec.ReplacedByTxHash != nil {
+		replaced = rec.ReplacedByTxHash[:]
+	}
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO mempool_reconciliation (
+			prediction_id, resolution_ts, outcome,
+			actual_target_block, actual_tx_index, block_delta,
+			ordering_correct, pool_path_correct,
+			replaced_by_tx_hash, failure_reason
+		) VALUES (
+			$1, $2, $3,
+			$4, $5, $6,
+			$7, $8,
+			$9, $10
+		)
+		ON CONFLICT (prediction_id) DO NOTHING
+	`,
+		rec.PredictionID, rec.ResolutionTs, rec.Outcome,
+		actualBlock, rec.ActualTxIndex, blockDelta,
+		rec.OrderingCorrect, rec.PoolPathCorrect,
+		replaced, rec.FailureReason,
+	)
+	return err
+}

--- a/internal/db/mempool_reconciliation_test.go
+++ b/internal/db/mempool_reconciliation_test.go
@@ -1,0 +1,254 @@
+package db
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestOutcomeConstantsMatchSchema pins the outcome string constants to the
+// CHECK constraint in `migrations/0004_mempool_reconciliation.sql`. A drift
+// here (e.g. renaming "confirmed" to "landed") would make every write fail
+// with a CHECK violation; this test catches it without touching the DB.
+func TestOutcomeConstantsMatchSchema(t *testing.T) {
+	wantConfirmed := "confirmed"
+	wantDropped := "dropped"
+	wantReplaced := "replaced"
+	wantStillPending := "still_pending"
+	if OutcomeConfirmed != wantConfirmed {
+		t.Fatalf("OutcomeConfirmed = %q, want %q (migration 0004 CHECK constraint)",
+			OutcomeConfirmed, wantConfirmed)
+	}
+	if OutcomeDropped != wantDropped {
+		t.Fatalf("OutcomeDropped = %q, want %q", OutcomeDropped, wantDropped)
+	}
+	if OutcomeReplaced != wantReplaced {
+		t.Fatalf("OutcomeReplaced = %q, want %q", OutcomeReplaced, wantReplaced)
+	}
+	if OutcomeStillPending != wantStillPending {
+		t.Fatalf("OutcomeStillPending = %q, want %q", OutcomeStillPending, wantStillPending)
+	}
+}
+
+// TestStaleConfirmationWindow pins the dropped-grace constant. Lowering it
+// would surface false drops on busy fee markets; raising it would delay
+// the "dropped" outcome past usefulness. A drift bug is far more likely
+// than an intentional change, so the test fails noisily when the constant
+// moves.
+func TestStaleConfirmationWindow(t *testing.T) {
+	if StaleConfirmationWindow != 12 {
+		t.Fatalf("StaleConfirmationWindow = %d, want 12 (Flashbots-aligned heuristic)",
+			StaleConfirmationWindow)
+	}
+}
+
+// TestMempoolReconciliationMetricsRegister exercises every path on the
+// metrics struct so a typo in a Name / Help / label triggers in CI.
+func TestMempoolReconciliationMetricsRegister(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewMempoolReconciliationMetrics(reg)
+
+	m.ReconciledTotal.WithLabelValues(OutcomeConfirmed).Inc()
+	m.ReconciledTotal.WithLabelValues(OutcomeDropped).Add(3)
+	m.DropsTotal.Inc()
+	m.QueueDepth.Set(7)
+	m.WriteLatencyMs.WithLabelValues("ok").Observe(1.5)
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("registry.Gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, f := range families {
+		names[f.GetName()] = true
+	}
+	for _, required := range []string{
+		"aether_mempool_reconciled_total",
+		"aether_mempool_reconciler_drops_total",
+		"aether_mempool_reconciler_queue_depth",
+		"aether_mempool_reconciler_write_latency_ms",
+	} {
+		if !names[required] {
+			t.Fatalf("missing metric family %s", required)
+		}
+	}
+}
+
+// TestNewReconciliationDefaults documents the zero-value behaviour for the
+// optional pointer fields. Without these defaults, a caller who forgets to
+// populate ActualTargetBlock for a `dropped` outcome would still produce
+// a row whose NULLs match the schema's expectations — this test pins that.
+func TestNewReconciliationDefaults(t *testing.T) {
+	rec := NewReconciliation{
+		PredictionID: uuid.New(),
+		ResolutionTs: time.Now().UTC(),
+		Outcome:      OutcomeDropped,
+	}
+	if rec.ActualTargetBlock != nil {
+		t.Errorf("ActualTargetBlock should default to nil; got %v", rec.ActualTargetBlock)
+	}
+	if rec.ActualTxIndex != nil {
+		t.Errorf("ActualTxIndex should default to nil; got %v", rec.ActualTxIndex)
+	}
+	if rec.PoolPathCorrect != nil {
+		t.Errorf("PoolPathCorrect should default to nil; got %v", rec.PoolPathCorrect)
+	}
+}
+
+// ------- Integration test, gated by MEMPOOL_LEDGER_TEST_DSN -------
+
+// TestPgMempoolReconciliationRoundTrip exercises the writer against a live
+// Postgres reachable via MEMPOOL_LEDGER_TEST_DSN. Skipped when the env var
+// is unset so `go test ./...` works on machines without Postgres.
+//
+// Pre-condition: migrations 0001 → 0004 applied. The test inserts one
+// prediction via raw SQL (mirroring what the Rust writer would emit),
+// invokes LookupPredictionByTxHash + InsertReconciliation, then verifies
+// the join. Cleanup truncates the rows it added; it does not touch
+// pre-existing data.
+func TestPgMempoolReconciliationRoundTrip(t *testing.T) {
+	dsn := os.Getenv("MEMPOOL_LEDGER_TEST_DSN")
+	if dsn == "" {
+		t.Skip("MEMPOOL_LEDGER_TEST_DSN unset — skipping live PG integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	reg := prometheus.NewRegistry()
+	metrics := NewMempoolReconciliationMetrics(reg)
+	recon, err := NewPgMempoolReconciliation(ctx, dsn, metrics)
+	if err != nil {
+		t.Fatalf("NewPgMempoolReconciliation: %v", err)
+	}
+	defer recon.Close()
+
+	// Insert a prediction we own. The tx hash is derived from two fresh
+	// UUIDs so re-running the test against the same DB does not collide
+	// with an orphan row from a previous failed run (the `pending_tx_hash`
+	// UNIQUE index would otherwise short-circuit our INSERT and we'd
+	// read back the stale prediction_id).
+	predID := uuid.New()
+	var txHash [32]byte
+	low := uuid.New()
+	high := uuid.New()
+	copy(txHash[0:16], low[:])
+	copy(txHash[16:32], high[:])
+	router := [20]byte{0x7a, 0x25, 0x0d, 0x56, 0x30, 0xb4, 0xcf, 0x53, 0x97, 0x39,
+		0xdf, 0x2c, 0x5d, 0xac, 0xb4, 0xc6, 0x59, 0xf2, 0x48, 0x8d}
+	tokenIn := [20]byte{0xc0, 0x2a, 0xaa, 0x39, 0xb2, 0x23, 0xfe, 0x8d, 0x0a, 0x0e,
+		0x5c, 0x4f, 0x27, 0xea, 0xd9, 0x08, 0x3c, 0x75, 0x6c, 0xc2}
+	tokenOut := [20]byte{0xa0, 0xb8, 0x69, 0x91, 0xc6, 0x21, 0x8b, 0x36, 0xc1, 0xd1,
+		0x9d, 0x4a, 0x2e, 0x9e, 0xb0, 0xce, 0x36, 0x06, 0xeb, 0x48}
+	poolAddr := [20]byte{0xB4, 0xe1, 0x6d, 0x01, 0x68, 0xe5, 0x2d, 0x35, 0xCa, 0xCD,
+		0x2c, 0x61, 0x85, 0xb4, 0x42, 0x81, 0xEc, 0x28, 0xC9, 0xDc}
+
+	_, err = recon.pool.Exec(ctx, `
+		INSERT INTO mempool_predictions (
+			prediction_id, decoded_at, pending_tx_hash, router_address, protocol,
+			token_in, token_out, amount_in, pool_address,
+			predicted_target_block, predicted_post_state
+		) VALUES (
+			$1, now(), $2, $3, 'uni_v2', $4, $5, 1000000, $6,
+			100, '{"kind":"v2","reserve_in":1000,"reserve_out":2000}'::jsonb
+		)
+		ON CONFLICT (pending_tx_hash) DO NOTHING
+	`, predID, txHash[:], router[:], tokenIn[:], tokenOut[:], poolAddr[:])
+	if err != nil {
+		t.Fatalf("seed prediction: %v", err)
+	}
+	t.Cleanup(func() {
+		// Cascade clears both rows when we delete the prediction.
+		_, _ = recon.pool.Exec(context.Background(),
+			`DELETE FROM mempool_predictions WHERE prediction_id = $1`, predID)
+	})
+
+	// Read it back through the public API.
+	pred, found, err := recon.LookupPredictionByTxHash(ctx, txHash)
+	if err != nil {
+		t.Fatalf("LookupPredictionByTxHash: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected prediction to be found by tx hash")
+	}
+	if pred.PredictionID != predID {
+		t.Fatalf("PredictionID = %v, want %v", pred.PredictionID, predID)
+	}
+	if pred.PoolAddress == nil || *pred.PoolAddress != poolAddr {
+		t.Fatalf("PoolAddress mismatch: %v vs %v", pred.PoolAddress, poolAddr)
+	}
+	if pred.PredictedTargetBlock != 100 {
+		t.Fatalf("PredictedTargetBlock = %d, want 100", pred.PredictedTargetBlock)
+	}
+
+	// Write a confirmed reconciliation row. Use Close() at end to drain.
+	actualBlock := uint64(101)
+	actualIdx := 5
+	blockDelta := 1
+	poolPathCorrect := true
+	recon.InsertReconciliation(NewReconciliation{
+		PredictionID:      predID,
+		ResolutionTs:      time.Now().UTC(),
+		Outcome:           OutcomeConfirmed,
+		ActualTargetBlock: &actualBlock,
+		ActualTxIndex:     &actualIdx,
+		BlockDelta:        &blockDelta,
+		PoolPathCorrect:   &poolPathCorrect,
+	})
+
+	// Allow the dispatcher to drain. Poll the row up to 2 s so we don't
+	// race on a slow CI Postgres.
+	deadline := time.Now().Add(2 * time.Second)
+	var landed bool
+	for time.Now().Before(deadline) {
+		var outcome string
+		err := recon.pool.QueryRow(ctx,
+			`SELECT outcome FROM mempool_reconciliation WHERE prediction_id = $1`,
+			predID,
+		).Scan(&outcome)
+		if err == nil && outcome == OutcomeConfirmed {
+			landed = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !landed {
+		t.Fatalf("reconciliation row did not land within 2s")
+	}
+}
+
+// TestPgMempoolReconciliationLookupMiss verifies the (false, nil err) case
+// for a hash that is not in `mempool_predictions`. Important because the
+// per-block loop treats `(false, nil)` as "tx hash is not a prediction"
+// (the dominant case) without logging.
+func TestPgMempoolReconciliationLookupMiss(t *testing.T) {
+	dsn := os.Getenv("MEMPOOL_LEDGER_TEST_DSN")
+	if dsn == "" {
+		t.Skip("MEMPOOL_LEDGER_TEST_DSN unset — skipping live PG integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	reg := prometheus.NewRegistry()
+	metrics := NewMempoolReconciliationMetrics(reg)
+	recon, err := NewPgMempoolReconciliation(ctx, dsn, metrics)
+	if err != nil {
+		t.Fatalf("NewPgMempoolReconciliation: %v", err)
+	}
+	defer recon.Close()
+
+	// A hash that no prediction ever uses (high bytes set).
+	missing := [32]byte{0xff, 0xff, 0xff, 0xff}
+	_, found, err := recon.LookupPredictionByTxHash(ctx, missing)
+	if err != nil {
+		t.Fatalf("LookupPredictionByTxHash error on miss: %v", err)
+	}
+	if found {
+		t.Fatalf("found=true for non-existent hash")
+	}
+}

--- a/migrations/0003_mempool_predictions.sql
+++ b/migrations/0003_mempool_predictions.sql
@@ -1,0 +1,79 @@
+-- Mempool predictions — public-flow observability ledger.
+--
+-- Records every pending-tx swap the engine decoded + analytically simulated,
+-- so a follow-up reconciler (issue #131 Go half) can compare against
+-- confirmed blocks and answer "did the tx land where we predicted, in the
+-- order we predicted, hitting the pool we predicted?" — all in SQL.
+--
+-- Independent of `arbs` / `bundles`: this side never submits, so there is no
+-- foreign key into the trade-ledger tables. The two ledgers can be enabled
+-- separately via distinct DSNs (DATABASE_URL = trade ledger,
+-- MEMPOOL_LEDGER_DSN = mempool ledger), so an operator can run mempool
+-- observability without provisioning the executor schema and vice versa.
+--
+-- U256 economics       → NUMERIC(78,0)  (max 2^256 has 78 digits).
+-- Variable-shape state → JSONB (V3 sqrt + tick; Curve A + balances;
+--                                Balancer balances + weights).
+-- All timestamps       → TIMESTAMPTZ.
+--
+-- Clock-authority policy (matches 0001_trade_ledger.sql):
+--   * `decoded_at` is CLIENT-SET. Writers MUST populate it at the moment
+--     the pending-tx event lands in the decoder; the `DEFAULT now()`
+--     fallback exists only for ad-hoc inserts and must not be relied on by
+--     application paths. The gap between "tx hit the mempool subscription"
+--     and "row landed in Postgres" can be tens of ms under load; trusting
+--     DB time would skew the detection-lead-vs-confirmation analysis the
+--     follow-up reconciler builds on.
+--
+-- See issue #131 for the broader observability plan, and CLAUDE.md for the
+-- 7-layer architecture context.
+
+CREATE TABLE IF NOT EXISTS mempool_predictions (
+    prediction_id              UUID PRIMARY KEY,
+    -- Client-set; instant of decode in the Rust pipeline.
+    decoded_at                 TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    -- 32-byte tx hash. UNIQUE so a re-broadcast of the same pending tx
+    -- (Alchemy WS can replay on reconnect) does not insert a duplicate
+    -- prediction row; the writer uses ON CONFLICT DO NOTHING.
+    pending_tx_hash            BYTEA            NOT NULL UNIQUE,
+    router_address             BYTEA            NOT NULL,
+    -- Wire label matches the decoder's `Protocol` debug rendering:
+    -- uni_v2 / sushi / uni_v3 / curve / balancer. Bound to TEXT (not an
+    -- enum type) so adding a new decoded protocol does not require a
+    -- migration; values are validated at the Rust boundary.
+    protocol                   TEXT             NOT NULL,
+    token_in                   BYTEA            NOT NULL,
+    token_out                  BYTEA            NOT NULL,
+    amount_in                  NUMERIC(78,0)    NOT NULL,
+    -- NULL when the (token_in, token_out, protocol) triple missed the live
+    -- pool registry — the pre-sim filter drops these before the writer is
+    -- called, but the column stays nullable so a future "filtered" code
+    -- path can emit a stub row for completeness.
+    pool_address               BYTEA,
+    -- current_head + 1 at decode time; the reconciler compares against
+    -- the actual landed block to produce `block_delta`.
+    predicted_target_block     BIGINT           NOT NULL,
+    -- Shape varies by protocol:
+    --   uni_v2 / sushi   → {"reserve_in": "..", "reserve_out": ".."}
+    --   uni_v3            → {"sqrt_price_x96_post": "..", "tick_post": ..}
+    --   balancer          → {"balance_in": "..", "balance_out": ".."}
+    --   curve             → {"balances_post": ["..", ".."], "amp": ".."}
+    predicted_post_state       JSONB            NOT NULL,
+    -- Populated when the post-state Bellman-Ford scan surfaced a profitable
+    -- cycle; NULL when the scan ran but found nothing.  A NOT NULL profit
+    -- factor is the SQL signal "we would have considered acting on this".
+    profit_factor_predicted    DOUBLE PRECISION,
+    -- Engine-side measurement of how far ahead of confirmation we saw the
+    -- pending tx (decoded_at - earliest builder-side timestamp). NULL when
+    -- the builder timestamp is unknown (Alchemy WS doesn't expose one
+    -- today; reserved for the MEV-Share SSE path).
+    detection_lead_ms          BIGINT,
+    engine_git_sha             TEXT
+);
+
+CREATE INDEX IF NOT EXISTS mempool_predictions_target_block_idx ON mempool_predictions (predicted_target_block);
+CREATE INDEX IF NOT EXISTS mempool_predictions_decoded_at_idx   ON mempool_predictions (decoded_at DESC);
+
+-- mempool_reconciliation lands in PR-2 (issue #131 Go half). Defining it
+-- here in a separate migration would couple the two PRs; the reconciler
+-- ships its own 0004_mempool_reconciliation.sql.

--- a/migrations/0004_mempool_reconciliation.sql
+++ b/migrations/0004_mempool_reconciliation.sql
@@ -1,0 +1,77 @@
+-- Mempool reconciliation — close the loop on persisted predictions.
+--
+-- Joins one-to-one with `mempool_predictions` (issue #131 first half /
+-- PR #133): for every prediction, the reconciler poll loop writes exactly
+-- one row here once the outcome is known. The two tables together answer
+-- "did the tx land where we said it would, in the order we said it would,
+-- hitting the pool we said it would?" — entirely in SQL.
+--
+-- Outcome lifecycle:
+--   confirmed     - tx landed in a block at or after predicted_target_block.
+--                   `actual_target_block`, `actual_tx_index`, `block_delta`,
+--                   `ordering_correct`, `pool_path_correct` are all populated.
+--   dropped       - prediction is now older than head - 12 blocks and no
+--                   matching tx has surfaced. Mirrors the Flashbots-side
+--                   "12-block dropped" heuristic. Only `resolution_ts`
+--                   carries meaning.
+--   replaced     - a later pending tx from the same sender + nonce landed
+--                   first (same-nonce replacement). `replaced_by_tx_hash`
+--                   carries the replacement's hash; the other "actual"
+--                   columns are NULL because the prediction itself never
+--                   confirmed.
+--   still_pending - reserved for the case where the reconciler shuts down
+--                   with predictions still in-flight; the next start-up
+--                   resumes from this state. Not emitted under steady-state
+--                   operation.
+--
+-- Clock-authority policy matches 0001_trade_ledger.sql / 0003_mempool_predictions:
+--   * `resolution_ts` is CLIENT-SET (writer populates it the moment the
+--     resolution is computed in code; the `DEFAULT now()` is a psql-level
+--     safety net only).
+--
+-- The FK to `mempool_predictions(prediction_id)` uses ON DELETE CASCADE so
+-- truncating predictions for a re-soak also clears reconciliation. The
+-- reverse direction is enforced by the writer (insert prediction first,
+-- then reconciliation), not by a CHECK constraint, so the writer can
+-- batch-insert reconciliations without locking against concurrent
+-- prediction inserts.
+
+CREATE TABLE IF NOT EXISTS mempool_reconciliation (
+    prediction_id          UUID PRIMARY KEY
+        REFERENCES mempool_predictions(prediction_id) ON DELETE CASCADE,
+    -- Client-set; instant of resolution in the reconciler loop.
+    resolution_ts          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    outcome                TEXT NOT NULL
+        CHECK (outcome IN ('confirmed','dropped','replaced','still_pending')),
+    -- NULL for `dropped` / `replaced` / `still_pending`. For `confirmed`:
+    -- the block the prediction's pending tx actually landed in.
+    actual_target_block    BIGINT,
+    -- Position within `actual_target_block`. NULL when outcome ≠ confirmed.
+    actual_tx_index        INTEGER,
+    -- `actual_target_block - predicted_target_block`. Negative = landed
+    -- earlier than predicted; positive = landed later. NULL when outcome
+    -- ≠ confirmed.
+    block_delta            INTEGER,
+    -- The mempool predictor records `predicted_target_block` only — it does
+    -- not predict tx ordering within the block. Until a predicted-index is
+    -- recorded by the engine (future work), `ordering_correct` is left
+    -- NULL on confirmed rows so the column stays a no-op rather than
+    -- a misleading TRUE.
+    ordering_correct       BOOLEAN,
+    -- TRUE when the receipt's logs contain an entry whose `address` matches
+    -- `mempool_predictions.pool_address`. FALSE when the receipt landed but
+    -- no log touched the predicted pool (router routed elsewhere, or the
+    -- predicted pool was wrong). NULL when outcome ≠ confirmed or
+    -- `pool_address` was NULL on the prediction.
+    pool_path_correct      BOOLEAN,
+    replaced_by_tx_hash    BYTEA,
+    -- Free-form reason for non-confirmed outcomes (e.g. the
+    -- "12-block window elapsed" / "same-nonce replacement" labels the
+    -- reconciler emits). NULL on `confirmed`.
+    failure_reason         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS mempool_reconciliation_actual_target_block_idx
+    ON mempool_reconciliation (actual_target_block);
+CREATE INDEX IF NOT EXISTS mempool_reconciliation_outcome_idx
+    ON mempool_reconciliation (outcome);


### PR DESCRIPTION
Go half of issue #131: closes the loop on PR #133's persisted predictions
by subscribing to `newHeads`, matching landed tx hashes against
`mempool_predictions`, and writing one `mempool_reconciliation` row per
prediction once the outcome is known. The two tables together answer
\"did the tx land where we said it would, in the order we said it would,
hitting the pool we said it would?\" — entirely in SQL.

Depends on #133 for the migration and the populated predictions table.

## Schema

`migrations/0004_mempool_reconciliation.sql` matches the schema in issue
#131's body. Cascade FK to `mempool_predictions(prediction_id)` so
truncating predictions also clears reconciliation rows for a re-soak.

## Layout

| Layer | Change |
|---|---|
| `migrations/0004_mempool_reconciliation.sql` (new) | Reconciliation table + outcome CHECK + indexes |
| `internal/db/mempool_reconciliation_pg.go` (new) | Sibling of `PgLedger` — pgxpool, bounded mpsc, dedicated writer goroutine. `LookupPredictionByTxHash` (sync), `InsertReconciliation` (fire-and-forget), `MarkStaleAsDropped` (batch). |
| `internal/db/mempool_reconciliation_metrics.go` (new) | `aether_mempool_reconciled_total{outcome}` + writer-internal drops / queue_depth / write_latency. |
| `cmd/reconciler/main.go` (new) | Standalone `aether-reconciler` binary. Two loops: `newHeads → BlockByHash → per-tx lookup → receipt-fetch → outcome=confirmed insert`; periodic `MarkStaleAsDropped(currentHead)`. |
| `internal/db/mempool_reconciliation_test.go` (new) | Pure unit tests + two integration tests gated on `MEMPOOL_LEDGER_TEST_DSN`. |

## Metrics

| Metric | Type | Labels |
|---|---|---|
| `aether_mempool_reconciled_total` | Counter | `outcome` (`confirmed` / `dropped` / `replaced` / `still_pending`) |
| `aether_mempool_reconciler_drops_total` | Counter | — |
| `aether_mempool_reconciler_queue_depth` | Gauge | — |
| `aether_mempool_reconciler_write_latency_ms` | Histogram | `result` (`ok`/`err`) |
| `aether_mempool_reconciler_headers_processed_total` | Counter | — |
| `aether_mempool_reconciler_{header,lookup,receipt}_fetch_errors_total` | Counter | — |
| `aether_mempool_block_delta` | Histogram | — (PromQL renders \"block accuracy\" as `histogram_quantile(0.5, …)` over a rolling 1h) |
| `aether_mempool_pool_path_total` | Counter | `protocol`, `correct` (`true`/`false`) |

The pool-path-accuracy gauge from issue #131 is rendered Grafana-side as
`sum(rate(aether_mempool_pool_path_total{correct=\"true\"}[1h])) /
 sum(rate(aether_mempool_pool_path_total[1h]))` so the metric stays
truly cumulative (Prometheus best practice) instead of being a
process-local 1h ring buffer.

## Local proof

```
go vet ./...                        # clean
go test ./... -race -count=1        # all packages ok
MEMPOOL_LEDGER_TEST_DSN=postgres://aether:aether@localhost:5433/aether \
  go test ./internal/db/... -run TestPgMempoolReconciliation -v
# TestPgMempoolReconciliationRoundTrip  PASS
# TestPgMempoolReconciliationLookupMiss PASS
cargo clippy --workspace -- -D warnings   # clean (Rust unchanged)
```

The two integration tests exercise the full SQL round-trip:

- `TestPgMempoolReconciliationRoundTrip` — seeds a prediction with a
  randomized tx hash, calls `LookupPredictionByTxHash`, calls
  `InsertReconciliation` with `outcome=confirmed`, polls until the row
  is visible. Asserts `PoolAddress` round-trip, `PredictedTargetBlock`,
  `outcome=confirmed` landing. Effectively the live-PG version of the
  confirmed-path loop body.
- `TestPgMempoolReconciliationLookupMiss` — pins the `(false, nil err)`
  return for a hash that is not a prediction (the per-block hot path's
  dominant case).

## Live soak — `dropped` outcome confirmed

Engine + reconciler running against the same Postgres on `:5433`:

```
$ tail /tmp/aether-soak2/reconciler-stderr.log
INFO PgMempoolReconciliation connected — reconciliation writes enabled component=reconciler channel_capacity=256 pool_size=4
INFO metrics server listening addr=:9094
INFO subscribed to newHeads
INFO stale sweep marked predictions as dropped rows=1 head=25099871

$ psql -c \"SELECT outcome, COUNT(*) FROM mempool_reconciliation GROUP BY outcome\"
 outcome | count
 dropped |     1
```

The `dropped` row resolved the one prediction left over from PR-1's soak
(its `predicted_target_block` was already > 12 blocks behind current
head when the reconciler started, so the very first 6 s sweep tick
closed it).

## Live `confirmed` outcome — pending

The `confirmed` path requires a pending tx hitting one of the 6 curated
routers on a pair in our 76-pool registry (~5% hit rate empirically per
PR #133's transcript). I will post the live `confirmed` transcript as a
PR comment once mainnet timing cooperates; the integration test above
already exercises the same SQL path through the same writer goroutine,
so the wire path is mechanically verified.

## Acceptance criteria (issue #131 — Go half)

- [x] `migrations/0004_mempool_reconciliation.sql` applies cleanly on
      a fresh PG17 with PR #133 already applied.
- [x] Reconciler subscribes to `newHeads`, fetches blocks, looks up
      predictions, and writes reconciliation rows.
- [x] `MarkStaleAsDropped` resolves predictions past the 12-block
      window. Verified live (1 dropped row produced from the PR #133
      soak's leftover prediction).
- [x] `aether_mempool_reconciled_total{outcome}` registered and bumped
      on every successful resolution.
- [ ] Live mainnet soak produces non-zero `confirmed` AND `dropped`.
      Dropped done; confirmed will land as a PR comment.

## Follow-up

- PR-3 adds the `aether-profit-scorer` binary computing realized P&L
  per reconciled prediction (issue #132).