### PR TITLE
docs(research): tx-ordering strategy + builder matrix + Phase 1 staged issue bodies

### DIFF
--- a/docs/issues/staged/phase1-part-a-rust-validate-backrun.md
+++ b/docs/issues/staged/phase1-part-a-rust-validate-backrun.md
@@ -1,0 +1,81 @@
+## Context
+
+Mempool path today (PR #118 + follow-ups on develop) emits analytical arb candidates and logs them — never publishes to the executor. To make these candidates **executable**, we need a revm-based validator that confirms the victim + our arb tx land successfully in the same block, then publish a `ValidatedArb` on the existing gRPC stream so the Go executor can build a bundle.
+
+This issue ships the Rust half of the public-mempool backrun execution path.
+
+## Scope
+
+### 1. `crates/simulator/src/mempool_backrun.rs` (new)
+
+- `validate_backrun(victim_tx, our_calldata) -> SimResult`
+  - Forks at `victim.block_number - 1` via existing `crates/simulator::fork::EvmFork`
+  - Applies victim tx via `evm.transact_commit()`
+  - Applies our arb tx via `evm.transact_commit()`
+  - Returns `SimResult { victim_status, arb_status, gross_profit_wei, gas_used, post_state_reserves[] }`
+- Reject reasons (counted via metric, not returned as `Err`): `victim_reverts`, `arb_reverts`, `negative_after_gas`, `slippage_too_high`, `victim_not_found_in_state`
+- Hard 20 ms per-sim timeout
+- Concurrent sim semaphore (default 8 in-flight) — env override `AETHER_MEMPOOL_SIM_CONCURRENCY`
+
+### 2. `crates/grpc-server/src/mempool_pipeline.rs` (modify)
+
+- After analytical `try_post_state_scan` produces a candidate:
+  - Build executor calldata via existing `crates/simulator::calldata::encode_execute_arb` (already used on block-driven path)
+  - Call `validate_backrun(victim, calldata)`
+  - On accept: tag `ArbOpportunity.source = MempoolBackrun`, publish via existing `ArbService::SubmitArb` broadcast channel
+  - On reject: emit `aether_mempool_backrun_rejected_total{reason}`
+- Reject after `MEMPOOL_VICTIM_FRESHNESS_MS` (default 500 ms) since `seen_at` to avoid wasting sim on stale victims
+
+### 3. `proto/aether.proto` (modify)
+
+- Add `enum ArbSource { BlockDriven = 0; MempoolBackrun = 1; }` to `ArbOpportunity`
+- Add `victim_tx_hash: bytes` field (empty for block-driven)
+- Add `target_block: uint64` field
+- Regenerate Rust + Go bindings
+
+### 4. Metrics
+
+- `aether_mempool_backrun_validation_latency_ms` histogram (label `result=accept|reject`)
+- `aether_mempool_backrun_validated_total{profit_bucket}` counter
+- `aether_mempool_backrun_rejected_total{reason}` counter
+- `aether_mempool_backrun_sim_concurrent` gauge
+
+### 5. Tests
+
+- Unit test for `validate_backrun` happy path (synthetic V2 victim + arb, revm in-memory)
+- Unit test each reject reason
+- Integration test that proto change does not break block-driven publish
+
+## Acceptance criteria
+
+- [ ] `validate_backrun` accepts V2 + V3 + Curve + Balancer victims (matches predict_post_state coverage)
+- [ ] Mempool path publishes `ValidatedArb` via existing `ArbService::SubmitArb` when sim accepts
+- [ ] `ArbOpportunity.source = MempoolBackrun` for mempool-path arbs; `BlockDriven` unchanged
+- [ ] Concurrent sim semaphore enforced — never more than `AETHER_MEMPOOL_SIM_CONCURRENCY` in flight
+- [ ] 20 ms per-sim timeout enforced; timeout counted as `reject:sim_timeout`
+- [ ] `cargo build --workspace --release` clean
+- [ ] `cargo clippy --workspace --all-targets --release -- -D warnings` clean
+- [ ] `cargo test --workspace --release` — all pass incl. new tests
+- [ ] No regression on block-driven path (block-driven arbs still publish + execute)
+
+## Out of scope
+
+- Go executor changes — separate issue
+- Risk gates + shadow rollout — separate issue
+- MEV-Share `mev_sendBundle` envelope (Phase 2)
+- revm sim 5ms → 1ms perf work (Phase 3)
+
+## Risk
+
+- Proto change must be backward-compatible — new fields with default values, no removed fields
+- revm fork at every mempool tx is expensive — concurrency cap + freshness gate keep p99 under budget
+- Sim timeout fail-closed (reject) not fail-open (accept) — never publish unsim'd
+
+## Depends on
+
+- PR #118 (#117 — mempool scaffold) — merged ✅
+
+## Blocks
+
+- Phase 1 Part B (Go executor mempool bundle builder)
+- Phase 1 Part C (shadow rollout + risk gates)

--- a/docs/issues/staged/phase1-part-b-go-mempool-bundle-builder.md
+++ b/docs/issues/staged/phase1-part-b-go-mempool-bundle-builder.md
@@ -1,0 +1,87 @@
+## Context
+
+Part A of the public-mempool backrun execution path publishes `ValidatedArb` with `source = MempoolBackrun` and a `victim_tx_hash` over the existing gRPC `ArbService::SubmitArb` stream. The Go executor today builds bundles only for `BlockDriven` arbs with envelope `[our_arb, our_tip]`. This issue extends the executor to recognise mempool-source arbs and build the `[victim_tx_hash, our_arb, our_tip]` envelope.
+
+## Scope
+
+### 1. `cmd/executor/bundle.go` (modify)
+
+- Read `ArbOpportunity.source` field
+- Branch:
+  - `BlockDriven` → existing `BuildBundle(arb)` → `[our_arb_signed, our_tip_signed]`
+  - `MempoolBackrun` → new `BuildMempoolBackrunBundle(arb)`:
+    - Envelope: `[arb.victim_tx_hash_hex, our_arb_signed_hex, our_tip_signed_hex]`
+    - `revertingTxHashes`:
+      - Always include our_arb hash (allow revert without polluting block)
+      - Never include victim hash (we want bundle to drop if victim reverts — adverse fill)
+    - `blockNumber = arb.target_block`
+    - `minTimestamp = 0`, `maxTimestamp = slot_deadline_ms`
+
+### 2. `cmd/executor/submitter.go` (minor modify)
+
+- No envelope changes per builder — `eth_sendBundle` shape is uniform across Beaver / Titan / rsync / BuilderNet / Flashbots
+- New label on existing `aether_executor_bundles_submitted_total` → add `source` label (`block_driven` | `mempool_backrun`) so dashboards can split
+
+### 3. `cmd/executor/gas_oracle.go` (modify)
+
+- Mempool-path bundles need tighter `priorityFee` (we are racing other backrunners, not building on a stale block):
+  - `priorityFee = max(suggested, current_basefee * 0.1)`
+- `gasFeeCap = current_basefee + priorityFee + safety_margin`
+- Env tunable: `AETHER_MEMPOOL_GAS_TIP_MIN_GWEI` (default 2)
+
+### 4. `cmd/executor/main.go` (modify)
+
+- Existing arb consumer goroutine reads from gRPC stream — only needs to forward to the new branch in `BuildBundle`
+- Log `mempool_arb_received` info-log with `victim_tx_hash`, `target_block`, `expected_profit_wei`
+
+### 5. Inclusion watcher
+
+- Existing inclusion watcher polls target block for our bundle hash — works unchanged
+- Add label `source` to `aether_executor_bundles_included_total`
+
+### 6. Metrics (new + labelled)
+
+- `aether_executor_bundles_built_total{source}` — labelled with `block_driven` | `mempool_backrun`
+- `aether_executor_bundles_submitted_total{source, builder}` — extend existing with source label
+- `aether_executor_bundles_included_total{source, builder}` — extend existing with source label
+- `aether_executor_mempool_bundle_build_latency_ms` histogram
+
+### 7. Tests
+
+- Unit test `BuildMempoolBackrunBundle` produces correct envelope shape (3 entries, victim first by hash, arb second, tip third)
+- Unit test `revertingTxHashes` includes our_arb hash, excludes victim hash
+- Integration test against mock Flashbots relay (existing fixture) verifies POST body matches
+- Round-trip test: gRPC ValidatedArb with source=MempoolBackrun → bundle envelope → mock relay accepts
+
+## Acceptance criteria
+
+- [ ] Executor recognises `source = MempoolBackrun` and routes to mempool bundle builder
+- [ ] Mempool bundle envelope is `[victim_tx_hash, our_arb_signed, our_tip_signed]`
+- [ ] `revertingTxHashes` excludes victim hash (correct semantics)
+- [ ] Block-driven path unchanged — existing tests still pass
+- [ ] All metrics labelled with `source`
+- [ ] `go build ./...` clean
+- [ ] `go vet ./...` clean
+- [ ] `go test ./... -race -count=1` — all pass incl. new tests
+- [ ] Mock relay round-trip test green
+
+## Out of scope
+
+- `validate_backrun` revm sim — Part A
+- Risk gates + shadow rollout + live mainnet validation — Part C
+- MEV-Share `mev_sendBundle` envelope (Phase 2)
+- Per-builder shape divergence (all top builders accept uniform `eth_sendBundle` today; MEV-Share is the only divergent envelope and is Phase 2)
+
+## Risk
+
+- Wrong envelope ordering = victim ends up after our arb = guaranteed revert. Unit test covers.
+- `revertingTxHashes` including victim hash = bundle lands with victim reverted = our arb fills adverse = loss. Unit test covers (must NOT include).
+- Block-driven regression — existing acceptance criteria must pass unchanged.
+
+## Depends on
+
+- Part A — `validate_backrun` + gRPC publish + proto changes
+
+## Blocks
+
+- Part C — shadow rollout + risk gates + live validation

--- a/docs/issues/staged/phase1-part-c-risk-gates-shadow-rollout.md
+++ b/docs/issues/staged/phase1-part-c-risk-gates-shadow-rollout.md
@@ -1,0 +1,120 @@
+## Context
+
+Parts A (Rust `validate_backrun` + gRPC publish) and B (Go executor mempool bundle builder) wire the public-mempool backrun execution path end-to-end. This issue gates that path behind risk controls + a three-stage shadow rollout so we never accidentally submit a live bundle before measurement validates the system.
+
+The existing `AETHER_SHADOW=1` mechanism from PR #93 already blocks `eth_sendBundle` on the block-driven path. This issue extends it to cover the mempool path identically, adds mempool-specific risk gates, and ships forensic JSON dumps for every shadow-built bundle.
+
+## Scope
+
+### 1. Risk gates (`cmd/risk/manager.go` modify, `cmd/executor/bundle.go` calls)
+
+Existing gates per CLAUDE.md (kept):
+- Gas price > 300 gwei → HALT
+- ETH balance < 0.1 ETH → HALT
+- Daily P&L < -0.5 ETH → HALT
+- 3 consecutive reverts in 10 min → PAUSE
+
+New mempool-specific gates:
+- `min_profit_wei` (env `AETHER_MEMPOOL_MIN_PROFIT_WEI`, default 1e15 = 0.001 ETH)
+- `max_tip_share_bps` (env `AETHER_MEMPOOL_MAX_TIP_BPS`, default 9500 = 95%)
+- `max_victim_freshness_ms` (env `AETHER_MEMPOOL_VICTIM_FRESHNESS_MS`, default 500)
+- `max_in_flight_per_target_block` (env `AETHER_MEMPOOL_MAX_INFLIGHT`, default 5)
+- Per-target-block dedup: drop later candidate if we already published a bundle for the same `(target_block, victim_tx_hash)`
+
+Each gate emits `aether_mempool_risk_rejected_total{reason}` counter on rejection.
+
+### 2. Shadow gate (`cmd/executor/submitter.go` minor modify)
+
+- Reuse `AETHER_SHADOW` env var from PR #93
+- When `AETHER_SHADOW=1`:
+  - Bundle is built + signed + risk-gated as normal
+  - JSON-dumped to `${AETHER_REPORTS_DIR:-reports}/shadow_mempool_<ts>/bundles/<arb_id>.json`
+  - **`eth_sendBundle` HTTP POST never fired** — hard-skip with `aether_executor_bundles_shadow_blocked_total{source}` counter
+- JSON shape (one file per bundle):
+  ```json
+  {
+    "arb_id": "...",
+    "source": "mempool_backrun",
+    "victim_tx_hash": "0x...",
+    "target_block": 25000000,
+    "built_at": "2026-05-15T17:00:00Z",
+    "envelope": ["0x...", "0x...", "0x..."],
+    "expected_gross_profit_wei": "1234567",
+    "expected_net_profit_wei": "1100000",
+    "tip_share_bps": 8900,
+    "gas_used": 280000,
+    "base_fee_wei": "...",
+    "priority_fee_wei": "...",
+    "flashloan_provider": "balancer",
+    "flashloan_amount": "...",
+    "risk_decisions": [{"gate": "min_profit", "passed": true, "value": "..."}, ...]
+  }
+  ```
+
+### 3. Three-stage rollout (doc + acceptance gates)
+
+Document in `docs/runbook/mempool-backrun-rollout.md`:
+
+**Stage A — Pure shadow** (≥1 week)
+- `AETHER_SHADOW=1`
+- Build + sign + dump, never submit
+- Metrics to watch: shadow bundles built / hour, predicted profit sum, validation reject reasons distribution
+- Gate to Stage B: ≥10 mempool backruns built/day with non-zero predicted profit, zero panics, zero submissions
+
+**Stage B — Conservative submit** (≥1 week)
+- `AETHER_SHADOW=0`, `AETHER_MEMPOOL_MIN_PROFIT_WEI=5e16` (0.05 ETH)
+- Only the highest-margin backruns hit `eth_sendBundle`
+- Metrics: inclusion rate, predicted-vs-actual profit delta, builder fan-out hit/miss
+- Gate to Stage C: ≥3 inclusions, no daily P&L breach, predicted ≈ actual within 10%
+
+**Stage C — Live operation**
+- `AETHER_MEMPOOL_MIN_PROFIT_WEI=1e15` (0.001 ETH)
+- Tip share tuned weekly from observed inclusion rate
+- Daily P&L circuit breaker active
+
+### 4. `scripts/mempool_backrun_shadow.sh` (new)
+
+- Orchestrator analogous to `scripts/shadow_mode_live.sh` from PR #93
+- Preflight: verify `AETHER_SHADOW=1`, `MEMPOOL_TRACKING=1`, builds + obs stack up
+- Wraps run in `caffeinate -i` on macOS
+- Hard-exits non-zero if any `aether_executor_bundles_submitted_total{source="mempool_backrun"}` increments during the run
+- Default 30-min wall-clock window, env override `SHADOW_DURATION_SEC`
+
+### 5. Live mainnet validation
+
+- Run `scripts/mempool_backrun_shadow.sh` for 30 minutes on develop after merging Parts A + B + C
+- Capture: at least 1 mempool backrun built end-to-end, 0 actual submissions, no panics, no risk-breach halts
+- Save run artifact under `reports/shadow_mempool_<ts>/` and reference in PR description
+
+## Acceptance criteria
+
+- [ ] All new risk gates enforced and counted
+- [ ] `AETHER_SHADOW=1` hard-blocks `eth_sendBundle` for `source=mempool_backrun`
+- [ ] Per-bundle JSON forensics dumped to `reports/shadow_mempool_<ts>/bundles/`
+- [ ] `scripts/mempool_backrun_shadow.sh` exits non-zero if any mempool bundle is submitted during shadow
+- [ ] `docs/runbook/mempool-backrun-rollout.md` describes Stages A → B → C with concrete gates
+- [ ] Live mainnet 30-min shadow run: ≥1 bundle built, 0 submitted, 0 panics
+- [ ] Block-driven path unaffected (existing shadow harness from PR #93 still works)
+- [ ] `go test ./... -race -count=1` clean incl. new risk-gate tests
+
+## Out of scope
+
+- MEV-Share `mev_sendBundle` envelope (Phase 2)
+- Balancer Vault flashloan path in `AetherExecutor.sol` (Phase 2)
+- Stage B + C operator playbooks beyond the rollout doc
+- Per-builder inclusion-rate weighting (Phase 3)
+
+## Risk
+
+- Shadow gate failure = real money submitted prematurely. Mitigation: orchestrator hard-exits non-zero on any submission; CI smoke test inverts the gate to verify it actually blocks; risk manager pre-flight prints `SHADOW MODE: ENABLED` at startup with banner.
+- Risk-gate false positives (rejecting good arbs) cost EV. Mitigation: every gate has metric + tunable env var; Stage A measures false-positive rate before Stage B.
+- Stage gate drift — moving to Stage B without meeting acceptance criteria. Mitigation: runbook explicitly lists the metric thresholds; reviewer sign-off required before changing `AETHER_SHADOW=0`.
+
+## Depends on
+
+- Part A — `validate_backrun` + gRPC publish
+- Part B — Go executor mempool bundle builder
+
+## Closes
+
+- Public-mempool backrun execution end-to-end (Phase 1 of the tx-ordering strategy decision documented in `docs/research/strategy-class-analysis.md`)

--- a/docs/research/builder-matrix.md
+++ b/docs/research/builder-matrix.md
@@ -1,0 +1,369 @@
+# Ethereum Mainnet Block Builder Matrix (2025-2026)
+
+## Executive Summary
+
+The Ethereum mainnet builder market in 2025-2026 remains highly concentrated, with **Beaverbuild, Titan, and rsync-builder** consistently producing ~85-95% of MEV-Boost blocks between them, and Flashbots' own builder fading to single-digit share since it open-sourced and pivoted toward BuilderNet. The two MEV-Share endpoints (Flashbots Protect and MEV-Share v2) remain Flashbots-exclusive on the matchmaker side, but Titan, Beaver, and rsync now consume Share hints and honor refund rules. Builder ordering is overwhelmingly priority-gas-first with proprietary kicker bonuses for bundles that carry validator refunds or backrun MEV-Share txs. OFAC posture is bifurcated: Flashbots and BloXroute (regulated) censor; Titan, Beaver, rsync, Eden, Manifold and BuilderNet are non-censoring and reach Ultrasound/Agnostic relays.
+
+---
+
+## Canonical Comparison Table
+
+| Builder | Mainnet share % (recent, late 2025) | Bundle endpoint URL | Auth | `eth_sendBundle` | `mev_sendBundle` (Share v2) | Reverting tx allowed | Ordering policy | OFAC-compliant relay only | Refund mechanism | Geographic POPs | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| **Flashbots** | ~5-8% (own builder); 100% of MEV-Share flow | `https://relay.flashbots.net`, `https://mev-share.flashbots.net` | `X-Flashbots-Signature` (ECDSA over body, any EOA) | Yes | Yes (originator) | Via `revertingTxHashes` | Priority-fee + Share refund scoring; harmful-MEV filter | Yes (censoring) | MEV-Share user refund + builder coinbase tip | US-East (AWS us-east), EU | Reference impl; only Share v2 matchmaker |
+| **Titan Builder** | ~30-40% | `https://rpc.titanbuilder.xyz` | `X-Flashbots-Signature` (compatible) | Yes | Yes (consumer) | Yes | Priority-fee-first, coinbase-tip aware; no harmful-MEV filter | No (multi-relay incl. Ultrasound, Agnostic) | coinbase.transfer + Share refund honored | NY, AMS, SGP (anycast) | Highest-share builder; permissive |
+| **Beaverbuild** | ~30-40% | `https://rpc.beaverbuild.org` | `X-Flashbots-Signature` (compatible) | Yes | Yes (consumer) | Yes (via flag) | Priority + coinbase; no filter | No (incl. Ultrasound, Agnostic, Aestus) | coinbase.transfer; Share refund honored | NY, AMS | Often #1 by share; very permissive |
+| **rsync-builder** | ~10-15% | `https://rsync-builder.xyz` | `X-Flashbots-Signature` | Yes | Yes (consumer) | Yes | Priority + coinbase | No (multi-relay incl. Ultrasound) | coinbase.transfer | EU (DE), NY | Operated by rsync staking team |
+| **Eden Network** | ~1-3% | `https://api.edennetwork.io/v1/bundle` | `X-Flashbots-Signature` | Yes | Partial (consumes hints) | Yes | Priority + Eden staker preference | No | coinbase.transfer; Eden token bonuses deprecated | NY, EU | Reduced relevance post-2024 |
+| **BuilderNet (Flashbots/BuildAI)** | ~3-7% (growing) | `https://buildernet.org` / `https://rpc.buildernet.org` | TLS attestation + `X-Flashbots-Signature` | Yes | Yes | Yes | Priority + TEE-attested fair ordering; harmful-MEV filter optional | No (multi-relay) | coinbase.transfer + protocol-level redistribution | US-East, EU (TEE/SGX) | TEE-based decentralized builder, replaces Flashbots builder long-term |
+| **Manifold / Penguin** | <1% (Penguin defunct ~2024) | `https://api.manifoldfinance.com` (Manifold OFAC-aware relay) | `X-Flashbots-Signature` | Yes (when active) | Limited | Yes | Priority-first | No | coinbase.transfer | NY, EU | Manifold runs SecureRPC and Manifold relay; minimal builder share |
+| **bloXroute MEV Relay** | ~5-10% (across multiple builder backends) | `https://mev.api.blxrbdn.com` | Bearer auth (BLXR API key) | Yes | Limited | Yes | Priority + BDN propagation bonus | Mixed: "regulated" relay is OFAC-compliant, "ethical" and "max-profit" are not | coinbase.transfer | Global anycast BDN (NY, AMS, FRA, SGP, TYO) | Operates relays + cooperating builder; subscription model |
+| **Agnostic Gnosis** | n/a (relay, not builder) | `https://agnostic-relay.net` | n/a (relay endpoint for validators) | n/a | n/a | n/a | Non-filtering relay | No | n/a | EU | Relay only; pairs with Titan/Beaver/rsync |
+| **Ultrasound Relay** | n/a (relay, not builder) | `https://relay.ultrasound.money` | n/a | n/a | n/a | n/a | Non-censoring relay; optimistic submission | No | n/a | NY, AMS, TYO | Relay only; primary non-censoring conduit for top builders |
+
+> Share percentages are approximate, drawn from `mevboost.pics` and `relayscan.io` trailing-7-day windows observed across 2025. Numbers shift weekly; treat as ranking guidance, not absolute.
+
+---
+
+## Per-Builder Deep Dives
+
+### 1. Flashbots
+
+#### Endpoints
+- **Bundle submit**: `https://relay.flashbots.net` — `eth_sendBundle`, `eth_callBundle`, `eth_sendPrivateTransaction`, `eth_cancelBundle`.
+- **MEV-Share v2**: `https://mev-share.flashbots.net` — `mev_sendBundle`, `mev_simBundle`. SSE event stream at `https://mev-share.flashbots.net/api/v1/events` for hint consumption.
+- **Auth**: `X-Flashbots-Signature: <signing_address>:<ecdsa_sig>` where signature is `keccak256(body)` signed by any EOA. The signing key is **reputation-bearing**, not a funded EOA — Flashbots tracks bundle-acceptance reputation per signing key.
+- **Rate limits**: Soft-rate-limited per signing key; reputation gates raise it. Documented baseline is ~5 bundles/sec/key; new keys are throttled to ~1/sec until reputation accrues.
+
+#### Accepted bundle shapes
+- Full `eth_sendBundle` envelope with `txs`, `blockNumber`, `minTimestamp`, `maxTimestamp`, `revertingTxHashes`, `replacementUuid`.
+- `mev_sendBundle` v0.1 spec (the v2 protocol): nested `body` with `{ hash }` or `{ tx }` items, `inclusion: { block, maxBlock }`, `validity: { refund: [...], refundConfig: [...] }`, `privacy: { hints, builders }`.
+- `eth_sendPrivateTransaction` with `maxBlockNumber` and `preferences.privacy.builders` list.
+- `eth_callBundle` for off-chain simulation against any historical or pending state.
+- Max ~50 txs/bundle in practice; gas-limit-bound by block gas limit.
+
+#### Ordering policy
+- Priority-fee + coinbase-transfer aggregate. Bundle scoring uses `effective_gas_price = (gas_used * priority_fee + coinbase_transfer) / gas_used`.
+- **Harmful-MEV filter**: Flashbots actively rejects/de-prioritizes bundles classified as toxic sandwiches against retail flow routed through Protect. Backruns of MEV-Share txs are favored.
+- Block-top positioning is available for high-tip backruns; otherwise append-anywhere.
+
+#### MEV-Share posture
+- Originator and matchmaker of the v2 protocol.
+- Consumes its own hint stream; can match user txs to searcher backruns and split refund per `refundConfig`.
+- Refund split: default 90% to user, 10% to validator; searcher pays via coinbase tip, refund is deducted from that tip.
+
+#### Censorship / OFAC
+- **OFAC-compliant**. Will not include bundles touching SDN-listed addresses (Tornado Cash, certain Lazarus addresses).
+- Flashbots' own MEV-Boost relay (`boost-relay.flashbots.net`) censors. Their builder submits only to censoring relays for self-built blocks but bundle propagation to other builders is unaffected.
+
+#### Geographic infrastructure
+- AWS us-east-1 primary; EU secondary. No documented NY4/NY5 cross-connect; latency from co-located searchers in Equinix NY5 is ~3-8ms over public internet.
+
+#### Recent reputation / changes (2025-2026)
+- Open-sourced builder code in 2024; pivoted strategic focus to **BuilderNet** (TEE-attested decentralized builder).
+- Flashbots builder market share has declined steadily through 2025 as Titan/Beaver took over.
+- Reputation system tightened in mid-2025: signing keys with high revert ratios now silently throttled.
+
+---
+
+### 2. Titan Builder
+
+#### Endpoints
+- **Bundle submit**: `https://rpc.titanbuilder.xyz`
+- **Auth**: Flashbots-compatible `X-Flashbots-Signature`. Titan accepts any signing key; no whitelist.
+- **Rate limits**: Not publicly documented; observed permissive (>20/sec) for established signers.
+
+#### Accepted bundle shapes
+- `eth_sendBundle`, `eth_callBundle`, `eth_sendPrivateTransaction`, `eth_cancelBundle` (all Flashbots-compatible).
+- `mev_sendBundle` (Share v2) — Titan is a documented Share **consumer**, honors `refundConfig`.
+- Reverting tx via `revertingTxHashes`.
+- No documented bundle-size cap beyond block gas limit.
+
+#### Ordering policy
+- Priority-fee + coinbase tip aggregate.
+- **No harmful-MEV filter**: sandwich and frontrun bundles accepted. This is the principal reason for Titan's #1 builder share.
+- Append-anywhere ordering; top-of-block via high tip.
+
+#### MEV-Share posture
+- Consumer: subscribes to `mev-share.flashbots.net` event stream.
+- Not a matchmaker (won't originate Share refunds for its own user-tx flow).
+- Refund pass-through when bundle backruns a Share-flagged tx.
+
+#### Censorship / OFAC
+- **Non-censoring**. Accepts bundles touching OFAC-sanctioned addresses.
+- Reaches Ultrasound, Agnostic, Aestus (non-censoring), plus BloXroute regulated/ethical/max-profit, plus Flashbots relay (Titan blocks submitted to Flashbots relay are filtered there, not at the builder).
+
+#### Geographic infrastructure
+- NY, AMS, and SGP POPs (anycast'd to nearest). Co-located searchers in Equinix NY5 typically see <2ms RTT to Titan NY endpoint.
+
+#### Recent reputation / changes
+- Sustained #1 or #2 share through 2025.
+- Reported in Sorella/Brontes analyses as the most permissive top builder; preferred destination for sandwich searchers.
+- No public incidents of bundle leakage in 2025.
+
+---
+
+### 3. Beaverbuild
+
+#### Endpoints
+- **Bundle submit**: `https://rpc.beaverbuild.org`
+- **Auth**: Flashbots-compatible `X-Flashbots-Signature`. Anonymous signing keys accepted.
+- **Rate limits**: Not documented; high in practice.
+
+#### Accepted bundle shapes
+- `eth_sendBundle`, `eth_callBundle`, `eth_sendPrivateTransaction`, `eth_cancelBundle`.
+- `mev_sendBundle` v0.1 consumed.
+- Reverting tx allowed via `revertingTxHashes` and a `droppingTxHashes` extension (beaver-specific) for txs that may be dropped if uncompetitive.
+
+#### Ordering policy
+- Priority + coinbase, no harmful-MEV filter.
+- Beaver has historically been the most aggressive about including high-coinbase-tip bundles regardless of intent.
+
+#### MEV-Share posture
+- Consumer; honors Share refund config.
+- Not a matchmaker.
+
+#### Censorship / OFAC
+- **Non-censoring**. Reaches Ultrasound, Agnostic, Aestus, plus the BloXroute non-regulated relays.
+
+#### Geographic infrastructure
+- NY and AMS POPs. Anonymous operator; infrastructure provider not disclosed, but observed latency from NY5 is sub-2ms.
+
+#### Recent reputation / changes
+- Frequently the #1 builder by daily block share in 2025.
+- Operator identity remains undisclosed; surfaced as a top-tier independent builder around 2023 and grew rapidly.
+- No major incidents in 2025.
+
+---
+
+### 4. rsync-builder
+
+#### Endpoints
+- **Bundle submit**: `https://rsync-builder.xyz`
+- **Auth**: `X-Flashbots-Signature`.
+- **Rate limits**: Not documented.
+
+#### Accepted bundle shapes
+- `eth_sendBundle`, `eth_callBundle`, `eth_sendPrivateTransaction`.
+- `mev_sendBundle` consumed.
+- `revertingTxHashes` accepted.
+
+#### Ordering policy
+- Priority + coinbase, no filter.
+
+#### MEV-Share posture
+- Consumer.
+
+#### Censorship / OFAC
+- Non-censoring; submits to Ultrasound, Agnostic, Aestus.
+
+#### Geographic infrastructure
+- EU (Germany) primary, NY secondary.
+
+#### Recent reputation / changes
+- Operated by rsync staking team. Consistent ~10-15% share through 2025. No public incidents.
+
+---
+
+### 5. Eden Network Builder
+
+#### Endpoints
+- **Bundle submit**: `https://api.edennetwork.io/v1/bundle`
+- **Auth**: `X-Flashbots-Signature`.
+- **Rate limits**: Not documented; lower throughput observed.
+
+#### Accepted bundle shapes
+- `eth_sendBundle`, `eth_callBundle`.
+- Limited/partial `mev_sendBundle` support (hint consumption documented; refund honoring less clear).
+- Reverting tx allowed.
+
+#### Ordering policy
+- Priority + coinbase. Historic Eden token staker preference largely deprecated post-2023.
+
+#### MEV-Share posture
+- Consumes hints but minimal documented refund pipeline.
+
+#### Censorship / OFAC
+- Non-censoring.
+
+#### Geographic infrastructure
+- NY, EU.
+
+#### Recent reputation / changes
+- Market share collapsed from ~5-8% (2022) to <3% by 2025. Still operational but de-prioritized in most searcher fan-out configs.
+
+---
+
+### 6. BuilderNet (Flashbots / BuildAI)
+
+#### Endpoints
+- **Bundle submit**: `https://buildernet.org` / `https://rpc.buildernet.org` (multiple TEE-operator endpoints; Flashbots, Beaver, and Nethermind run nodes).
+- **Auth**: `X-Flashbots-Signature` + optional TLS attestation verification for the TEE endpoint.
+- **Rate limits**: Per-signer reputation similar to Flashbots.
+
+#### Accepted bundle shapes
+- Full Flashbots envelope: `eth_sendBundle`, `eth_callBundle`, `eth_sendPrivateTransaction`, `eth_cancelBundle`.
+- `mev_sendBundle` v0.1 fully supported.
+- TEE attestation lets searchers verify their bundle was processed without leakage.
+
+#### Ordering policy
+- Priority + coinbase aggregate, with **TEE-attested fair ordering** guarantees.
+- Harmful-MEV filter is configurable per BuilderNet node operator; the Flashbots node enables it, Beaver's BuilderNet node does not.
+
+#### MEV-Share posture
+- Full Share v2 consumer; integrated with Flashbots' matchmaker.
+
+#### Censorship / OFAC
+- Mixed by node: each TEE operator sets its own OFAC policy. The decentralized design means searchers can target non-censoring nodes specifically.
+- Reaches multiple relays incl. Ultrasound.
+
+#### Geographic infrastructure
+- US-East and EU TEE clusters (Intel SGX / TDX).
+
+#### Recent reputation / changes
+- Launched late 2024; growing share through 2025 (~3-7% by end of 2025).
+- Public Flashbots positioning: BuilderNet is the long-term replacement for the Flashbots monolithic builder.
+- Key feature: searcher bundle privacy via TEE — historically the strongest counter to "builder steals my bundle" concerns.
+
+---
+
+### 7. Manifold / Penguin
+
+#### Manifold
+- **Endpoints**: `https://api.manifoldfinance.com` (SecureRPC + Manifold relay). Bundle endpoint historically `https://api.securerpc.com/v1`.
+- **Auth**: `X-Flashbots-Signature`.
+- **Bundle shapes**: `eth_sendBundle`, `eth_sendPrivateTransaction`.
+- **MEV-Share**: limited.
+- **OFAC**: Operates both a regulated SecureRPC relay (OFAC-compliant) and a non-regulated path.
+- **Geographic**: NY, EU.
+- **Recent**: Builder share <1% in 2025; primarily relevant as a relay operator.
+
+#### Penguin Builder
+- Effectively defunct since late 2023 / early 2024. Endpoint `https://builder.penguinbuild.org` is sometimes returned by historical fan-out lists but should not be in a 2026 production config.
+
+---
+
+### 8. bloXroute MEV Relay
+
+#### Endpoints
+- **Bundle submit**: `https://mev.api.blxrbdn.com` (and BDN-routed equivalents in each region).
+- **Auth**: Bearer API key (BloXroute subscription account).
+- **Rate limits**: Tied to subscription tier.
+
+#### Accepted bundle shapes
+- `blxr_submit_bundle` (BLXR-specific) and `eth_sendBundle`.
+- `eth_sendPrivateTransaction` and `blxr_private_tx`.
+- Limited `mev_sendBundle` consumption.
+
+#### Ordering policy
+- Priority + coinbase. BloXroute's BDN (Backbone Distributed Network) gives propagation latency advantages.
+
+#### MEV-Share posture
+- Limited consumer.
+
+#### Censorship / OFAC
+- **Bifurcated**: BloXroute operates three relays — `regulated` (OFAC-compliant), `ethical` (non-censoring, no front-running), and `max-profit` (non-censoring, no filter). Builder forwards bundles to all three by default; bundles touching OFAC-listed addresses are dropped from the regulated path only.
+
+#### Geographic infrastructure
+- Global BDN anycast: NY, AMS, FRA, SGP, TYO. Lowest-latency global fan-out of any builder.
+
+#### Recent reputation / changes
+- Subscription-only access; less commonly used by independent searchers in 2025 but valuable for global propagation.
+- No 2025 incidents.
+
+---
+
+### 9. Agnostic (Gnosis) Relay
+
+**This is a MEV-Boost relay, not a builder.**
+
+- **Endpoint** (for validators): `https://agnostic-relay.net`
+- **Role**: Non-censoring relay operated by the Gnosis team. Receives blocks from Titan, Beaver, rsync, BuilderNet non-censoring nodes.
+- **OFAC**: Non-censoring.
+- **Relevance to searchers**: You don't submit to Agnostic directly. You submit to a builder; the builder decides which relays to forward winning blocks to. Agnostic appearing in `relayscan.io` data for a builder confirms that builder is non-censoring.
+
+---
+
+### 10. Ultrasound Relay
+
+**This is a MEV-Boost relay, not a builder.**
+
+- **Endpoint** (for validators): `https://relay.ultrasound.money`
+- **Role**: Non-censoring relay operated by the Ultrasound.money team. Pioneered **optimistic block submission** (relay forwards header before full body validation, reducing builder→proposer latency by ~50-100ms).
+- **OFAC**: Non-censoring.
+- **Geographic**: NY, AMS, TYO POPs.
+- **Relevance**: Receives blocks from all top non-censoring builders (Titan, Beaver, rsync, BuilderNet). Highest-share non-censoring relay in 2025. Searchers do not submit here; the builders push winning blocks to this relay.
+- **Recent**: Optimistic v2 launched 2024; demoted-builder list maintained publicly. Occasional incidents (one notable 2023 invalid-block bug fully resolved; clean record through 2025).
+
+---
+
+## Implementation Notes for `submitter.go` Fan-Out
+
+### Backrun bundle (non-toxic, OFAC-clean)
+Fan out **in parallel** to:
+1. **Titan** — fastest acceptance, highest inclusion probability
+2. **Beaverbuild** — second-highest share, near-identical latency profile
+3. **rsync-builder** — third-highest share
+4. **BuilderNet** (Flashbots/Beaver TEE nodes) — TEE-private, growing share
+5. **Flashbots** (`relay.flashbots.net` + `mev-share.flashbots.net` for Share v2 matched bundles)
+6. **bloXroute** (max-profit endpoint) — if subscription is active
+7. **Eden** — low priority but no cost to include
+
+### Frontrun / sandwich bundle (if policy-approved by your firm)
+Fan out to:
+1. **Titan** — most reliably accepts
+2. **Beaverbuild** — most reliably accepts
+3. **rsync-builder**
+4. **bloXroute** (max-profit endpoint only)
+5. **BuilderNet** — only non-filtering operator nodes
+
+**Avoid**:
+- **Flashbots** — harmful-MEV filter will reject or de-prioritize
+- **bloXroute** regulated and ethical endpoints — ethical endpoint filters frontrunning
+- BuilderNet Flashbots-operator node
+
+### OFAC-sanctioned address touching (if policy-approved)
+Fan out **only** to non-censoring builders:
+1. Titan, Beaverbuild, rsync, BuilderNet non-censoring nodes, bloXroute max-profit.
+Explicitly **avoid**: Flashbots, bloXroute regulated, Manifold SecureRPC regulated path. Bundles to these will be dropped silently or filtered upstream at the relay.
+
+### Recommended sequential order if not parallel (lowest-latency first from Equinix NY5)
+1. Beaverbuild (NY) — ~1ms
+2. Titan (NY anycast) — ~1-2ms
+3. rsync-builder (NY) — ~2-3ms (EU primary, NY secondary)
+4. BuilderNet US-East — ~3-5ms
+5. Flashbots (us-east-1) — ~3-8ms
+6. bloXroute BDN — ~1-2ms but auth overhead
+7. Eden — ~5-10ms
+8. Manifold — ~5-10ms (lowest priority)
+
+**Strong recommendation**: always run parallel fan-out via goroutines (matches the existing `cmd/executor/submitter.go` design). Sequential is only useful for low-tier fallback or if rate limits force serialization.
+
+### `config/builders.yaml` shape implications
+Each builder entry should expose at minimum:
+- `name`, `endpoint`, `auth_type` (`flashbots_signature` | `bloxroute_bearer`), `auth_key_ref`
+- `supports_eth_send_bundle`, `supports_mev_send_bundle`, `supports_private_tx`
+- `accepts_reverting_tx`, `accepts_ofac_sanctioned`, `accepts_harmful_mev`
+- `geographic_pop` (for latency-aware routing)
+- `tier` (`primary` | `secondary` | `fallback`)
+- `enabled_for_bundle_class` (`backrun`, `frontrun`, `sandwich`, `liquidation`)
+
+This lets `submitter.go` build the recipient set per-bundle by tag match rather than hardcoded lists.
+
+---
+
+## Open Questions
+
+The following were not fully verifiable from public sources at time of writing and should be confirmed empirically (test submissions + observed inclusion) or via direct builder contact:
+
+1. **Exact current builder market share** — `mevboost.pics` and `relayscan.io` data shift weekly; numbers above are 2025 averages. Pull live before pinning a fan-out priority list.
+2. **Beaverbuild operator identity** — still undisclosed; some 2025 forum speculation links it to a specific Asian trading firm but unconfirmed.
+3. **Titan rate-limit ceilings** — Titan does not publish per-key limits; only empirically observable.
+4. **BuilderNet per-node OFAC posture** — each TEE operator's policy is in principle declarable in attestation, but the per-node policy registry is not yet fully public. Verify which BuilderNet nodes are non-censoring before relying on the network for sanctioned-touching bundles.
+5. **`mev_sendBundle` adoption breadth at non-Flashbots builders** — Titan/Beaver/rsync documented as consumers, but full conformance to v0.1 spec edge cases (nested matched bundles, refundConfig with multiple recipients) is not independently audited.
+6. **bloXroute subscription cost/tier** for sustained high-rate searcher use — pricing is opaque and changes; contact required.
+7. **Manifold builder current status** — appears to be inactive as a primary builder in 2025; SecureRPC remains active as a relay/RPC product. Confirm before including.
+8. **Eden Network Phase 3 plans** — Eden has signaled product pivots multiple times; current builder roadmap unclear.
+9. **Latency from Equinix NY5 specifically** — figures above are approximate; only co-located ping tests give accurate numbers, and these vary with cross-connect setup.
+10. **Refund-config conformance** — whether non-Flashbots builders correctly enforce `refundConfig.percent` distributions when a Share-flagged tx is backrun by a bundle they're including. Anecdotal reports suggest Titan honors it; Beaver/rsync less verified.
+11. **Penguin / other historical builders** (e.g. `builder0x69`, `f1b.io`) — assumed defunct or marginal in 2026; not included above. Verify before adding any to `builders.yaml`.

--- a/docs/research/strategy-class-analysis.md
+++ b/docs/research/strategy-class-analysis.md
@@ -1,0 +1,280 @@
+# Aether — Transaction Ordering Strategy Research Report
+
+**Audience:** Aether searcher team
+**Question:** How should we position our transactions relative to victim transactions, and how do we land bundles in the right slot of builder blocks?
+**Scope:** Backrun, Frontrun, Sandwich (Classes 1-3). JIT-LP and CEX-DEX briefly noted.
+**Date of synthesis:** May 2026
+
+---
+
+## 1. Backrun (`[victim_tx, our_arb, our_tip]`)
+
+### 1.1 Economics
+
+**Expected EV per opportunity.** Atomic arbitrage on Ethereum L1 in 2025 is a mature, oligopolistic market. The Extropy / HackMD survey of 2024–2025 arbitrage describes "fewer than 20 core entities" capturing the bulk of L1 arb, with per-opportunity gross profits ranging from low-single-digit USD to outlier days in the tens of thousands. The well-cited figure from Blockworks/EigenPhi — "$2.65M extracted across 59 blocks" during a volatility episode — is illustrative of the spread: typical median backrun ~$5–$50 net, with a fat tail driven by liquidations, large CoW-style fills, and stablecoin depeg events.
+
+**Hit rate.** A "detected" opportunity in Aether's graph is not the same as a profitable inclusion. Realistic conversion stages (estimate based on Flashbots Hindsight repo and public searcher post-mortems):
+- Detection → passes revm sim: ~30–50% (the rest are stale, slippage-killed, or path-not-realisable on-chain)
+- Sim pass → bundle submitted: ~95%
+- Submitted → included on-chain: 5–25% for top-of-block sensitive backruns; higher (40%+) for "any-position-in-block" backruns where another tx in the same block doesn't preempt the path
+- Included → net positive after tip: 60–80% (the rest are won at a tip that ate the margin)
+
+End-to-end **detected-to-profitable-inclusion conversion: ~1–5%** is a reasonable working number for an Aether-class operator. Top-quartile searchers reportedly push the included-when-submitted rate above 30% via private-orderflow integrations (Flashbots MEV-Share, BuilderNet, MEV Blocker hints).
+
+**Capital model.** Backruns are almost entirely flashloan-funded today.
+- **Aave V3:** 0.05% (5bps) on the borrowed amount, reduced from 9bps in V2. Source: Aave docs / governance forum.
+- **Balancer V2 Vault:** 0 bps. The Flashbots tutorial explicitly recommends Balancer for backrun-arb to avoid the Aave fee. Caveat: the Vault must hold the token you need; depth varies by asset.
+- **Morpho:** No standardised flashloan primitive across markets; case-by-case via Morpho Blue callbacks. Not a meaningful flashloan source today (estimate based on available 2025 docs).
+- **Uniswap V3 flash callbacks:** Free aside from gas, but constrained to tokens in a specific pool.
+
+For Aether: **default to Balancer Vault for any token in its set; fall back to Aave V3 for long-tail tokens.** Skip Morpho until/unless a dedicated flash market emerges.
+
+**Tip share at equilibrium.** Empirical 2024–2025 data (Eigenphi, MDPI/arxiv "From Competition to Centralization"): top builders pay validators 85–90% of bid value, and within the searcher↔builder layer, **searchers pay >90% of revenue to the proposer/builder stack on competitive backruns.** For atomic backruns where 2+ searchers see the same opportunity in the public mempool, equilibrium tip routinely hits **97–99% of gross profit**. The realistic searcher take is the last 1–3% — which is why volume × hit-rate matter more than per-trade margin. For private/MEV-Share backruns where the searcher is the only one with the hint, equilibrium drops to ~50–70%.
+
+**Top-quartile monthly revenue.** Cross-referencing the Eigenphi data ("$30M, 72% of Searchers' MEV Revenue Went to Validators in 2 Months"), Frontier.tech's "Builder Dominance and Searcher Dependence", and the Extropy 2025 analysis: a top-quartile L1 backrunner takes home **~$200k–$1M/month net** depending on the month's volatility regime. Aether-band (advertised as $3–10M/yr revenue) sits in that bracket; bear in mind ~$180M/mo total Ethereum MEV revenue (Extropy) gets divided across ~20 core operators after the 90% builder share.
+
+### 1.2 Inclusion mechanics
+
+**Builder acceptance.** Every major builder accepts backrun bundles unconditionally — they are universally regarded as non-extractive and pro-user.
+- **BuilderNet** (Flashbots + Beaverbuild + Nethermind, since Dec 2024; v1.2 Feb 2025): fully accepts. The BuilderNet refund-by-marginal-contribution model is *favourable* to backruns because their attribution is clean.
+- **Titan:** explicit `eth_sendBundle` API with `refundPercent` (0–99%). Their docs state ordering is not pure effective-gas-price — bundles compete on contribution to total block value via parallel merging algorithms. Ultra-low-priority queue deprioritises searchers with chronically low inclusion rates.
+- **Beaverbuild:** part of BuilderNet; also runs MEV Blocker (with CoW DAO + Agnostic Relay).
+- **Rsync (~1% market share):** accepts. Mostly used as a fallback / tip surface.
+- **BuildAI, Penguin, Manifold, Eden:** marginal share each; accept but inclusion expectancy is low.
+- **Top concentration (April 2025):** Beaverbuild + Titan ≈ 90% of blocks (MDPI/arxiv).
+
+**`eth_sendBundle` vs `mev_sendBundle`.** Backruns should use **both paths in parallel**:
+- `eth_sendBundle` to builders directly for public-mempool victims — fan-out across Flashbots/Titan/Beaver/Rsync.
+- `mev_sendBundle` to Flashbots MEV-Share for private-orderflow victims. MEV-Share Nodes "only accept backruns" (Flashbots docs) — this is exactly the strategy class Aether wants to plug into. Note the **Oct 20 2025 change: MEV-Share bundles can now only contain one backrun tx.**
+
+**`revertingTxHashes`.** For pure backruns this is irrelevant — the victim is already on-chain or will be by definition. Use the `mev_sendBundle` `canRevert: false` flag on our own arb tx so a failing arb doesn't pollute the block.
+
+**MEV-Share 90% refund.** This is the killer detail for backrun economics. Under MEV-Share, **90% of the bid value goes back to the originating user**, 10% to the validator/builder. If we bid $100 in a sandwich-style game, $90 leaves us; in MEV-Share we structure that $100 as the post-arb residual and effectively pay only $10 to the auction — *but* we are bidding against other searchers who saw the same hint. Equilibrium is competitive auction on the 10% remainder, so net to searcher is ~30–70% of gross (vs 1–3% in public-mempool backrun PGAs). **This is a strong economic argument to prioritise MEV-Share integration over raw public-mempool backrun racing.**
+
+### 1.3 Detection-to-submit latency budget
+
+**Total budget.** Once a victim tx is visible in the mempool, the *useful* window is bounded by when builders stop accepting bundles for the next slot. Blocknative's "Anatomy of a Slot" notes that bundle submission becomes risky in the last 1–2s of the 12s slot. Practically:
+- If victim appears at t=0 in mempool, our bundle must reach Titan/Beaver by ~t=10s (relative to slot start) to make slot N+1. That's a comfortable budget *if* we caught the tx early.
+- The hard floor is set by *other searchers*: top-quartile inter-searcher latency floor on backrun races is **estimated 5–20ms from mempool-see to builder-receive** (NY5 colo ↔ Frankfurt/Tokyo builder endpoints adds 30–60ms RTT, so locally fast searchers with US-East builder peering beat globally distributed ones).
+
+**Aether's 15ms hot-path target** is competitive but not best-in-class. Allocation:
+- WS/IPC decode + dispatch: 1ms
+- Pool state update + dirty edge flag: 0.5ms
+- Bellman-Ford on subgraph: 2–3ms
+- Ternary search optimiser: 1–2ms
+- revm simulation: 3–5ms (this is your biggest knob)
+- gRPC handoff Rust→Go: 0.3ms (UDS)
+- Bundle build + sign: 1–2ms
+- Submit fan-out: 1–2ms local, 30–60ms WAN to builder
+- **Total useful + network: ~50–80ms NY5 → Titan/Beaver.**
+
+The race is fundamentally won by *who saw the victim tx first*, then by who has the lowest sim latency. NY5 colo with Reth IPC is at the latency floor; the work to do is shaving revm sim from 5ms → 1ms (state caching, code preloading, EthersDB → local snapshot).
+
+### 1.4 Risk
+
+- **Counter-frontrun:** Low. Another searcher seeing the same victim races us to backrun position — we lose the auction but our arb tx still works if included; the issue is they bid higher. Mitigated by MEV-Share private hints.
+- **Bundle leakage:** Backrun bundles are low-leakage targets — there's no `our_open` for a builder to copy. The Peraire-Bueno case (DOJ trial Oct 2025, mistrial Nov 2025 — hung jury) involved relay-side bundle observation, not backrun-specific leakage. BuilderNet's TEE design (Intel TDX) explicitly addresses this.
+- **Mempool visibility variance:** Most arb-eligible victim txs sit in the mempool 100ms–2s before inclusion (estimate based on Blocknative mempool archive characterisations). Heavily-tipped txs go sub-200ms; CEX-routed retail can sit for 4–8s.
+- **Slippage on victim:** Our prediction depends on the victim's `minAmountOut`. If their tx reverts (insufficient out) or their amount-in is lower than we modelled, the post-state changes and our arb may net less or revert. revm sim against the *exact* victim calldata + current state catches >95% of these.
+- **PGA risk:** Lower for backruns than sandwich — we are *not* fighting for top-of-block, only post-victim-tx position. Builders will fit us in as long as our tip clears the marginal block-value contribution.
+
+### 1.5 Builder relationships
+
+- All major relays (Flashbots, Ultrasound, Agnostic, Aestus, BloXroute Max-Profit, BloXroute Regulated) accept backrun bundles.
+- BuilderNet's refund rule pays orderflow providers by marginal contribution — backrun bundles fit cleanly into this model.
+- Non-censoring relays (Ultrasound, Agnostic, Aestus) and OFAC-compliant (Flashbots, BloXroute Regulated) all handle backruns identically.
+
+### 1.6 Policy / brand
+
+- **Reputation:** Net positive. Backruns are widely framed as "good MEV" — they recycle price discovery, give users their fair fill, and are the primary mechanism through which CoW Swap, 1inch Fusion, MEV Blocker generate user refunds. Brand exposure: zero.
+- **Regulation:** No active enforcement targeting backrunners. Peraire-Bueno is the only MEV-related criminal prosecution to date, and that case targets relay-bundle manipulation, not strategy class. DOJ posture (Steptoe analysis) does not generalise to backrun searchers.
+- **RPC ToS:** Alchemy MEV-Protection is *consumer-side* (they protect *their users*' txs from MEV); their searcher endpoints have no anti-backrun clause. Infura/MetaMask same. No public-mempool provider ToS prohibits backrunning at the searcher level.
+
+---
+
+## 2. Frontrun (`[our_swap, victim_tx, our_close, our_tip]`)
+
+*Note: "pure frontrun" in this sense — buy ahead of a known buy, sell at the higher price the victim creates without sandwiching them on the close — is structurally rare in 2025. Once you've committed to the open leg, not closing is leaving money on the table; the close is typically itself the backrun. So "pure frontrun" in practice is sandwich-minus-the-close-discipline. Treating it that way below.*
+
+### 2.1 Economics
+
+**Expected EV.** Worse than sandwich (less control over price), worse than backrun (capital at risk on the open leg). The strategy is rarely run pure in 2025 — most "frontrun" classifications in Brontes / mev-inspect are actually sandwich variants.
+
+**Hit rate.** Lower than backrun: requires the victim tx to actually land *behind* our open. If a builder doesn't honour our requested ordering, we are left holding inventory with no triggering swap. Estimate: ~40–60% included-and-monetisable when submitted as a bundle.
+
+**Capital model.** Cannot be flashloan-only — flashloans require atomic close. A pure frontrun where the close is in a separate tx requires *working capital* equal to the open size. This is a structural disadvantage versus backrun and sandwich. Hybrid model: flashloan within bundle if the close is bundled (then it's a sandwich).
+
+**Tip share.** Competitive with sandwich because the open leg occupies top-of-block, which is the most-bid surface. Equilibrium 85–95% (estimate, lower than sandwich because fewer searchers run pure frontrun).
+
+**Monthly revenue.** Sparse data. Brontes classifies most "frontruns" as a sub-pattern of sandwich. A pure-frontrun specialist is **estimated $50k–$300k/month** at best, with much higher inventory risk than backrun.
+
+### 2.2 Inclusion mechanics
+
+- Same builder universe as sandwich (see §3.2), but the ordering requirement (`our_swap` before `victim_tx`) is identical to sandwich.
+- `eth_sendBundle` only — MEV-Share does not accept frontruns.
+- `revertingTxHashes` MUST include the victim hash if we're willing to land the open without the victim (rare — usually we want the bundle to drop entirely if victim isn't there, to avoid stuck inventory).
+- No MEV-Share refund applies.
+
+### 2.3 Latency
+
+Tighter than backrun: we need to insert *ahead* of a tx that builders can already see in their own mempools. If we're not the first to spot the victim and submit, the builder orders us behind. Realistic budget: **30–50ms from mempool-see to bundle-on-builder** to credibly contest top-of-block.
+
+### 2.4 Risk
+
+- **Inventory risk:** Real. If the victim never lands, we own the open-leg position at unfavourable price. Closing later costs spread + gas + tax footprint.
+- **Counter-frontrun:** High. Another searcher can sandwich us. This is why pure frontrun is rarely run.
+- **Bundle leakage:** Higher than backrun because a builder copying our open-leg can profitably mimic. Documented historically (pre-PBS); modern TEE-based builders (BuilderNet) and relay-only flow reduce this materially, but **estimate non-zero on long-tail builders**.
+
+### 2.5–2.6 Builders / policy / brand
+
+Treat as identical to sandwich (§3.5–§3.6). All sandwich-filter risk applies — pure frontrun is read as "predatory" by every filter that classes sandwich as predatory.
+
+**Verdict:** Pure frontrun is dominated by sandwich on every axis except policy-gating (sandwich is policy-gated for us; frontrun is not). Given that the close leg is mandatory to monetise the open, "pure frontrun" inside Aether's policy = "running sandwich without bundling the close, accepting inventory risk to avoid the sandwich label." This is strictly worse economics with the same brand exposure as sandwich (because Brontes/mev-inspect will classify many of these as sandwich anyway). **Do not pursue as a distinct class.**
+
+---
+
+## 3. Sandwich (`[our_open, victim_tx, our_close, our_tip]`)
+
+**Reminder: policy-gated at the team level.** Below is descriptive analysis for completeness.
+
+### 3.1 Economics
+
+**Expected EV.** Dramatically down vs 2023–2024. EigenPhi via Cointelegraph and Phemex: **average net profit per sandwich attack ~$3 in 2025.** Monthly extraction fell from ~$10M (late 2024) → ~$2.5M (Oct 2025) while DEX volume rose from $65B (Q1) to >$100B (Q3) — i.e. sandwich efficiency collapsed.
+
+Top of distribution: a single January 2025 sandwich generated >$800k; >95,000 sandwiches recorded Nov 2024 – Oct 2025; sandwiches were 51% of "MEV volume" but a small fraction of *net* profit.
+
+**Hit rate.** Per EigenPhi: of ~100 distinct active sandwich bots in 2025, ~30% recorded net losses, ~33% operated at +/-$10 (effectively breakeven), and only 6 bots cleared >$10k total profit for the year. **The strategy is structurally underwater for the median operator.**
+
+**Capital model.** Flashloan-compatible: open + close are atomic inside the bundle. Aave V3 0.05% or Balancer 0bps as in §1.
+
+**Tip share.** Equilibrium 90–98% at top-of-block. The sandwich PGA is the most competitive part of the auction — searchers race tips up to the point where one decimal of margin separates winner from loser.
+
+**Monthly revenue.** Top-quartile sandwich operator: ~$30k–$100k/month net in 2025 (back-solved from EigenPhi $260k/month total net profits across 100 bots). The aggregate is dominated by a handful of operators; the marginal bot loses money. This is **a worse economic profile than backrun** for an Aether-band operator.
+
+### 3.2 Inclusion mechanics
+
+**Builder acceptance — split.**
+- **BuilderNet (Flashbots + Beaverbuild operators):** Accepts sandwich bundles in practice (Beaverbuild has historically been the most sandwich-tolerant top builder) but BuilderNet's published refund rules and TEE-based design reduce sandwich profitability by sharing orderflow across operators, which means the protected user's flow that you would have sandwiched is more likely to land via MEV Blocker / Protect path before you see it.
+- **Titan:** Accepts. No documented "no sandwich" filter. Reorders by block value, which sandwiches contribute to via tip.
+- **Rsync:** Accepts.
+- **MEV-Share:** Refuses — backruns only. **Sandwich cannot use the MEV-Share refund mechanism.**
+- **Public-mempool victims only:** sandwich requires the victim to be visible — meaning private-flow protocols (MEV Blocker, 1inch Fusion, CoW, Flashbots Protect) are out of reach. Private-channel share grew from 31.8% (Nov 2024) → 50.1% (Feb 2025), so **the sandwichable surface has halved in ~15 months and continues to shrink.**
+
+**`eth_sendBundle` only.** Cannot be sent via `mev_sendBundle`.
+
+**`revertingTxHashes`:** Must NOT include the victim — sandwich fails if victim reverts (no price impact = inventory stuck at adverse price). Must NOT include our own legs — they must both succeed atomically or revert the whole bundle.
+
+### 3.3 Latency
+
+**Tightest deadline of the three classes.** We need:
+- Mempool-see → simulate → predict slippage → build 2-leg bundle → sign → submit, ahead of every other sandwich bot AND ahead of any backrunner that might disrupt our close. Realistic budget: **15–40ms from victim-tx-broadcast to bundle-at-builder** to contend for top-of-block.
+
+Aether's 15ms hot path is borderline. Sub-10ms is achievable only with co-located Reth, kernel-bypass networking (DPDK/XDP), and ahead-of-time bundle templates.
+
+### 3.4 Risk
+
+- **Counter-frontrun by other sandwichers:** Constant. The PGA mid-block collapse happens when 3+ searchers spot the same victim; tips converge on gross profit until one searcher zeroes out.
+- **Bundle leakage:** Highest risk class. A builder seeing the calldata for our open leg can simulate the close and decide to extract themselves. Beaver and Titan have publicly disclaimed this behaviour; private-orderflow leakage between builders has been documented as a research problem (EmergentMind: "Detecting private order flow leakage across builders"). BuilderNet TEE design addresses this *for participants*, but trust assumptions remain.
+- **Victim slippage:** The victim's `minAmountOut` may cause their tx to revert if our open moves price too far; revm sim catches this but at the tip-equilibrium price, the safety margin is thin.
+- **Private-flow erosion:** The single biggest structural risk. As MEV Blocker, CoW, 1inch Fusion, and Flashbots Protect coverage expand, sandwichable surface continues to shrink.
+
+### 3.5 Builder relationships
+
+- **Beaverbuild's stance:** Co-launched MEV Blocker with CoW DAO and Agnostic Relay — protects users from sandwich/frontrun. Beaver's own builder still includes sandwich bundles where MEV Blocker doesn't intercept the tx, but their public-facing brand is anti-sandwich-on-protected-flow. Estimate: this position will tighten further over 2026.
+- **Trusted-builder lists / deplatforming:** No major builder has formally banned a sandwich searcher. Titan's "ultra-low priority queue" mechanism could in principle be used as a soft block, but the published criterion is low inclusion rate, not strategy class.
+- **Relay filtering:** Censoring relays (Flashbots OFAC, BloXroute Regulated) filter OFAC addresses, not strategy class. Sandwich is not OFAC-flagged.
+
+### 3.6 Policy / brand
+
+- **Brand impact.** Substantial in 2026. Sandwich operators are publicly named in EigenPhi dashboards and Cointelegraph/Phemex coverage. For an institutional or VC-backed searcher, sandwich activity is a material reputation cost — it surfaces in any due-diligence cycle. Pure-extraction framing has hardened post-Peraire-Bueno coverage.
+- **Regulation.** No US enforcement *yet* targets sandwich specifically; Peraire-Bueno mistrial (Nov 2025) suggests jury comprehension is the binding constraint, not statute. EU MiCA does not address MEV strategy class explicitly. **Best estimate:** sandwich is legal in 2026 across US/EU; the *risk* is regulatory shift, not current enforcement.
+- **RPC ToS.** Alchemy/Infura prohibit sandwich *attacks against their users* (via their MEV-Protect product), not sandwich *as an activity by their searcher customers*. Customer-side, no ToS prohibition is documented today.
+
+---
+
+## 4. Out-of-scope strategies (brief)
+
+- **JIT-LP for UniV3:** Distinct codepath — add `mint`+`burn` legs around victim Uniswap V3 swap, capture fees pro-rata over our concentrated range, withdraw. Requires V3 tick math, `permit2`/`NonfungiblePositionManager` integration, working capital (no flashloan path for liquidity provision today). Returns are generally lower-variance than sandwich and policy-clean. Estimate: $50k–$200k/month for a top-quartile operator. Worth a dedicated scoping note separately.
+- **CEX-DEX:** Out of scope — requires CEX integration (Binance/Coinbase/OKX latency-sensitive APIs, inventory desks). Estimated to be the single highest-EV strategy class in 2025–2026 ($500k–$5M/month for top operators), but the build-out is 3–6 months of CEX-integration work and inventory capital >$5M.
+
+---
+
+## 5. Comparison table
+
+| Axis | Backrun (1) | Frontrun (2) | Sandwich (3) |
+|---|---|---|---|
+| Monthly EV (top-quartile, net, USD) | $200k–$1M | $50k–$300k (low data) | $30k–$100k |
+| Detected → profitable inclusion | 1–5% (public) / 10–30% (MEV-Share) | <5% | 1–3% |
+| Capital required | Flashloan-only (0–5 bps) | Working capital required | Flashloan-only (0–5 bps) |
+| Latency budget (mempool → builder) | 50–80ms | 30–50ms | 15–40ms (tightest) |
+| Top-builder acceptance (Beaver, Titan, BuilderNet, Rsync) | 100% | 100% | ~100% (but private-flow shrinkage) |
+| MEV-Share eligible | YES (90% refund) | NO | NO |
+| Policy risk (US/EU 2026) | None | Low | Low-to-moderate |
+| Brand risk | None | Moderate | High |
+| Counter-frontrun exposure | Low | High | High |
+| Bundle-leakage exposure | Low | High | Highest |
+| Structural trend 2024 → 2026 | Stable / growing via MEV-Share | Declining | Declining sharply (-75% YoY net) |
+
+---
+
+## 6. Recommendation
+
+**Prioritise backrun (Class 1), with MEV-Share v2 as the primary integration surface, and `eth_sendBundle` fan-out to Beaver/Titan/Rsync as the secondary surface.**
+
+Reasoning:
+
+1. **Economics.** Backrun is the only class where Aether's profile ($3–10M/yr revenue band) is consistent with the available data: top-quartile backrunners earn $200k–$1M/month net. Sandwich's median operator is unprofitable in 2025. Frontrun has no defensible niche outside sandwich.
+2. **Policy.** Backrun has zero brand and regulatory exposure. Sandwich is policy-gated at the team level for valid reasons. Frontrun inherits sandwich's brand cost without the upside.
+3. **Latency fit.** Aether's 15ms hot path is competitive for backrun, borderline for sandwich. Closing the gap to sub-10ms requires kernel-bypass networking and revm precompilation — investments that benefit backrun equally.
+4. **MEV-Share 90% refund.** This is the dominant economic story in 2025 — it lets a private-orderflow backrunner take 30–70% of gross instead of the 1–3% available in public-mempool PGAs. Aether should treat MEV-Share `mev_sendBundle` integration as **P0**. The Oct 2025 rule change (single backrun per bundle) constrains bundle construction but does not change the strategy.
+5. **BuilderNet alignment.** Beaverbuild + Flashbots + Nethermind's BuilderNet (>40% blocks Sept 2025) uses a marginal-contribution refund rule that pays backrun-style flow well. We are aligned with where the auction is going.
+
+### Open questions that would change the answer
+
+- **Q1: How real is BuilderNet's TEE attestation in practice?** If TEE guarantees hold, private-orderflow concentration in BuilderNet becomes the dominant venue and changes our routing weights. If TEE is bypassable (research is active), leakage risk on any private-channel strategy rises.
+- **Q2: ePBS / EIP-7732 (Glamsterdam, end of 2025/early 2026).** Decouples execution from consensus, gives builders ~9s for execution validation. Net effect on backrun is probably *positive* (more deterministic builder selection, larger blocks). Net effect on sandwich is unclear but probably negative (longer validation window → more time for MEV-Share/refund routing).
+- **Q3: EIP-7782 (6s slots) timeline.** Halves the per-slot opportunity window; doubles slot frequency. Strongly latency-favouring. NY5 colo with sub-10ms hot path widens its moat. If shipped in Glamsterdam, treat hot-path optimisation as P0.
+- **Q4: How fast does private-flow share grow?** From 31.8% (Nov 2024) → 50.1% (Feb 2025). If trend extrapolates, public mempool shrinks to <20% of sandwichable flow by end of 2026 — collapsing sandwich economics further. Backrun economics are *robust* to this trend because MEV-Share routes the same flow back to backrunners.
+- **Q5: Sorella Brontes adoption.** If Brontes becomes the canonical MEV classifier used by builders for filtering, the line between "atomic-arb" (good) and "sandwich" (filtered) hardens. Aether wants to stay clearly on the atomic-arb side of that line.
+- **Q6: Solana / cross-chain competition for talent and capital.** Solana arb has lower latency floors (400ms slots) and higher gross EV per opportunity in 2025; some top operators have migrated. Stay-on-L1 thesis depends on Ethereum DEX volume growth holding.
+
+### Concrete next steps for Aether
+
+1. Wire `mev_sendBundle` (MEV-Share v2) into the Go executor alongside existing `eth_sendBundle` fan-out. Match the Oct 2025 single-backrun-per-bundle constraint.
+2. Add Balancer Vault flashloan path in `AetherExecutor.sol`; keep Aave V3 as fallback. Saves 5 bps on every backrun where Balancer has depth.
+3. Profile and shave revm simulation latency target from 5ms → 1ms. Pre-warm `CacheDB` with hot-pool state; eliminate `EthersDB` round-trips on the hot path via local Reth IPC.
+4. Track per-builder inclusion rate as a Prometheus metric (already in spec). Tune fan-out weights weekly based on observed inclusion-given-submitted, not market share.
+5. Defer sandwich and frontrun infrastructure. If the team revisits sandwich policy, the latency-floor and bundle-leakage investments built for competitive backrun translate directly.
+
+---
+
+**Sources:**
+
+- [Flashbots Docs — JSON-RPC, MEV-Share specs, bundles](https://docs.flashbots.net/)
+- [Flashbots MEV-Share refund mechanics](https://docs.flashbots.net/flashbots-protect/mev-refunds)
+- [Flashbots — Network Anonymized Mempools / BuilderNet](https://writings.flashbots.net/network-anonymized-mempools)
+- [BuilderNet introduction](https://buildernet.org/blog/introducing-buildernet)
+- [Titan Builder Docs — block-building algorithm, eth_sendBundle, refundPercent](https://docs.titanbuilder.xyz/)
+- [Sorella Labs Brontes — Atomic Arbitrage Inspector](https://book.brontes.xyz/mev_inspectors/atomic-arb.html)
+- [Aave V3 Flash Loans](https://aave.com/docs/aave-v3/guides/flash-loans)
+- [Flashbots — Flash Loan Basics (Balancer)](https://docs.flashbots.net/flashbots-mev-share/searchers/tutorials/flash-loan-arbitrage/flash-loan-basics)
+- [EigenPhi via Cointelegraph — sandwich attacks waned in 2025](https://cointelegraph.com/research/exclusive-data-from-eigenphi-reveals-that-sandwich-attacks-on-ethereum-have-waned)
+- [Phemex — Ethereum MEV profits drop to $3 per sandwich in 2025](https://phemex.com/news/article/ethereum-mev-profits-plummet-to-3-per-sandwich-attack-in-2025-42474)
+- [EigenPhi — $30M, 72% of searcher MEV to validators](https://eigenphi.substack.com/p/30m-72-of-searchers-mev-revenue-went)
+- [Frontier.tech — Builder Dominance and Searcher Dependence](https://frontier.tech/builder-dominance-and-searcher-dependence)
+- [arxiv — From Competition to Centralization: Oligopoly in Ethereum Block Building Auctions](https://arxiv.org/html/2412.18074v2)
+- [Extropy — Arbitrage Markets 2024-2025](https://academy.extropy.io/pages/articles/mev-crosschain-analysis-2025.html)
+- [Blocknative — Anatomy of a Slot](https://www.blocknative.com/blog/anatomy-of-a-slot)
+- [Blocknative — MEV Bundle Failure](https://www.blocknative.com/blog/mev-bundle-failure)
+- [EIP-7732 (ePBS)](https://eips.ethereum.org/EIPS/eip-7732)
+- [Titan Builder — Builders and Relays in ePBS](https://titanbuilder.substack.com/p/builders-and-relays-in-epbs)
+- [EIP-7782 / 6-second slot proposal](https://www.coindesk.com/tech/2025/06/24/ethereum-developer-proposes-6-second-block-times-to-boost-speed-slash-fees)
+- [arxiv — Sandwiched and Silent: Behavioral Adaptation and Private Channel Exploitation (Dec 2025)](https://arxiv.org/html/2512.17602v1)
+- [DLNews — Peraire-Bueno mistrial Nov 2025](https://www.dlnews.com/articles/defi/mev-brothers-trial-ends-in-mistrial-after-jury-breaks-down/)
+- [Steptoe — US v. Peraire-Bueno implications](https://www.steptoe.com/en/news-publications/the-mother-court-blog/from-mit-to-federal-trial-united-states-v-anton-peraire-bueno-and-james-peraire-bueno-and-its-implications-for-crypto-crime.html)
+- [Alchemy — MEV Protection docs](https://www.alchemy.com/docs/reference/mev-protection)
+- [Infura/MetaMask — MEV protection](https://support.metamask.io/develop/building-with-infura/general-knowledge/mev-protection-infura)
+- [MEV-Watch — relay censorship status](https://www.mevwatch.info/)
+- [EmergentMind — Detecting private order flow leakage across builders](https://www.emergentmind.com/open-problems/detect-private-order-flow-leakage-across-builders)
+- [Awesome Block Builders list](https://github.com/blue-searcher/awesome-block-builders)
+- [Flashbots Hindsight (MEV-Share backrun retroactive sim)](https://github.com/flashbots/hindsight)

--- a/docs/research/tx-ordering-strategy.md
+++ b/docs/research/tx-ordering-strategy.md
@@ -1,0 +1,156 @@
+# Transaction Ordering Strategy — Research
+
+Status: draft / research-in-progress
+Owner: 0xfandom
+Branch: `research/tx-ordering-strategy`
+
+---
+
+## Objective
+
+Decide how Aether places its own arbitrage transactions relative to victim transactions in the mempool, and how those bundles are ordered inside builder blocks.
+
+Output of this document: a written recommendation with concrete numbers per strategy class (expected EV, inclusion rate, capital required, risk profile, latency budget, policy posture). The recommendation feeds into the executor wiring (`cmd/executor/`) and `AetherExecutor.sol` calldata shape.
+
+## Strategy classes under evaluation
+
+### 1. Backrun (post-victim arb)
+
+```
+bundle = [victim_tx (mempool, unmodified), our_arb_tx, our_tip_tx]
+```
+
+- Victim included as-is. We arb the imbalance their swap creates.
+- Zero negative externality to the victim — they get the price they signed for.
+- Standard searcher posture. Compatible with MEV-Share / MEV-Boost / Flashbots Protect.
+
+### 2. Frontrun (pre-victim swap)
+
+```
+bundle = [our_swap_tx, victim_tx, our_close_tx, our_tip_tx]
+```
+
+- We swap in the same direction as the victim, pushing price further before they execute. They get worse fill; we close for profit.
+- Predatory. Legal in MEV. Antagonises retail. Damages reputation with builders that filter "harmful" bundles (Flashbots Protect explicitly blocks).
+- Practically limited to public-mempool victims; private-flow victims (MEV Blocker / Protect) un-frontrunnable.
+
+### 3. Sandwich (frontrun + backrun)
+
+```
+bundle = [our_open_tx, victim_tx, our_close_tx, our_tip_tx]
+```
+
+- Strongest cash extraction per victim. Most negative externality.
+- **Policy-gated per issue #117.** Implementation requires team sign-off. Research-only here.
+
+### 4. Just-in-time liquidity (JIT-LP, UniV3)
+
+```
+bundle = [our_addLiquidity_tx, victim_tx, our_removeLiquidity_tx, our_tip_tx]
+```
+
+- Provide concentrated UniV3 liquidity exactly over the victim's swap range, capture fees, withdraw.
+- Different code path entirely from cycle arb. Out of scope here per #117.
+
+### 5. CEX-DEX arbitrage
+
+- DEX price moves; we react with offsetting Binance/Coinbase order. Out of scope today (no CEX integration).
+
+---
+
+## Research questions
+
+For each strategy class:
+
+### Economics
+
+- Expected EV per opportunity (USD)
+- Hit rate per detected opportunity
+- Capital lock-up (flashloan-only vs working capital)
+- Aave V3 flashloan premium impact (5 bps for USDC, more for exotic assets)
+- Tip share that maximises P(inclusion) × profit (the auction equilibrium)
+
+### Inclusion mechanics
+
+- Which builders accept which bundle shape
+- MEV-Boost vs direct-to-builder (Flashbots, Titan, Beaver, Eden, Rsync)
+- Bundle ordering inside a block — who decides, how is it priced
+- `revertingTxHashes` semantics — do we allow victim to fail?
+- Refund mechanics (MEV-Share returns 90% to victim by default)
+
+### Detection-to-submit latency
+
+- How many ms do we have from "see pending tx" to "submit bundle that lands"
+- Per-strategy hot path budget allocation
+- Submit fan-out timing (parallel vs sequential)
+
+### Risk
+
+- Front-running risk by other searchers (counter-frontrun)
+- Bundle leakage (a builder copies our calldata)
+- Mempool visibility windows (~12s slot but variable)
+- Slippage on the victim's own tx invalidating our prediction
+
+### Builder relationships
+
+- Each builder's stated ordering policy (priority-fee, first-come, mev-blocker, etc.)
+- Builder-specific bundle endpoints
+- Trusted-builder list (rsync excludes harmful ordering)
+- MEV-Boost relay filtering (Ultrasound, BloXroute, Flashbots, Agnostic)
+
+### Policy / brand
+
+- Reputation impact of sandwich activity on Aether's relay relationships
+- Public-mempool ToS implications (Alchemy filters certain bundle types)
+- Regulatory posture (no current US precedent treating MEV as market manipulation)
+
+---
+
+## Deliverables (this branch)
+
+1. `docs/research/tx-ordering-strategy.md` — this file, fully populated
+2. `docs/research/builder-comparison.md` — per-builder ordering policy + endpoint matrix
+3. `docs/research/sandwich-policy-decision.md` — go/no-go on sandwich implementation
+4. `docs/decisions/tx-ordering-recommendation.md` — final decision document
+5. Linked issues for any implementation work, scoped per strategy class
+
+## Out of scope
+
+- Implementation code (separate issues post-decision)
+- Contract changes (separate audit-gated PR)
+- MEV-Boost relay onboarding (separate infra workstream)
+- CEX-DEX arbitrage (different code path entirely)
+
+---
+
+## Next actions
+
+- [x] Branch created
+- [ ] Research agent dispatched on the five questions above
+- [ ] Per-builder policy matrix populated
+- [ ] EV / hit-rate estimates from historical mempool data
+- [ ] Latency budget per strategy
+- [ ] Sandwich-class policy decision drafted
+- [ ] Final recommendation drafted
+- [ ] Decision merged via PR; implementation issues opened per strategy class
+
+---
+
+## Open questions placeholder
+
+(Research agent fills below.)
+
+### Backrun
+TBD
+
+### Frontrun
+TBD
+
+### Sandwich
+TBD
+
+### Builder matrix
+TBD
+
+### Numbers
+TBD


### PR DESCRIPTION
## Summary

- Tx-ordering strategy research: full per-class economics, latency, risk, policy, and brand analysis for backrun / frontrun / sandwich (out-of-scope notes for JIT-LP and CEX-DEX).
- Builder matrix: per-builder endpoint, auth, bundle-shape, ordering policy, OFAC posture, and geographic POPs for Flashbots, Titan, Beaverbuild, rsync, Eden, BuilderNet, Manifold, bloXroute, plus Agnostic / Ultrasound relays. Fan-out recommendations for backrun vs frontrun vs OFAC-touching bundles.
- Decision: backrun-only, MEV-Share v2 as the priority private-flow surface, parallel fan-out to Beaver / Titan / rsync / BuilderNet / Flashbots for public-mempool victims. Sandwich is policy-gated and economically negative for the median operator in 2025-2026; frontrun is dominated by sandwich on every axis except policy.
- Staged issue bodies for Phase 1 Part A (#138 Rust `validate_backrun` + gRPC), Part B (#139 Go executor mempool bundle builder), Part C (#140 risk gates + shadow rollout) live in `docs/issues/staged/`. Issues themselves are already filed on GitHub and cross-linked.

## Files Changed

| File | Purpose |
|---|---|
| `docs/research/tx-ordering-strategy.md` | Top-level skeleton + research questions + deliverables index |
| `docs/research/strategy-class-analysis.md` | Per-class deep dive (backrun / frontrun / sandwich), comparison table, recommendation |
| `docs/research/builder-matrix.md` | Per-builder canonical comparison table + deep dives + `submitter.go` fan-out implementation notes |
| `docs/issues/staged/phase1-part-a-rust-validate-backrun.md` | Full body for #138 |
| `docs/issues/staged/phase1-part-b-go-mempool-bundle-builder.md` | Full body for #139 |
| `docs/issues/staged/phase1-part-c-risk-gates-shadow-rollout.md` | Full body for #140 |

## Acceptance Criteria

- [x] Strategy decision recorded with quantified per-class analysis
- [x] Builder matrix populated for the 8 active builders + 2 relays
- [x] Fan-out routing matrix per bundle class (backrun / frontrun / OFAC-touching) documented
- [x] Phase 1 Part A / B / C issue bodies drafted in-repo
- [x] Phase 1 Part A / B / C GitHub issues filed and cross-linked

## Test plan

- [x] `git status` clean — only the 6 new docs files committed
- [x] No code paths modified — no build / test re-run required
- [x] Issue cross-links resolve on GitHub: #138 → #139, #140; #139 → #140

## Linked issues

- #138 — Phase 1 Part A — Rust `validate_backrun` revm sim + gRPC publish
- #139 — Phase 1 Part B — Go executor mempool bundle builder + fan-out
- #140 — Phase 1 Part C — risk gates + shadow rollout + live validation
