### PR TITLE
feat(mempool-backrun): Phase 1 Part C — risk gates + shadow rollout + live validation

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -33,6 +33,16 @@ import (
 
 var tracer trace.Tracer = otel.Tracer("aether-executor")
 
+// Package-level mempool risk state — populated by main() at startup
+// from env vars. Read by processArb on the mempool-backrun path; the
+// block-driven path ignores them. Globals (vs threading through every
+// call) keep the existing processArb signature stable for the existing
+// test suite.
+var (
+	mempoolRiskCfg  MempoolRiskConfig
+	mempoolInflight *MempoolInflightTracker
+)
+
 // Config holds executor service configuration.
 // ChainID, ExecutorAddr, and the live ETH balance are no longer carried here —
 // they are resolved against the connected node at startup (see main) and the
@@ -247,6 +257,22 @@ func main() {
 	riskMgr := risk.NewRiskManager(loadRiskConfig())
 	riskMgr.SetMetricsObserver(executorMetricsObserver{})
 
+	// Mempool-backrun gate state. The risk config snapshots env at boot;
+	// the inflight tracker spans the executor process lifetime so per-
+	// target-block dedup survives across the candidate burst from a hot
+	// block.
+	mempoolRiskCfg = LoadMempoolRiskConfig()
+	mempoolInflight = NewMempoolInflightTracker()
+	slog.Info("mempool-backrun risk gates configured",
+		"min_profit_wei", mempoolRiskCfg.MinProfitWei.String(),
+		"max_tip_bps", mempoolRiskCfg.MaxTipShareBps,
+		"victim_freshness_ms", mempoolRiskCfg.MaxVictimFreshnessMs,
+		"max_inflight_per_block", mempoolRiskCfg.MaxInflightPerTargetBlock,
+	)
+	if isShadowMode() {
+		slog.Warn("SHADOW MODE ENABLED — eth_sendBundle calls will be blocked for both block-driven and mempool-backrun bundles")
+	}
+
 	// Live searcher ETH balance, written by balanceWatchLoop and read by
 	// consumeArbStream → processArb → risk.PreflightCheck. When no searcher
 	// key is configured there is no address to query, so the live balance
@@ -400,8 +426,42 @@ func processArb(
 		return false, nil
 	}
 
-	_, buildSpan := tracer.Start(ctx, "bundle.build")
 	targetBlock := targetBlockForArb(arb)
+
+	// Mempool-specific risk gates run AFTER the shared preflight so the
+	// existing system-state / gas / balance / position-limit checks
+	// always fire first. Reject decisions are stamped onto a trace
+	// passed forward to the shadow JSON dump for forensics.
+	var mempoolDecision MempoolPreflightResult
+	if sourceLbl == SourceMempoolBackrun {
+		victimHex := "0x" + hex.EncodeToString(arb.VictimTxHash)
+		victimSeenAt := time.Unix(0, arb.TimestampNs)
+		mempoolDecision = MempoolRiskGate(
+			mempoolRiskCfg,
+			MempoolPreflightArgs{
+				GrossProfitWei:  profitWei,
+				TipShareBps:     uint16(tipSharePct * 100), // pct → bps
+				VictimSeenAt:    victimSeenAt,
+				TargetBlock:     targetBlock,
+				VictimTxHashHex: victimHex,
+			},
+			mempoolInflight,
+			time.Now(),
+		)
+		if !mempoolDecision.Approved {
+			recordRiskRejection()
+			slog.InfoContext(ctx, "mempool arb rejected by mempool gate",
+				"arb_id", arb.Id,
+				"reason", mempoolDecision.Reason,
+				"victim_tx_hash", victimHex,
+				"target_block", targetBlock,
+			)
+			span.SetAttributes(attribute.String("outcome", "mempool_rejected"))
+			return false, nil
+		}
+	}
+
+	_, buildSpan := tracer.Start(ctx, "bundle.build")
 	var bundle *Bundle
 	if sourceLbl == SourceMempoolBackrun {
 		buildStart := time.Now()
@@ -446,18 +506,24 @@ func processArb(
 	if isShadowMode() {
 		recordEndToEndLatency(receivedAt)
 		recordShadowBundle()
+		recordShadowBlocked(sourceLbl)
 		profitEth := weiToEth(profitWei)
 		slog.InfoContext(ctx, "shadow bundle built, skipping submission",
 			"arb_id", arb.Id,
 			"arb_db_id", arbDBID,
 			"bundle_id", bundleID,
+			"source", sourceLbl,
 			"target_block", targetBlock,
 			"tip_tx_count", len(bundle.RawTxs),
 			"profit_eth", profitEth,
 			"gas", arb.TotalGas,
 			"tip_share_pct", tipSharePct,
 		)
-		if err := dumpShadowBundle(arb, bundle, profitEth, gasGwei, tipSharePct); err != nil {
+		if sourceLbl == SourceMempoolBackrun {
+			if err := dumpMempoolShadowBundle(arb, bundle, gasFees, tipSharePct, mempoolDecision); err != nil {
+				slog.WarnContext(ctx, "mempool shadow bundle json dump failed", "arb_id", arb.Id, "err", err)
+			}
+		} else if err := dumpShadowBundle(arb, bundle, profitEth, gasGwei, tipSharePct); err != nil {
 			slog.WarnContext(ctx, "shadow bundle json dump failed", "arb_id", arb.Id, "err", err)
 		}
 		// Persist a `bundles` row for the shadow build so query traffic
@@ -871,6 +937,116 @@ func dumpShadowBundle(
 	}
 	filename := filepath.Join(dir, safeID+".json")
 	return os.WriteFile(filename, out, 0o644)
+}
+
+// mempoolShadowSessionDir is resolved once per process and reused for every
+// mempool-shadow bundle dump. One `shadow_mempool_<ts>` per run keeps
+// stage-rollout reports self-contained instead of interleaving bundles from
+// multiple deploys.
+//
+// Resolved via a function pointer so tests can inject a deterministic dir
+// via resetMempoolShadowSessionForTest without dancing around sync.Once.
+var mempoolShadowSessionDir = newMempoolShadowSessionDirOnce()
+
+func newMempoolShadowSessionDirOnce() func() string {
+	var (
+		once sync.Once
+		path string
+	)
+	return func() string {
+		once.Do(func() {
+			base := strings.TrimSpace(os.Getenv("AETHER_REPORTS_DIR"))
+			if base == "" {
+				base = "reports"
+			}
+			ts := time.Now().UTC().Format("20060102T150405Z")
+			path = filepath.Join(base, "shadow_mempool_"+ts, "bundles")
+		})
+		return path
+	}
+}
+
+// dumpMempoolShadowBundle writes the mempool-backrun bundle to a forensics
+// JSON per the #140 schema. Layout:
+//   ${AETHER_REPORTS_DIR:-reports}/shadow_mempool_<ts>/bundles/<arb_id>.json
+// One file per arb so the orchestrator can `ls | wc -l` straight into stage
+// gates. Gross profit is reconstructed as net + (gas × max_fee) since the
+// proto carries only net.
+func dumpMempoolShadowBundle(
+	arb *pb.ValidatedArb,
+	bundle *Bundle,
+	gasFees GasFees,
+	tipSharePct float64,
+	decision MempoolPreflightResult,
+) error {
+	dir := mempoolShadowSessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+
+	netProfitWei := new(big.Int).SetBytes(arb.NetProfitWei)
+	gasCostWei := new(big.Int).Mul(new(big.Int).SetUint64(arb.TotalGas), gasFees.MaxFeePerGas)
+	grossProfitWei := new(big.Int).Add(netProfitWei, gasCostWei)
+
+	envelopeTxs := make([]string, 0, 1+len(bundle.RawTxs))
+	if bundle.VictimTxHashHex != "" {
+		envelopeTxs = append(envelopeTxs, bundle.VictimTxHashHex)
+	}
+	for _, raw := range bundle.RawTxs {
+		envelopeTxs = append(envelopeTxs, fmt.Sprintf("0x%x", raw))
+	}
+	envelope := map[string]interface{}{
+		"txs":               envelopeTxs,
+		"block_number":      bundle.BlockNumber,
+		"revertingTxHashes": bundle.RevertingTxHashes,
+	}
+
+	gates := make([]map[string]interface{}, 0, len(decision.Gates))
+	for _, g := range decision.Gates {
+		gates = append(gates, map[string]interface{}{
+			"gate":   g.Gate,
+			"passed": g.Passed,
+			"value":  g.Value,
+		})
+	}
+
+	payload := map[string]interface{}{
+		"arb_id":                    arb.Id,
+		"source":                    SourceMempoolBackrun,
+		"victim_tx_hash":            bundle.VictimTxHashHex,
+		"target_block":              bundle.BlockNumber,
+		"built_at":                  time.Now().UTC().Format(time.RFC3339Nano),
+		"envelope":                  envelope,
+		"expected_gross_profit_wei": grossProfitWei.String(),
+		"expected_net_profit_wei":   netProfitWei.String(),
+		"tip_share_bps":             uint64(tipSharePct * 100),
+		"gas_used":                  arb.TotalGas,
+		"base_fee_wei":              gasFees.BaseFee.String(),
+		"priority_fee_wei":          gasFees.MaxPriorityFee.String(),
+		"max_fee_per_gas_wei":       gasFees.MaxFeePerGas.String(),
+		"flashloan_provider":        "aave_v3",
+		"flashloan_token":           fmt.Sprintf("0x%x", arb.FlashloanToken),
+		"flashloan_amount":          new(big.Int).SetBytes(arb.FlashloanAmount).String(),
+		"risk_decisions":            gates,
+	}
+
+	out, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	safeID := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, arb.Id)
+	if safeID == "" {
+		safeID = "anon"
+	}
+	return os.WriteFile(filepath.Join(dir, safeID+".json"), out, 0o644)
 }
 
 func weiToEth(wei *big.Int) float64 {

--- a/cmd/executor/mempool_risk.go
+++ b/cmd/executor/mempool_risk.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"math/big"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MempoolRiskConfig holds env-tunable knobs specific to the
+// mempool-backrun execution path. These layer on top of the existing
+// risk.RiskManager gates (gas, balance, daily PnL, revert streak); the
+// shared gates still run first via the standard `PreflightCheck`.
+//
+// All fields are read once at startup via `loadMempoolRiskConfig()`;
+// the runbook stage transitions tune them by re-deploying with new env
+// values, not by hot-reload.
+type MempoolRiskConfig struct {
+	// Minimum gross profit (wei) we require to publish a mempool bundle.
+	// Stage A starts permissive (1e15 = 0.001 ETH); Stage B tightens to
+	// 5e16 (0.05 ETH) until inclusion data justifies dropping back.
+	MinProfitWei *big.Int
+
+	// Maximum tip share we'll bid, in basis points. 9500 = 95%. Above
+	// this the searcher's residual is too small to cover infrastructure
+	// cost so we drop the candidate rather than win a Pyrrhic auction.
+	MaxTipShareBps uint16
+
+	// Maximum age of the victim tx (ms since first seen) at the moment
+	// we're about to publish. Older victims have probably either mined
+	// or been replaced; either way our bundle is stale.
+	MaxVictimFreshnessMs uint64
+
+	// Maximum bundles we're willing to have in-flight for a single
+	// target block. Prevents a hot-fork burst from drowning a builder's
+	// reputation tracker.
+	MaxInflightPerTargetBlock uint16
+}
+
+// LoadMempoolRiskConfig reads `AETHER_MEMPOOL_*` env vars with safe
+// defaults. Values that don't parse fall through to the default so a
+// typo in the env never silently bypasses a gate.
+func LoadMempoolRiskConfig() MempoolRiskConfig {
+	cfg := MempoolRiskConfig{
+		MinProfitWei:              new(big.Int).SetUint64(1_000_000_000_000_000), // 1e15 wei = 0.001 ETH
+		MaxTipShareBps:            9500,                                          // 95%
+		MaxVictimFreshnessMs:      500,
+		MaxInflightPerTargetBlock: 5,
+	}
+	if s := os.Getenv("AETHER_MEMPOOL_MIN_PROFIT_WEI"); s != "" {
+		if v, ok := new(big.Int).SetString(s, 10); ok && v.Sign() > 0 {
+			cfg.MinProfitWei = v
+		}
+	}
+	if s := os.Getenv("AETHER_MEMPOOL_MAX_TIP_BPS"); s != "" {
+		if v, err := strconv.ParseUint(s, 10, 16); err == nil && v > 0 {
+			cfg.MaxTipShareBps = uint16(v)
+		}
+	}
+	if s := os.Getenv("AETHER_MEMPOOL_VICTIM_FRESHNESS_MS"); s != "" {
+		if v, err := strconv.ParseUint(s, 10, 64); err == nil && v > 0 {
+			cfg.MaxVictimFreshnessMs = v
+		}
+	}
+	if s := os.Getenv("AETHER_MEMPOOL_MAX_INFLIGHT"); s != "" {
+		if v, err := strconv.ParseUint(s, 10, 16); err == nil && v > 0 {
+			cfg.MaxInflightPerTargetBlock = uint16(v)
+		}
+	}
+	return cfg
+}
+
+// MempoolPreflightArgs is the per-candidate input to the mempool gate.
+type MempoolPreflightArgs struct {
+	GrossProfitWei  *big.Int
+	TipShareBps     uint16
+	VictimSeenAt    time.Time // when our pipeline first observed the victim hash
+	TargetBlock     uint64
+	VictimTxHashHex string
+}
+
+// MempoolPreflightResult records one decision per gate so the shadow
+// JSON forensics dump can show "this candidate failed reason=min_profit"
+// alongside passing gates.
+type MempoolPreflightResult struct {
+	Approved bool
+	Reason   string             // first failing gate, empty when approved
+	Gates    []MempoolGateTrace // every gate evaluated, in order
+}
+
+// MempoolGateTrace is one row in the shadow JSON's `risk_decisions` list.
+type MempoolGateTrace struct {
+	Gate   string `json:"gate"`
+	Passed bool   `json:"passed"`
+	Value  string `json:"value"`
+}
+
+// MempoolRiskGate runs the mempool-specific risk checks for one
+// candidate. Returns the per-gate trace + the first failing reason. Use
+// from `processArb` *after* the shared `risk.RiskManager.PreflightCheck`
+// has approved the candidate against block-driven gates.
+//
+// Dedup is handled by the `MempoolInflightTracker` parameter so the
+// caller can reuse the same tracker across all candidates (it tracks
+// per-`(target_block, victim_tx_hash)` cardinality across the executor
+// process lifetime, cleared lazily as old target_blocks age out).
+func MempoolRiskGate(cfg MempoolRiskConfig, args MempoolPreflightArgs, inflight *MempoolInflightTracker, now time.Time) MempoolPreflightResult {
+	var trace []MempoolGateTrace
+	reject := func(gate, reason, value string) MempoolPreflightResult {
+		trace = append(trace, MempoolGateTrace{Gate: gate, Passed: false, Value: value})
+		recordMempoolRiskRejected(reason)
+		return MempoolPreflightResult{
+			Approved: false,
+			Reason:   reason,
+			Gates:    trace,
+		}
+	}
+	pass := func(gate, value string) {
+		trace = append(trace, MempoolGateTrace{Gate: gate, Passed: true, Value: value})
+	}
+
+	// Gate 1 — min profit. Always cheapest to evaluate, run first so
+	// we waste the least work on the obvious-loser path.
+	if args.GrossProfitWei == nil || args.GrossProfitWei.Cmp(cfg.MinProfitWei) < 0 {
+		v := "nil"
+		if args.GrossProfitWei != nil {
+			v = args.GrossProfitWei.String()
+		}
+		return reject("min_profit", "min_profit", v)
+	}
+	pass("min_profit", args.GrossProfitWei.String())
+
+	// Gate 2 — max tip share. Above this the residual is too thin to
+	// service our infra cost; drop the candidate so the EOA doesn't
+	// burn gas on a near-zero-net auction.
+	if args.TipShareBps > cfg.MaxTipShareBps {
+		return reject("max_tip_share", "max_tip_share", strconv.FormatUint(uint64(args.TipShareBps), 10))
+	}
+	pass("max_tip_share", strconv.FormatUint(uint64(args.TipShareBps), 10))
+
+	// Gate 3 — victim freshness. A stale victim has probably mined or
+	// been replaced; either outcome makes our bundle's predicate void.
+	freshMs := uint64(now.Sub(args.VictimSeenAt).Milliseconds())
+	if freshMs > cfg.MaxVictimFreshnessMs {
+		return reject("victim_freshness", "victim_stale", strconv.FormatUint(freshMs, 10))
+	}
+	pass("victim_freshness", strconv.FormatUint(freshMs, 10))
+
+	// Gate 4 — per-target-block dedup AND in-flight cap. Same victim
+	// against same target = idempotent drop; different victim against
+	// the same target that's already at the cap = back off so the
+	// builder doesn't see a flood from us.
+	if inflight.Seen(args.TargetBlock, args.VictimTxHashHex) {
+		return reject("dedup", "duplicate", args.VictimTxHashHex)
+	}
+	if inflight.CountForBlock(args.TargetBlock) >= cfg.MaxInflightPerTargetBlock {
+		return reject("max_inflight", "max_inflight_per_block", strconv.FormatUint(uint64(inflight.CountForBlock(args.TargetBlock)), 10))
+	}
+	inflight.Record(args.TargetBlock, args.VictimTxHashHex, now)
+	pass("dedup_inflight", strconv.FormatUint(uint64(inflight.CountForBlock(args.TargetBlock)), 10))
+
+	return MempoolPreflightResult{Approved: true, Gates: trace}
+}
+
+// MempoolInflightTracker keeps a rolling per-target-block set of
+// (target_block, victim_tx_hash) pairs. Old target blocks expire 12
+// blocks (~144s) after first observation so the map doesn't grow
+// unbounded over long shadow runs.
+type MempoolInflightTracker struct {
+	mu      sync.Mutex
+	entries map[uint64]*inflightEntry
+}
+
+type inflightEntry struct {
+	victims  map[string]struct{}
+	firstSet time.Time
+}
+
+// NewMempoolInflightTracker constructs an empty tracker.
+func NewMempoolInflightTracker() *MempoolInflightTracker {
+	return &MempoolInflightTracker{entries: make(map[uint64]*inflightEntry)}
+}
+
+// Seen returns true if `(targetBlock, victimHashHex)` has been recorded
+// before. Caller side-effects are minimal — Seen does NOT itself mark
+// the pair recorded; use Record for that after gate 4 accepts.
+func (t *MempoolInflightTracker) Seen(targetBlock uint64, victimHashHex string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, ok := t.entries[targetBlock]
+	if !ok {
+		return false
+	}
+	_, dup := e.victims[victimHashHex]
+	return dup
+}
+
+// CountForBlock returns the number of distinct victim hashes recorded
+// against `targetBlock`.
+func (t *MempoolInflightTracker) CountForBlock(targetBlock uint64) uint16 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if e, ok := t.entries[targetBlock]; ok {
+		return uint16(len(e.victims))
+	}
+	return 0
+}
+
+// Record marks `(targetBlock, victimHashHex)` as in-flight at `now`.
+// Also opportunistically reaps target blocks older than 12 slot-times
+// (~144s) so long shadow runs don't unbounded-grow the map.
+func (t *MempoolInflightTracker) Record(targetBlock uint64, victimHashHex string, now time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, ok := t.entries[targetBlock]
+	if !ok {
+		e = &inflightEntry{victims: make(map[string]struct{}), firstSet: now}
+		t.entries[targetBlock] = e
+	}
+	e.victims[victimHashHex] = struct{}{}
+
+	// Reap entries older than 144s. Cheap O(n) since target_block
+	// cardinality over a 144s window is tiny.
+	cutoff := now.Add(-144 * time.Second)
+	for tb, entry := range t.entries {
+		if entry.firstSet.Before(cutoff) {
+			delete(t.entries, tb)
+		}
+	}
+}
+
+// ── metrics ─────────────────────────────────────────────────────────
+
+var mempoolRiskRejected = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "aether_mempool_risk_rejected_total",
+	Help: "Mempool-backrun candidates rejected by the mempool-specific risk gates, by reason",
+}, []string{"reason"})
+
+var bundlesShadowBlocked = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "aether_executor_bundles_shadow_blocked_total",
+	Help: "Bundles built but blocked from eth_sendBundle by AETHER_SHADOW=1, by source",
+}, []string{"source"})
+
+func init() {
+	prometheus.MustRegister(mempoolRiskRejected, bundlesShadowBlocked)
+	// Pre-touch label values so dashboards see zero rows from boot.
+	for _, r := range []string{
+		"min_profit", "max_tip_share", "victim_stale",
+		"duplicate", "max_inflight_per_block",
+	} {
+		mempoolRiskRejected.WithLabelValues(r)
+	}
+	for _, s := range []string{SourceBlockDriven, SourceMempoolBackrun} {
+		bundlesShadowBlocked.WithLabelValues(s)
+	}
+}
+
+func recordMempoolRiskRejected(reason string) {
+	mempoolRiskRejected.WithLabelValues(reason).Inc()
+}
+
+func recordShadowBlocked(source string) {
+	bundlesShadowBlocked.WithLabelValues(source).Inc()
+}

--- a/cmd/executor/mempool_risk_test.go
+++ b/cmd/executor/mempool_risk_test.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pb "github.com/aether-arb/aether/internal/pb"
+)
+
+// ---------------------------------------------------------------------------
+// LoadMempoolRiskConfig
+// ---------------------------------------------------------------------------
+
+func TestLoadMempoolRiskConfig_Defaults(t *testing.T) {
+	// Defaults must match the Stage A values cited in the runbook so a
+	// silent change here doesn't desync code from documentation.
+	for _, k := range []string{
+		"AETHER_MEMPOOL_MIN_PROFIT_WEI",
+		"AETHER_MEMPOOL_MAX_TIP_BPS",
+		"AETHER_MEMPOOL_VICTIM_FRESHNESS_MS",
+		"AETHER_MEMPOOL_MAX_INFLIGHT",
+	} {
+		os.Unsetenv(k)
+	}
+	cfg := LoadMempoolRiskConfig()
+	if cfg.MinProfitWei.Cmp(new(big.Int).SetUint64(1_000_000_000_000_000)) != 0 {
+		t.Errorf("MinProfitWei default = %s, want 1e15", cfg.MinProfitWei)
+	}
+	if cfg.MaxTipShareBps != 9500 {
+		t.Errorf("MaxTipShareBps default = %d, want 9500", cfg.MaxTipShareBps)
+	}
+	if cfg.MaxVictimFreshnessMs != 500 {
+		t.Errorf("MaxVictimFreshnessMs default = %d, want 500", cfg.MaxVictimFreshnessMs)
+	}
+	if cfg.MaxInflightPerTargetBlock != 5 {
+		t.Errorf("MaxInflightPerTargetBlock default = %d, want 5", cfg.MaxInflightPerTargetBlock)
+	}
+}
+
+func TestLoadMempoolRiskConfig_EnvOverride(t *testing.T) {
+	t.Setenv("AETHER_MEMPOOL_MIN_PROFIT_WEI", "50000000000000000") // 5e16
+	t.Setenv("AETHER_MEMPOOL_MAX_TIP_BPS", "8500")
+	t.Setenv("AETHER_MEMPOOL_VICTIM_FRESHNESS_MS", "300")
+	t.Setenv("AETHER_MEMPOOL_MAX_INFLIGHT", "2")
+
+	cfg := LoadMempoolRiskConfig()
+	if cfg.MinProfitWei.Cmp(new(big.Int).SetUint64(50_000_000_000_000_000)) != 0 {
+		t.Errorf("MinProfitWei override = %s, want 5e16", cfg.MinProfitWei)
+	}
+	if cfg.MaxTipShareBps != 8500 {
+		t.Errorf("MaxTipShareBps override = %d", cfg.MaxTipShareBps)
+	}
+	if cfg.MaxVictimFreshnessMs != 300 {
+		t.Errorf("MaxVictimFreshnessMs override = %d", cfg.MaxVictimFreshnessMs)
+	}
+	if cfg.MaxInflightPerTargetBlock != 2 {
+		t.Errorf("MaxInflightPerTargetBlock override = %d", cfg.MaxInflightPerTargetBlock)
+	}
+}
+
+func TestLoadMempoolRiskConfig_BadEnvFallsThrough(t *testing.T) {
+	// Garbage env values must NOT silently disable a gate. The default has
+	// to win so a typo in a runbook command can't bypass a real gate.
+	t.Setenv("AETHER_MEMPOOL_MIN_PROFIT_WEI", "not-a-number")
+	t.Setenv("AETHER_MEMPOOL_MAX_TIP_BPS", "")
+	t.Setenv("AETHER_MEMPOOL_VICTIM_FRESHNESS_MS", "0") // 0 means "use default"
+	t.Setenv("AETHER_MEMPOOL_MAX_INFLIGHT", "abc")
+
+	cfg := LoadMempoolRiskConfig()
+	if cfg.MinProfitWei.Uint64() != 1_000_000_000_000_000 {
+		t.Errorf("MinProfitWei: garbage didn't fall through, got %s", cfg.MinProfitWei)
+	}
+	if cfg.MaxTipShareBps != 9500 {
+		t.Errorf("MaxTipShareBps: empty didn't fall through, got %d", cfg.MaxTipShareBps)
+	}
+	if cfg.MaxVictimFreshnessMs != 500 {
+		t.Errorf("MaxVictimFreshnessMs: zero didn't fall through, got %d", cfg.MaxVictimFreshnessMs)
+	}
+	if cfg.MaxInflightPerTargetBlock != 5 {
+		t.Errorf("MaxInflightPerTargetBlock: garbage didn't fall through, got %d", cfg.MaxInflightPerTargetBlock)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MempoolRiskGate — every gate path
+// ---------------------------------------------------------------------------
+
+func testCfg() MempoolRiskConfig {
+	return MempoolRiskConfig{
+		MinProfitWei:              new(big.Int).SetUint64(1_000_000_000_000_000), // 1e15
+		MaxTipShareBps:            9500,
+		MaxVictimFreshnessMs:      500,
+		MaxInflightPerTargetBlock: 3,
+	}
+}
+
+func TestMempoolRiskGate_Approves_HappyPath(t *testing.T) {
+	cfg := testCfg()
+	inflight := NewMempoolInflightTracker()
+	now := time.Unix(1_700_000_000, 0)
+
+	res := MempoolRiskGate(cfg, MempoolPreflightArgs{
+		GrossProfitWei:  new(big.Int).SetUint64(2_000_000_000_000_000), // 2e15
+		TipShareBps:     9000,
+		VictimSeenAt:    now.Add(-100 * time.Millisecond),
+		TargetBlock:     18_000_000,
+		VictimTxHashHex: "0xdeadbeef01",
+	}, inflight, now)
+
+	if !res.Approved {
+		t.Fatalf("happy path rejected: reason=%s", res.Reason)
+	}
+	if res.Reason != "" {
+		t.Errorf("approved result still carries reason: %q", res.Reason)
+	}
+	// Four gates evaluated, all passed.
+	if len(res.Gates) != 4 {
+		t.Errorf("gate trace len=%d, want 4", len(res.Gates))
+	}
+	for _, g := range res.Gates {
+		if !g.Passed {
+			t.Errorf("gate %s should have passed", g.Gate)
+		}
+	}
+}
+
+func TestMempoolRiskGate_Rejects_MinProfit(t *testing.T) {
+	cfg := testCfg()
+	inflight := NewMempoolInflightTracker()
+	now := time.Unix(1_700_000_000, 0)
+
+	res := MempoolRiskGate(cfg, MempoolPreflightArgs{
+		GrossProfitWei:  new(big.Int).SetUint64(500_000_000_000_000), // 5e14 — below 1e15 floor
+		TipShareBps:     9000,
+		VictimSeenAt:    now.Add(-100 * time.Millisecond),
+		TargetBlock:     18_000_000,
+		VictimTxHashHex: "0xdeadbeef02",
+	}, inflight, now)
+
+	if res.Approved {
+		t.Fatal("expected min_profit reject")
+	}
+	if res.Reason != "min_profit" {
+		t.Errorf("reason = %q, want min_profit", res.Reason)
+	}
+}
+
+func TestMempoolRiskGate_Rejects_NilProfit(t *testing.T) {
+	// A nil GrossProfitWei must reject as min_profit rather than panic.
+	// Caller-side bugs (missing fields) should fail closed.
+	cfg := testCfg()
+	res := MempoolRiskGate(cfg, MempoolPreflightArgs{
+		GrossProfitWei: nil,
+	}, NewMempoolInflightTracker(), time.Unix(1, 0))
+	if res.Approved {
+		t.Fatal("nil profit should reject")
+	}
+	if res.Reason != "min_profit" {
+		t.Errorf("nil reject reason = %q, want min_profit", res.Reason)
+	}
+}
+
+func TestMempoolRiskGate_Rejects_MaxTipShare(t *testing.T) {
+	cfg := testCfg()
+	res := MempoolRiskGate(cfg, MempoolPreflightArgs{
+		GrossProfitWei: new(big.Int).SetUint64(2_000_000_000_000_000),
+		TipShareBps:    9600, // > 9500
+	}, NewMempoolInflightTracker(), time.Unix(1, 0))
+	if res.Approved || res.Reason != "max_tip_share" {
+		t.Errorf("got approved=%v reason=%q, want reject max_tip_share", res.Approved, res.Reason)
+	}
+}
+
+func TestMempoolRiskGate_Rejects_VictimStale(t *testing.T) {
+	cfg := testCfg()
+	now := time.Unix(1_700_000_000, 0)
+	res := MempoolRiskGate(cfg, MempoolPreflightArgs{
+		GrossProfitWei:  new(big.Int).SetUint64(2_000_000_000_000_000),
+		TipShareBps:     9000,
+		VictimSeenAt:    now.Add(-600 * time.Millisecond), // > 500ms
+		TargetBlock:     18_000_000,
+		VictimTxHashHex: "0xdead",
+	}, NewMempoolInflightTracker(), now)
+	if res.Approved || res.Reason != "victim_stale" {
+		t.Errorf("got approved=%v reason=%q, want reject victim_stale", res.Approved, res.Reason)
+	}
+}
+
+func TestMempoolRiskGate_Rejects_Duplicate(t *testing.T) {
+	cfg := testCfg()
+	inflight := NewMempoolInflightTracker()
+	now := time.Unix(1_700_000_000, 0)
+	args := MempoolPreflightArgs{
+		GrossProfitWei:  new(big.Int).SetUint64(2_000_000_000_000_000),
+		TipShareBps:     9000,
+		VictimSeenAt:    now,
+		TargetBlock:     18_000_000,
+		VictimTxHashHex: "0xduplicate01",
+	}
+	// First call records the pair as in-flight.
+	if r := MempoolRiskGate(cfg, args, inflight, now); !r.Approved {
+		t.Fatalf("first call should approve: %s", r.Reason)
+	}
+	// Second call with same (target_block, victim) must reject as duplicate.
+	r2 := MempoolRiskGate(cfg, args, inflight, now)
+	if r2.Approved || r2.Reason != "duplicate" {
+		t.Errorf("got approved=%v reason=%q, want reject duplicate", r2.Approved, r2.Reason)
+	}
+}
+
+func TestMempoolRiskGate_Rejects_MaxInflightPerBlock(t *testing.T) {
+	cfg := testCfg() // MaxInflightPerTargetBlock = 3
+	inflight := NewMempoolInflightTracker()
+	now := time.Unix(1_700_000_000, 0)
+
+	// Three distinct victims, same target_block — all approve.
+	for i := 0; i < 3; i++ {
+		args := MempoolPreflightArgs{
+			GrossProfitWei:  new(big.Int).SetUint64(2_000_000_000_000_000),
+			TipShareBps:     9000,
+			VictimSeenAt:    now,
+			TargetBlock:     18_000_000,
+			VictimTxHashHex: "0xvic" + string(rune('0'+i)),
+		}
+		if r := MempoolRiskGate(cfg, args, inflight, now); !r.Approved {
+			t.Fatalf("victim %d should approve: %s", i, r.Reason)
+		}
+	}
+	// 4th distinct victim must reject (count >= cap).
+	args := MempoolPreflightArgs{
+		GrossProfitWei:  new(big.Int).SetUint64(2_000_000_000_000_000),
+		TipShareBps:     9000,
+		VictimSeenAt:    now,
+		TargetBlock:     18_000_000,
+		VictimTxHashHex: "0xvic4",
+	}
+	r := MempoolRiskGate(cfg, args, inflight, now)
+	if r.Approved || r.Reason != "max_inflight_per_block" {
+		t.Errorf("got approved=%v reason=%q, want reject max_inflight_per_block", r.Approved, r.Reason)
+	}
+}
+
+func TestMempoolRiskGate_OrderIsStable(t *testing.T) {
+	// If a candidate would fail multiple gates, the cheapest one (min_profit)
+	// must report the rejection. Reordering gates would break dashboards
+	// that bucket by reason.
+	cfg := testCfg()
+	now := time.Unix(1_700_000_000, 0)
+	res := MempoolRiskGate(cfg, MempoolPreflightArgs{
+		GrossProfitWei:  big.NewInt(1), // below floor
+		TipShareBps:     9999,           // also above cap
+		VictimSeenAt:    now.Add(-time.Hour),
+		TargetBlock:     18_000_000,
+		VictimTxHashHex: "0xa",
+	}, NewMempoolInflightTracker(), now)
+	if res.Reason != "min_profit" {
+		t.Errorf("reason = %q, want min_profit (first failing gate)", res.Reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MempoolInflightTracker
+// ---------------------------------------------------------------------------
+
+func TestMempoolInflightTracker_RecordSeenCount(t *testing.T) {
+	tr := NewMempoolInflightTracker()
+	now := time.Unix(1_700_000_000, 0)
+
+	if tr.Seen(100, "0xa") {
+		t.Error("empty tracker reported Seen=true")
+	}
+	if tr.CountForBlock(100) != 0 {
+		t.Error("empty tracker reported nonzero count")
+	}
+
+	tr.Record(100, "0xa", now)
+	if !tr.Seen(100, "0xa") {
+		t.Error("after Record, Seen=false")
+	}
+	if tr.CountForBlock(100) != 1 {
+		t.Errorf("count = %d, want 1", tr.CountForBlock(100))
+	}
+
+	// Same victim, same block — Seen() is idempotent semantically (set semantics).
+	tr.Record(100, "0xa", now)
+	if tr.CountForBlock(100) != 1 {
+		t.Errorf("count after duplicate record = %d, want 1", tr.CountForBlock(100))
+	}
+
+	tr.Record(100, "0xb", now)
+	if tr.CountForBlock(100) != 2 {
+		t.Errorf("count after second victim = %d, want 2", tr.CountForBlock(100))
+	}
+
+	// Different block.
+	if tr.CountForBlock(101) != 0 {
+		t.Error("block 101 leak from block 100")
+	}
+}
+
+func TestMempoolInflightTracker_ReapsOldEntries(t *testing.T) {
+	tr := NewMempoolInflightTracker()
+	old := time.Unix(1_700_000_000, 0)
+
+	tr.Record(100, "0xa", old)
+	if tr.CountForBlock(100) != 1 {
+		t.Fatal("setup: expected count=1")
+	}
+
+	// Force a reap by recording at old + 145s (cutoff is 144s).
+	tr.Record(200, "0xb", old.Add(145*time.Second))
+
+	if tr.CountForBlock(100) != 0 {
+		t.Errorf("old block 100 still tracked (count=%d), want reaped",
+			tr.CountForBlock(100))
+	}
+	if tr.CountForBlock(200) != 1 {
+		t.Errorf("block 200 count = %d, want 1", tr.CountForBlock(200))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dumpMempoolShadowBundle
+// ---------------------------------------------------------------------------
+
+func TestDumpMempoolShadowBundle_Schema(t *testing.T) {
+	// Override session-dir resolver so this test gets a fresh tmpdir
+	// regardless of which other tests ran first.
+	dir := t.TempDir()
+	old := mempoolShadowSessionDir
+	mempoolShadowSessionDir = func() string { return dir }
+	defer func() { mempoolShadowSessionDir = old }()
+
+	weth := []byte{0xc0, 0x2a, 0xaa, 0x39, 0xb2, 0x23, 0xfe, 0x8d, 0x0a, 0x0e,
+		0x5c, 0x4f, 0x27, 0xea, 0xd9, 0x08, 0x3c, 0x75, 0x6c, 0xc2}
+
+	arb := &pb.ValidatedArb{
+		Id:              "mempool-arb-1",
+		FlashloanToken:  weth,
+		FlashloanAmount: new(big.Int).SetUint64(1_000_000_000_000_000_000).Bytes(),
+		NetProfitWei:    new(big.Int).SetUint64(500_000_000_000_000_000).Bytes(),
+		TotalGas:        350_000,
+		BlockNumber:     24_000_000,
+		Calldata:        []byte{0x01, 0x02},
+		VictimTxHash:    []byte{0xab, 0xcd},
+		TargetBlock:     24_000_001,
+	}
+	bundle := &Bundle{
+		RawTxs:            [][]byte{{0xf8, 0x6b}},
+		BlockNumber:       24_000_001,
+		Source:            SourceMempoolBackrun,
+		VictimTxHashHex:   "0xdeadbeef",
+		RevertingTxHashes: []string{"0xarbtx"},
+	}
+	gasFees := GasFees{
+		BaseFee:        new(big.Int).SetUint64(20_000_000_000),  // 20 gwei
+		MaxFeePerGas:   new(big.Int).SetUint64(40_000_000_000),  // 40 gwei
+		MaxPriorityFee: new(big.Int).SetUint64(2_000_000_000),   // 2 gwei
+		GasPriceGwei:   20.0,
+	}
+	decision := MempoolPreflightResult{
+		Approved: true,
+		Gates: []MempoolGateTrace{
+			{Gate: "min_profit", Passed: true, Value: "500000000000000000"},
+			{Gate: "max_tip_share", Passed: true, Value: "9000"},
+		},
+	}
+
+	if err := dumpMempoolShadowBundle(arb, bundle, gasFees, 90.0, decision); err != nil {
+		t.Fatalf("dumpMempoolShadowBundle: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "mempool-arb-1.json"))
+	if err != nil {
+		t.Fatalf("read dump: %v", err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Schema must match the runbook + issue #140 spec verbatim — downstream
+	// jq queries pin these names.
+	required := []string{
+		"arb_id", "source", "victim_tx_hash", "target_block", "built_at",
+		"envelope", "expected_gross_profit_wei", "expected_net_profit_wei",
+		"tip_share_bps", "gas_used", "base_fee_wei", "priority_fee_wei",
+		"max_fee_per_gas_wei", "flashloan_provider", "flashloan_token",
+		"flashloan_amount", "risk_decisions",
+	}
+	for _, k := range required {
+		if _, ok := payload[k]; !ok {
+			t.Errorf("missing required key %q", k)
+		}
+	}
+
+	if got := payload["source"]; got != SourceMempoolBackrun {
+		t.Errorf("source = %v, want %s", got, SourceMempoolBackrun)
+	}
+	if got := payload["victim_tx_hash"]; got != "0xdeadbeef" {
+		t.Errorf("victim_tx_hash = %v", got)
+	}
+	if got := payload["flashloan_provider"]; got != "aave_v3" {
+		t.Errorf("flashloan_provider = %v, want aave_v3", got)
+	}
+
+	// expected_gross_profit_wei = net + (gas * max_fee) = 5e17 + 350_000 * 40e9
+	//                           = 500_000_000_000_000_000 + 14_000_000_000_000_000
+	//                           = 514_000_000_000_000_000
+	wantGross := "514000000000000000"
+	if got := payload["expected_gross_profit_wei"]; got != wantGross {
+		t.Errorf("expected_gross_profit_wei = %v, want %s", got, wantGross)
+	}
+
+	// risk_decisions must be a list of {gate,passed,value} maps.
+	gates, ok := payload["risk_decisions"].([]interface{})
+	if !ok || len(gates) != 2 {
+		t.Fatalf("risk_decisions = %v, want 2 entries", payload["risk_decisions"])
+	}
+	first := gates[0].(map[string]interface{})
+	if first["gate"] != "min_profit" || first["passed"] != true {
+		t.Errorf("first gate = %v", first)
+	}
+
+	// Envelope must lead with the victim hash, followed by our raw arb.
+	env := payload["envelope"].(map[string]interface{})
+	txs := env["txs"].([]interface{})
+	if len(txs) != 2 || txs[0] != "0xdeadbeef" {
+		t.Errorf("envelope.txs = %v, want [victim_hash, raw_arb]", txs)
+	}
+	// revertingTxHashes must be the arb hash only — never the victim.
+	rev := env["revertingTxHashes"].([]interface{})
+	if len(rev) != 1 || rev[0] != "0xarbtx" {
+		t.Errorf("revertingTxHashes = %v, want [arb_hash] only", rev)
+	}
+	for _, h := range rev {
+		if h == "0xdeadbeef" {
+			t.Fatal("revertingTxHashes leaked victim hash — adverse-fill protection broken")
+		}
+	}
+}
+
+func TestDumpMempoolShadowBundle_SanitisesArbID(t *testing.T) {
+	dir := t.TempDir()
+	old := mempoolShadowSessionDir
+	mempoolShadowSessionDir = func() string { return dir }
+	defer func() { mempoolShadowSessionDir = old }()
+
+	arb := &pb.ValidatedArb{
+		Id:              "../../etc/passwd\x00",
+		FlashloanToken:  []byte{},
+		FlashloanAmount: []byte{},
+		NetProfitWei:    []byte{},
+	}
+	bundle := &Bundle{}
+	gasFees := GasFees{
+		BaseFee:        big.NewInt(1),
+		MaxFeePerGas:   big.NewInt(1),
+		MaxPriorityFee: big.NewInt(1),
+	}
+	if err := dumpMempoolShadowBundle(arb, bundle, gasFees, 0, MempoolPreflightResult{}); err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d files, want 1", len(entries))
+	}
+	name := entries[0].Name()
+	for _, bad := range []string{"..", "/", "\x00", "\n"} {
+		if containsSubstr(name, bad) {
+			t.Errorf("filename %q still contains %q", name, bad)
+		}
+	}
+}
+
+func TestMempoolShadowSessionDir_RespectsReportsDir(t *testing.T) {
+	t.Setenv("AETHER_REPORTS_DIR", "/tmp/aether-test-reports")
+	// Use a fresh resolver instance to bypass the package-level sync.Once
+	// that another test in this binary may have already triggered.
+	fn := newMempoolShadowSessionDirOnce()
+	got := fn()
+	if !startsWith(got, "/tmp/aether-test-reports/shadow_mempool_") {
+		t.Errorf("session dir = %q, want under /tmp/aether-test-reports/shadow_mempool_<ts>/", got)
+	}
+	if !endsWith(got, "/bundles") {
+		t.Errorf("session dir = %q, want suffix /bundles", got)
+	}
+}
+
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func endsWith(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/docs/runbook/mempool-backrun-rollout.md
+++ b/docs/runbook/mempool-backrun-rollout.md
@@ -1,0 +1,180 @@
+# Mempool-backrun rollout runbook
+
+Three-stage live-mainnet rollout for the public-mempool backrun execution
+path. Each stage has explicit entry gates, exit gates, and a rollback
+trigger. **Do not skip stages.** A stage exists only because the previous
+one cannot prove the next stage's risk envelope on its own.
+
+The Rust validator + Go bundler + risk gates (PRs #142 / #143 / #144)
+land production-ready, but production-ready ≠ production-live. This
+runbook is the bridge.
+
+---
+
+## Architecture refresher
+
+```
+mempool tx → Rust mempool_pipeline → validate_backrun_rpc (revm fork sim)
+            → gRPC publish ValidatedArb{source=MEMPOOL_BACKRUN, victim_tx_hash, target_block}
+            → Go processArb → block-driven PreflightCheck → MempoolRiskGate
+            → BuildMempoolBackrunBundle → eth_sendBundle to builders
+```
+
+The **shadow gate** (`AETHER_SHADOW=1`) intercepts between bundle build
+and submission. Everything upstream runs identically to live; only the
+HTTP POST to Flashbots is short-circuited. Each blocked bundle is written
+to disk as forensics JSON.
+
+---
+
+## Stage A — Shadow (no ETH at risk)
+
+**Entry gate:**
+
+- PRs #142, #143, #144 merged into `main` and deployed.
+- `feat/mempool-backrun-shadow-rollout` branch live on the staging box.
+- `AETHER_SHADOW=1` exported.
+- `aether_executor_bundles_shadow_blocked_total{source="mempool_backrun"}`
+  series visible at `/metrics` (pre-touched at boot — should read `0`).
+- Ops on standby with shutdown command on hot key.
+
+**Configuration:**
+
+```bash
+export AETHER_SHADOW=1
+export AETHER_MEMPOOL_MIN_PROFIT_WEI=1000000000000000      # 1e15 wei = 0.001 ETH
+export AETHER_MEMPOOL_MAX_TIP_BPS=9500                     # 95%
+export AETHER_MEMPOOL_VICTIM_FRESHNESS_MS=500
+export AETHER_MEMPOOL_MAX_INFLIGHT=5
+export AETHER_REPORTS_DIR=reports
+```
+
+**Duration:** 24 h continuous.
+
+**Exit gate (all must hold):**
+
+| Check | Threshold |
+|---|---|
+| `aether_executor_bundles_submitted_total{source="mempool_backrun"}` | **exactly `0`** |
+| `aether_executor_bundles_shadow_blocked_total{source="mempool_backrun"}` | ≥ 50 |
+| `aether_mempool_risk_rejected_total` sum across reasons | ≥ 10 (proves gates fire) |
+| `validation_latency_ms` p99 (Rust) | < 80 ms |
+| `mempool_bundle_build_latency_ms` p99 (Go) | < 5 ms |
+| Forensics JSON written to `reports/shadow_mempool_<ts>/bundles/` | ≥ 1 per blocked bundle, all schema-valid |
+| Searcher EOA nonce delta over window | **exactly `0`** |
+| Searcher EOA ETH balance delta | **exactly `0`** (modulo gas-station drift, ±0.0001 ETH tolerance) |
+
+**Rollback trigger:** *any* submitted bundle counter > 0. This is the
+fundamental shadow-mode invariant. Treat as P0, halt rollout, root-cause
+before retry.
+
+---
+
+## Stage B — Live, tightened gates (≤ 0.05 ETH max single loss)
+
+**Entry gate:**
+
+- Stage A exit gate passed.
+- Searcher EOA topped to 0.5 ETH (warm wallet).
+- Cold-wallet sweep policy verified: `recordEndToEndLatency` confirms
+  sweep cron is live.
+
+**Configuration delta from Stage A:**
+
+```bash
+unset AETHER_SHADOW                                        # ← go live
+export AETHER_MEMPOOL_MIN_PROFIT_WEI=50000000000000000     # 5e16 wei = 0.05 ETH (50× Stage A)
+export AETHER_MEMPOOL_MAX_TIP_BPS=8500                     # 85% — leave margin for infra cost
+export AETHER_MEMPOOL_VICTIM_FRESHNESS_MS=300              # 300 ms — tighter staleness
+export AETHER_MEMPOOL_MAX_INFLIGHT=2                       # 2 per target block — limit blast radius
+```
+
+**Duration:** 48 h or 100 included bundles, whichever first.
+
+**Exit gate (all must hold):**
+
+| Check | Threshold |
+|---|---|
+| Cumulative net PnL (mempool source) | ≥ 0 ETH |
+| Worst single bundle outcome | ≥ -0.05 ETH (one min-profit floor) |
+| `bundles_included_total{source="mempool_backrun"}` ÷ `bundles_submitted_total{source="mempool_backrun"}` | ≥ 0.05 (5% inclusion) |
+| `revert_streak` consecutive | ≤ 2 (third revert auto-PAUSEs via existing circuit breaker) |
+| No `risk.SystemState` transition to `Halted` or `Paused` |
+| No alert fired from `aether_gas_price_gwei` or `aether_daily_pnl_eth` halts |
+| Etherscan spot-check 5 included bundles | victim tx lands at position N, our arb at N+1, in same block |
+
+**Rollback trigger:**
+
+- Cumulative net PnL < -0.05 ETH at any point.
+- Any single bundle loss > 0.05 ETH.
+- Inclusion rate < 1% over 6 h (signals fundamental mispricing of fees).
+
+Rollback action: re-export `AETHER_SHADOW=1`, return to Stage A, deploy
+patch.
+
+---
+
+## Stage C — Production min profit (0.001 ETH)
+
+**Entry gate:**
+
+- Stage B exit gate passed.
+- 24 h soak under Stage B config with no incidents.
+
+**Configuration delta from Stage B:**
+
+```bash
+export AETHER_MEMPOOL_MIN_PROFIT_WEI=1000000000000000      # back to 0.001 ETH (Stage A value)
+export AETHER_MEMPOOL_MAX_TIP_BPS=9500                     # back to 95%
+export AETHER_MEMPOOL_VICTIM_FRESHNESS_MS=500              # back to 500 ms
+export AETHER_MEMPOOL_MAX_INFLIGHT=5                       # back to 5
+```
+
+**Steady-state monitoring:**
+
+- Daily PnL dashboard on Grafana — alert on -0.5 ETH (existing
+  `aether_daily_pnl_eth` halt threshold).
+- Inclusion rate by source, p99 latency by source, revert rate by source
+  — all dashboards already split by `source` label.
+- Weekly forensics audit: re-pull a random 1% of `bundles` rows from
+  Postgres where `source = 'mempool_backrun'`, manually compare bundle
+  envelope against `revertingTxHashes` invariant (our arb hash present,
+  victim hash absent).
+
+**Rollback trigger:** same as Stage B but with daily PnL window —
+sustained negative PnL > -0.2 ETH/day for 3 days = drop back to Stage B
+gates and patch.
+
+---
+
+## Operational notes
+
+- **Shadow JSON layout:** `${AETHER_REPORTS_DIR:-reports}/shadow_mempool_<ts>/bundles/<arb_id>.json`
+  per process. `<ts>` is the executor process start, UTC ISO compact.
+  Re-running the process creates a new dir — one dir = one shadow run,
+  never interleave reports.
+- **Forensics retention:** keep Stage A shadow dirs ≥ 30 days for incident
+  post-mortem reconstruction. Stage B/C use the Postgres `bundles` table
+  for the same purpose, where `is_shadow = false`.
+- **Source label drift:** every Prometheus counter touching the bundle
+  hot path carries `{source=block_driven|mempool_backrun}`. If a new
+  metric appears without that label, treat it as a regression — the
+  dashboards and alerts assume the split.
+- **Adverse fill guard:** `revertingTxHashes` carries **only** our arb
+  hash. Bundle constructor asserts this; do not relax. If the victim is
+  marked revert-allowed, our arb can land while the victim rolls back —
+  zero protection against bad fills.
+- **Tip share unit:** `MempoolRiskConfig.MaxTipShareBps` is basis points
+  (9500 = 95%). `processArb` computes `uint16(tipSharePct * 100)` where
+  `tipSharePct` is already a percentage — result is bps. Keep this
+  conversion explicit; off-by-100 here = trivially bypassed gate.
+
+---
+
+## Reference
+
+- Mempool risk config + gates: `cmd/executor/mempool_risk.go`
+- Bundle construction: `cmd/executor/bundle.go` (`BuildMempoolBackrunBundle`)
+- Shadow JSON dump: `cmd/executor/main.go` (`dumpMempoolShadowBundle`)
+- Orchestrator script: `scripts/mempool_backrun_shadow.sh`
+- Rust validator: `crates/simulator/src/mempool_backrun.rs`

--- a/scripts/mempool_backrun_shadow.sh
+++ b/scripts/mempool_backrun_shadow.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# mempool_backrun_shadow.sh — Stage A orchestrator for the public-mempool
+# backrun rollout (docs/runbook/mempool-backrun-rollout.md).
+#
+# Boots the Go executor with AETHER_SHADOW=1, lets it run for $DURATION
+# seconds against the live Rust validator stream, scrapes /metrics, and
+# hard-exits non-zero if any of:
+#   - aether_executor_bundles_submitted_total{source="mempool_backrun"} > 0
+#     (shadow-mode submission leak — P0)
+#   - no shadow-blocked counter incremented at all (pipeline broken)
+#   - schema-invalid forensics JSON
+#
+# Companion of scripts/mempool_capture.sh (Rust side, Stage 1 proof) —
+# this script proves the Go executor's mempool path in the same style.
+#
+# Usage:
+#   ./scripts/mempool_backrun_shadow.sh                # 600 s default
+#   DURATION=300 ./scripts/mempool_backrun_shadow.sh
+#
+# Requires:
+#   - target/release/aether-executor built
+#   - Rust mempool pipeline already running and publishing to gRPC
+#   - AETHER_EXECUTOR_ADDRESS, AETHER_PRIVATE_KEY in env (or .env)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+DURATION="${DURATION:-600}"
+METRICS_PORT="${EXECUTOR_METRICS_PORT:-9093}"
+REPORTS_BASE="${AETHER_REPORTS_DIR:-reports}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="$ROOT/$REPORTS_BASE/shadow_mempool_$TS"
+LOG="$OUT_DIR/executor.log"
+M_END="$OUT_DIR/metrics_end.txt"
+ENV_FILE="$OUT_DIR/env.txt"
+SUMMARY="$OUT_DIR/summary.md"
+
+mkdir -p "$OUT_DIR"
+
+BIN="target/release/aether-executor"
+if [ ! -x "$BIN" ]; then
+  BIN="bin/aether-executor"
+fi
+if [ ! -x "$BIN" ]; then
+  echo "ERROR: missing aether-executor binary — run: go build -o bin/aether-executor ./cmd/executor" >&2
+  exit 2
+fi
+
+# Stage A configuration — runbook section "Stage A — Shadow"
+export AETHER_SHADOW=1
+export AETHER_REPORTS_DIR="$REPORTS_BASE"
+export AETHER_MEMPOOL_MIN_PROFIT_WEI="${AETHER_MEMPOOL_MIN_PROFIT_WEI:-1000000000000000}"
+export AETHER_MEMPOOL_MAX_TIP_BPS="${AETHER_MEMPOOL_MAX_TIP_BPS:-9500}"
+export AETHER_MEMPOOL_VICTIM_FRESHNESS_MS="${AETHER_MEMPOOL_VICTIM_FRESHNESS_MS:-500}"
+export AETHER_MEMPOOL_MAX_INFLIGHT="${AETHER_MEMPOOL_MAX_INFLIGHT:-5}"
+export EXECUTOR_METRICS_PORT="$METRICS_PORT"
+
+{
+  echo "## Shadow capture environment"
+  echo "binary:             $BIN"
+  echo "duration:           ${DURATION}s"
+  echo "metrics port:       $METRICS_PORT"
+  echo "AETHER_SHADOW:      $AETHER_SHADOW"
+  echo "MIN_PROFIT_WEI:     $AETHER_MEMPOOL_MIN_PROFIT_WEI"
+  echo "MAX_TIP_BPS:        $AETHER_MEMPOOL_MAX_TIP_BPS"
+  echo "VICTIM_FRESHNESS:   ${AETHER_MEMPOOL_VICTIM_FRESHNESS_MS}ms"
+  echo "MAX_INFLIGHT:       $AETHER_MEMPOOL_MAX_INFLIGHT"
+  echo "REPORTS_DIR:        $REPORTS_BASE"
+  echo "started at:         $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$ENV_FILE"
+
+echo "==> shadow capture starting (${DURATION}s) → $OUT_DIR"
+
+# caffeinate -i prevents the box from idle-sleeping during a long shadow
+# window (macOS only — no-op on Linux as `command -v` fails). We do NOT
+# block display sleep, only idle.
+if command -v caffeinate >/dev/null 2>&1; then
+  PRE="caffeinate -i"
+else
+  PRE=""
+fi
+
+# shellcheck disable=SC2086
+$PRE "$BIN" >"$LOG" 2>&1 &
+PID=$!
+echo "==> executor pid=$PID"
+
+cleanup() {
+  if kill -0 "$PID" 2>/dev/null; then
+    kill "$PID" 2>/dev/null || true
+    sleep 1
+    kill -9 "$PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Wait for /metrics to come up.
+for i in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:$METRICS_PORT/metrics" >/dev/null 2>&1; then
+    echo "==> /metrics live after ${i}s"
+    break
+  fi
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "ERROR: executor exited during boot — see $LOG" >&2
+    tail -30 "$LOG" >&2
+    exit 3
+  fi
+  sleep 1
+done
+
+echo "==> running for ${DURATION}s"
+sleep "$DURATION"
+
+curl -fsS "http://127.0.0.1:$METRICS_PORT/metrics" >"$M_END"
+kill "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+
+# ── Verdict checks ──────────────────────────────────────────────────────
+
+extract_labeled() {
+  # extract_labeled <metric> <label_value>
+  awk -v m="$1" -v lv="$2" '
+    $1 ~ "^"m"\\{" {
+      if (match($1, "source=\""lv"\"")) {
+        sum += $NF
+      }
+    }
+    END { print sum+0 }
+  ' "$M_END"
+}
+
+extract_total() {
+  awk -v m="$1" '$1 ~ "^"m"(\\{|$)" { sum += $NF } END { print sum+0 }' "$M_END"
+}
+
+SUBMITTED_MEMPOOL=$(extract_labeled aether_executor_bundles_submitted_total mempool_backrun)
+BLOCKED_MEMPOOL=$(extract_labeled aether_executor_bundles_shadow_blocked_total mempool_backrun)
+RISK_REJECTED=$(extract_total aether_mempool_risk_rejected_total)
+BUILT_MEMPOOL=$(extract_labeled aether_executor_bundles_built_total mempool_backrun)
+
+# Count forensics JSON files in the bundles/ subdir of the most recent
+# shadow_mempool_* dir under REPORTS_BASE. The executor stamps its own
+# session dir on first call; we look there, not at $OUT_DIR which is the
+# orchestrator's dir.
+LATEST_SESSION="$(ls -dt "$REPORTS_BASE"/shadow_mempool_*/bundles 2>/dev/null | head -1 || true)"
+JSON_COUNT=0
+SCHEMA_BAD=0
+if [ -n "$LATEST_SESSION" ] && [ -d "$LATEST_SESSION" ]; then
+  JSON_COUNT=$(find "$LATEST_SESSION" -name '*.json' -type f | wc -l | awk '{print $1}')
+  # Schema sanity: every file must contain the required top-level keys.
+  if command -v jq >/dev/null 2>&1; then
+    while IFS= read -r f; do
+      missing=$(jq -r '
+        ["arb_id","source","victim_tx_hash","target_block","built_at",
+         "envelope","expected_gross_profit_wei","expected_net_profit_wei",
+         "tip_share_bps","gas_used","base_fee_wei","priority_fee_wei",
+         "flashloan_provider","flashloan_amount","risk_decisions"]
+        - [paths(scalars,arrays,objects) | select(length==1) | .[0]]
+        | length' "$f" 2>/dev/null || echo "X")
+      if [ "$missing" != "0" ]; then
+        SCHEMA_BAD=$((SCHEMA_BAD + 1))
+      fi
+    done < <(find "$LATEST_SESSION" -name '*.json' -type f)
+  fi
+fi
+
+VERDICT="PASS"
+REASONS=()
+
+if [ "$SUBMITTED_MEMPOOL" -gt 0 ]; then
+  VERDICT="FAIL"
+  REASONS+=("P0: bundles_submitted{source=mempool_backrun}=$SUBMITTED_MEMPOOL — shadow-mode submission LEAK")
+fi
+if [ "$BLOCKED_MEMPOOL" -eq 0 ] && [ "$BUILT_MEMPOOL" -gt 0 ]; then
+  VERDICT="FAIL"
+  REASONS+=("bundles built ($BUILT_MEMPOOL) but none shadow-blocked — gate broken")
+fi
+if [ "$BUILT_MEMPOOL" -eq 0 ]; then
+  VERDICT="INCONCLUSIVE"
+  REASONS+=("no mempool bundles built — Rust pipeline likely not publishing")
+fi
+if [ "$SCHEMA_BAD" -gt 0 ]; then
+  VERDICT="FAIL"
+  REASONS+=("$SCHEMA_BAD JSON files missing required schema keys")
+fi
+
+{
+  echo "# Mempool backrun — Stage A shadow capture"
+  echo
+  echo "**Verdict:** $VERDICT"
+  echo "**Date:** $(date -u +%Y-%m-%d) (UTC)"
+  echo "**Duration:** ${DURATION}s"
+  echo
+  if [ ${#REASONS[@]} -gt 0 ]; then
+    echo "## Failure reasons"
+    echo
+    for r in "${REASONS[@]}"; do echo "- $r"; done
+    echo
+  fi
+  echo "## Counters"
+  echo
+  echo '| metric | value |'
+  echo '|---|---|'
+  echo "| bundles_built{source=mempool_backrun} | $BUILT_MEMPOOL |"
+  echo "| bundles_submitted{source=mempool_backrun} | $SUBMITTED_MEMPOOL |"
+  echo "| bundles_shadow_blocked{source=mempool_backrun} | $BLOCKED_MEMPOOL |"
+  echo "| mempool_risk_rejected_total (all reasons) | $RISK_REJECTED |"
+  echo "| forensics JSON files written | $JSON_COUNT |"
+  echo "| forensics JSON schema bad | $SCHEMA_BAD |"
+  echo
+  echo "## Files"
+  echo
+  echo "- \`$ENV_FILE\` — capture env"
+  echo "- \`$LOG\` — executor stdout/stderr"
+  echo "- \`$M_END\` — final /metrics scrape"
+  echo "- \`$LATEST_SESSION\` — forensics JSON dump dir"
+} > "$SUMMARY"
+
+echo
+cat "$SUMMARY"
+echo
+
+case "$VERDICT" in
+  PASS) exit 0 ;;
+  INCONCLUSIVE) exit 4 ;;
+  FAIL) exit 5 ;;
+esac


### PR DESCRIPTION
## Summary

- Adds mempool-specific risk gates (`min_profit`, `max_tip_share`, `victim_freshness`, `dedup` + `max_inflight_per_block`) layered **after** the existing block-driven `PreflightCheck` so all shared gates fire first
- Adds `AETHER_SHADOW=1` enforcement on the mempool path with per-bundle JSON forensics dump at `${AETHER_REPORTS_DIR:-reports}/shadow_mempool_<ts>/bundles/<arb_id>.json`
- Adds three-stage rollout runbook (shadow → 0.05 ETH min profit → 0.001 ETH steady-state) with explicit entry / exit / rollback gates keyed to existing Prometheus counters
- Adds `scripts/mempool_backrun_shadow.sh` orchestrator that boots the executor, runs Stage A, and hard-exits non-zero on any submission leak, broken gate, or schema-invalid forensics JSON

## Files Changed

| File | Purpose |
|---|---|
| `cmd/executor/mempool_risk.go` | `MempoolRiskConfig` (env-tunable), `MempoolRiskGate`, `MempoolInflightTracker` with 144 s reaper, new metrics |
| `cmd/executor/mempool_risk_test.go` | Default + env-override config, every reject path, tracker semantics, dump JSON schema pin |
| `cmd/executor/main.go` | Globals + `main()` init, `MempoolRiskGate` call in `processArb`, mempool branch of shadow path, `dumpMempoolShadowBundle`, session dir resolver |
| `docs/runbook/mempool-backrun-rollout.md` | Stage A / B / C gates + ops notes |
| `scripts/mempool_backrun_shadow.sh` | Stage A orchestrator |

## New environment variables

| Env | Default | Stage |
|---|---|---|
| `AETHER_MEMPOOL_MIN_PROFIT_WEI` | `1e15` (0.001 ETH) | A & C |
| `AETHER_MEMPOOL_MAX_TIP_BPS` | `9500` (95%) | A & C; B uses 8500 |
| `AETHER_MEMPOOL_VICTIM_FRESHNESS_MS` | `500` | A & C; B uses 300 |
| `AETHER_MEMPOOL_MAX_INFLIGHT` | `5` | A & C; B uses 2 |
| `AETHER_REPORTS_DIR` | `reports` | All — orchestrator parameterises this |

## New metrics

| Metric | Type | Labels |
|---|---|---|
| `aether_mempool_risk_rejected_total` | Counter | `reason` (`min_profit`, `max_tip_share`, `victim_stale`, `duplicate`, `max_inflight_per_block`) |
| `aether_executor_bundles_shadow_blocked_total` | Counter | `source` (`block_driven`, `mempool_backrun`) |

Both label sets pre-touched at boot so dashboards see zero rows from process start instead of "missing series."

## Adverse-fill invariant (regression-pinned)

`revertingTxHashes` in the mempool envelope carries **only** our arb hash — never the victim hash. The dump schema test (`TestDumpMempoolShadowBundle_Schema`) asserts this explicitly:

```go
for _, h := range rev {
    if h == "0xdeadbeef" {
        t.Fatal("revertingTxHashes leaked victim hash — adverse-fill protection broken")
    }
}
```

A regression there flips the strategy from backrun to sandwich semantically and is treated as a P0.

## Acceptance Criteria

- [x] Mempool risk gates layered after shared `PreflightCheck`; reject reason bucketed in `aether_mempool_risk_rejected_total{reason}`
- [x] `AETHER_SHADOW=1` blocks `eth_sendBundle` for `source=mempool_backrun` and dumps JSON to the specified path with the runbook-pinned schema
- [x] `aether_executor_bundles_shadow_blocked_total{source}` increments on every blocked bundle
- [x] Three-stage runbook with explicit entry / exit / rollback gates per stage
- [x] Orchestrator script enforces "no submission" invariant + schema validity, hard-exits non-zero on violation
- [x] Per-target-block dedup + in-flight cap with 144 s reap so the tracker doesn't grow unbounded over long shadow runs

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages pass (executor +cmd/executor 4.0 s)
- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --release` — all green (one pre-existing env-race flake passes with `--test-threads=1`)
- [x] `forge test` — 59/59 pass
- [x] `bash -n scripts/mempool_backrun_shadow.sh` — syntax OK
- [ ] Stage A live-mainnet shadow capture for ≥ 24 h, exit gate verified before promoting to Stage B

## Stacked PR notes

This PR stacks on top of #143 (`feat/mempool-backrun-go-bundle`). Review #142 → #143 → this PR in order; merging out-of-order will surface phantom conflicts against `develop`.

Closes #140