### PR TITLE
feat: min-liquidity floor + replay diagnostic gating to suppress dead-pool phantoms

### DIFF
--- a/crates/detector/src/bellman_ford.rs
+++ b/crates/detector/src/bellman_ford.rs
@@ -71,6 +71,11 @@ impl BellmanFord {
             }
 
             for edge in graph.edges_from(u) {
+                // Skip edges whose backing pool is below the min-liquidity
+                // floor — drained/dead pools must never seed a cycle.
+                if edge.filtered {
+                    continue;
+                }
                 let v = edge.to;
                 let new_dist = dist[u] + edge.weight;
 
@@ -174,7 +179,7 @@ impl BellmanFord {
             if let Some(best_edge) = graph
                 .edges_from(from)
                 .iter()
-                .filter(|e| e.to == to)
+                .filter(|e| e.to == to && !e.filtered)
                 .min_by(|a, b| {
                     a.weight
                         .partial_cmp(&b.weight)
@@ -238,6 +243,11 @@ impl BellmanFord {
             }
 
             for edge in graph.edges_from(u) {
+                // Skip edges whose backing pool is below the min-liquidity
+                // floor — drained/dead pools must never seed a cycle.
+                if edge.filtered {
+                    continue;
+                }
                 let v = edge.to;
                 let new_dist = dist[u] + edge.weight;
 
@@ -610,6 +620,99 @@ mod tests {
         let bf = BellmanFord::new(6, 1_000_000);
         let cycles = bf.detect_negative_cycles(&graph);
         assert!(cycles.is_empty());
+    }
+
+    // --------------- Min-liquidity floor filtering ---------------
+
+    #[test]
+    fn test_filtered_edge_breaks_cycle() {
+        // Profitable triangle 0->1->2->0 where vertex 1 is WETH. The 0->1 edge's
+        // WETH-side reserve is below the floor, so that edge is `filtered` and the
+        // cycle must NOT be detected — even though every edge weight stays
+        // profitable. Disabling the floor restores detection.
+        let p01 = make_pool_id(1, ProtocolType::UniswapV2);
+        let p12 = make_pool_id(2, ProtocolType::SushiSwap);
+        let p20 = make_pool_id(3, ProtocolType::Curve);
+
+        // Reserve pairs (all 18-decimal tokens, fee 1.0) chosen so each hop's
+        // rate = reserve_out / reserve_in = 1.1 → product 1.331 > 1 (profitable).
+        // 1e18 raw == 1.0 human unit.
+        let weth_below_floor = 500_000_000_000_000_000.0_f64; // 0.5 WETH < floor 1.0
+        let token_in_for_0to1 = weth_below_floor / 1.1; // gives rate 1.1 on 0->1
+
+        let build = |floor: f64| -> PriceGraph {
+            let mut g = PriceGraph::new(3);
+            // vertex 1 = WETH (18 decimals, like all others here).
+            g.add_edge(0, 1, 1.0, p01, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+            g.add_edge(1, 2, 1.0, p12, Address::repeat_byte(2), ProtocolType::SushiSwap, U256::from(1u64));
+            g.add_edge(2, 0, 1.0, p20, Address::repeat_byte(3), ProtocolType::Curve, U256::from(1u64));
+            g.set_weth_vertex(1);
+            g.set_min_liquidity_weth(floor);
+            // 0->1: WETH (vertex 1) is the output side, reserve below floor.
+            g.update_edge_from_reserves(0, 1, p01, token_in_for_0to1, weth_below_floor, 1.0);
+            // 1->2 and 2->0: non-WETH-output / non-WETH-paired, ample reserves,
+            // each rate = out/in = 1.1.
+            g.update_edge_from_reserves(1, 2, p12, 1.0e18, 1.1e18, 1.0);
+            g.update_edge_from_reserves(2, 0, p20, 1.0e18, 1.1e18, 1.0);
+            g
+        };
+
+        let bf = BellmanFord::new(6, 1_000_000);
+
+        // With the floor active the 0->1 edge is filtered → no cycle.
+        let filtered_graph = build(1.0);
+        assert!(
+            filtered_graph.edges_from(0)[0].filtered,
+            "0->1 edge should be filtered (0.5 WETH < floor 1.0)"
+        );
+        let cycles = bf.detect_negative_cycles(&filtered_graph);
+        assert!(
+            cycles.is_empty(),
+            "a filtered edge on the only cycle must suppress detection, got {} cycles",
+            cycles.len()
+        );
+
+        // With the floor disabled (0.0) the same graph yields the profitable cycle.
+        let open_graph = build(0.0);
+        assert!(
+            !open_graph.edges_from(0)[0].filtered,
+            "0->1 edge should not be filtered when floor is disabled"
+        );
+        let cycles = bf.detect_negative_cycles(&open_graph);
+        assert!(
+            !cycles.is_empty(),
+            "with the floor disabled the profitable cycle must be detected"
+        );
+        assert!(cycles[0].is_profitable());
+    }
+
+    #[test]
+    fn test_filtered_edge_skipped_in_affected_scan() {
+        // Same setup, verifying detect_from_affected also skips filtered edges.
+        let p01 = make_pool_id(1, ProtocolType::UniswapV2);
+        let p12 = make_pool_id(2, ProtocolType::SushiSwap);
+        let p20 = make_pool_id(3, ProtocolType::Curve);
+
+        let weth_below_floor = 500_000_000_000_000_000.0_f64;
+        let token_in_for_0to1 = weth_below_floor / 1.1;
+
+        let mut g = PriceGraph::new(3);
+        g.add_edge(0, 1, 1.0, p01, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+        g.add_edge(1, 2, 1.0, p12, Address::repeat_byte(2), ProtocolType::SushiSwap, U256::from(1u64));
+        g.add_edge(2, 0, 1.0, p20, Address::repeat_byte(3), ProtocolType::Curve, U256::from(1u64));
+        g.set_weth_vertex(1);
+        g.set_min_liquidity_weth(1.0);
+        g.update_edge_from_reserves(0, 1, p01, token_in_for_0to1, weth_below_floor, 1.0);
+        g.update_edge_from_reserves(1, 2, p12, 1.0e18, 1.1e18, 1.0);
+        g.update_edge_from_reserves(2, 0, p20, 1.0e18, 1.1e18, 1.0);
+
+        let bf = BellmanFord::new(6, 1_000_000);
+        let cycles = bf.detect_from_affected(&g, &[0, 1, 2]);
+        assert!(
+            cycles.is_empty(),
+            "affected scan must skip the filtered edge and find no cycle, got {} cycles",
+            cycles.len()
+        );
     }
 
     // --------------- Disconnected components ---------------

--- a/crates/grpc-server/src/bin/aether_profit_scorer.rs
+++ b/crates/grpc-server/src/bin/aether_profit_scorer.rs
@@ -160,6 +160,10 @@ const AAVE_POOL: Address = address!("87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2");
 const BALANCER_VAULT: Address = address!("BA12222222228d8Ba445958a75a0704d566BF2C8");
 const BANCOR_NETWORK: Address = address!("eEF417e1D5CC832e619ae18D2F140De2999dD4fB");
 const WETH_ADDR: Address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+/// Default WETH-side min-liquidity floor for the diagnostic detectors; matches
+/// the engine's `EngineConfig::min_liquidity_weth` default so the scorer skips
+/// the same drained WETH-paired pools the live engine does.
+const MIN_LIQUIDITY_WETH: f64 = 1.0;
 const USDC_ADDR: Address = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 const DAI_ADDR: Address = address!("6B175474E89094C44Da98b954EedeAC495271d0F");
 const USDT_ADDR: Address = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
@@ -1343,6 +1347,19 @@ async fn bootstrap_state(
         // Unknown tokens default to the ERC20 standard of 18.
         graph.set_token_decimals(t0, known_token_decimals(&pool.token0).unwrap_or(18));
         graph.set_token_decimals(t1, known_token_decimals(&pool.token1).unwrap_or(18));
+
+        // Enable the WETH-denominated min-liquidity floor only when a WETH
+        // vertex is actually present, so synthetic-graph unit tests (which
+        // never reference WETH_ADDR) keep `weth_vertex = None` and behave
+        // exactly as before. Set before `update_edge_from_reserves` so the
+        // `filtered` flags are computed on seeding.
+        if pool.token0 == WETH_ADDR {
+            graph.set_weth_vertex(t0);
+            graph.set_min_liquidity_weth(MIN_LIQUIDITY_WETH);
+        } else if pool.token1 == WETH_ADDR {
+            graph.set_weth_vertex(t1);
+            graph.set_min_liquidity_weth(MIN_LIQUIDITY_WETH);
+        }
 
         let fee = (10_000 - pool.fee_bps) as f64 / 10_000.0;
         let pool_id = PoolId {

--- a/crates/grpc-server/src/bin/aether_replay.rs
+++ b/crates/grpc-server/src/bin/aether_replay.rs
@@ -238,6 +238,19 @@ fn build_graph(
         graph.set_token_decimals(t0, known_token_decimals(&p.token0).unwrap_or(18));
         graph.set_token_decimals(t1, known_token_decimals(&p.token1).unwrap_or(18));
 
+        // Enable the WETH-denominated min-liquidity floor when a WETH vertex is
+        // present (matching the engine + scorer default of 1.0 WETH) so the
+        // diagnostic detector skips drained WETH-paired pools. Set before
+        // `update_edge_from_reserves` so the `filtered` flags are computed on
+        // seeding. Synthetic graphs without WETH keep `weth_vertex = None`.
+        if p.token0 == aether_common::types::addresses::WETH {
+            graph.set_weth_vertex(t0);
+            graph.set_min_liquidity_weth(1.0);
+        } else if p.token1 == aether_common::types::addresses::WETH {
+            graph.set_weth_vertex(t1);
+            graph.set_min_liquidity_weth(1.0);
+        }
+
         let fee = (10_000 - p.fee_bps) as f64 / 10_000.0;
         let pool_id = PoolId {
             address: p.address,

--- a/crates/grpc-server/src/bin/aether_replay.rs
+++ b/crates/grpc-server/src/bin/aether_replay.rs
@@ -28,6 +28,10 @@ use aether_common::types::{known_token_decimals, PoolId, ProtocolType, SwapStep}
 use aether_detector::bellman_ford::BellmanFord;
 use aether_detector::gas as gas_model;
 use aether_detector::opportunity::DetectedCycle;
+use aether_grpc_server::cycle_gating::{
+    build_fingerprint_index, gate_pre_sim, GatingConfig, PreSimGateVerdict,
+};
+use aether_grpc_server::EngineMetrics;
 use aether_detector::optimizer::ternary_search_optimal_input;
 use aether_grpc_server::historical::{
     fetch_pool_state_at, getReservesCall, load_executor_init_bytecode, load_pools, slot0Call,
@@ -301,6 +305,27 @@ fn build_graph(
     (graph, token_index)
 }
 
+/// Apply the engine's pre-simulation gates to a freshly detected cycle batch,
+/// keeping only the cycles the production engine would actually act on. The
+/// `aether-rust` engine runs this same `gate_pre_sim` between detection and
+/// simulation; mirroring it here keeps the diagnostic output free of phantom
+/// cycles (e.g. f64-overflow profit factors from a transiently corrupted fork
+/// pool) that the engine drops at the `profit_factor_impossible` cap.
+fn gate_cycles(cycles: Vec<DetectedCycle>, graph: &PriceGraph) -> Vec<DetectedCycle> {
+    let config = GatingConfig::default();
+    let metrics = EngineMetrics::new();
+    let fingerprint_index = build_fingerprint_index(&cycles, &config);
+    cycles
+        .into_iter()
+        .filter(|c| {
+            matches!(
+                gate_pre_sim(c, graph, &fingerprint_index, &config, &metrics),
+                PreSimGateVerdict::Pass
+            )
+        })
+        .collect()
+}
+
 fn print_cycles(cycles: &[DetectedCycle], token_index: &TokenIndex, top: usize) {
     let mut ranked: Vec<&DetectedCycle> = cycles.iter().filter(|c| c.is_profitable()).collect();
     ranked.sort_by(|a, b| {
@@ -459,7 +484,10 @@ async fn main() -> Result<()> {
     // Run detector — same code path as production.
     let t_detect = Instant::now();
     let detector = BellmanFord::new(args.max_hops, args.max_time_us);
-    let cycles = detector.detect_negative_cycles(&graph);
+    // Mirror the engine: gate the raw cycle batch so phantom cycles (graph
+    // f64-overflow / corrupted-edge signatures the engine drops pre-sim) never
+    // surface in the diagnostic output.
+    let cycles = gate_cycles(detector.detect_negative_cycles(&graph), &graph);
     let detect_ms = t_detect.elapsed().as_millis();
 
     let profitable = cycles.iter().filter(|c| c.is_profitable()).count();
@@ -1233,7 +1261,10 @@ async fn run_full_block_replay(
             running_states.iter().map(|(&i, &s)| (i, s)).collect();
 
         let (graph, token_index) = build_graph(&pools, &states);
-        let cycles = detector.detect_negative_cycles(&graph);
+        // Mirror the engine's pre-sim gating so corrupted-fork-state phantoms
+        // (e.g. an impersonated tx transiently draining a pool) don't pollute
+        // the per-tx diagnostic the way the ungated detector did.
+        let cycles = gate_cycles(detector.detect_negative_cycles(&graph), &graph);
         let profitable = cycles.iter().filter(|c| c.is_profitable()).count();
 
         if profitable > 0 {

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -34,7 +34,7 @@ use aether_state::token_index::TokenIndex;
 // Import the proto ValidatedArb type from service module
 use aether_grpc_server::EngineMetrics;
 
-use crate::cycle_gating::{
+use aether_grpc_server::cycle_gating::{
     self, GatingConfig, PostSimGateVerdict, PreSimGateVerdict,
 };
 use crate::pipeline;

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -91,6 +91,10 @@ pub struct EngineConfig {
     /// (`add_edge` without seeded reserves) should override this with a
     /// permissive config; production runs use the strict default.
     pub gating: GatingConfig,
+    /// Minimum WETH-side reserve (≈ half pool TVL) for a WETH-paired pool to
+    /// participate in detection; aligns with the >$10K qualification rule; 0
+    /// disables.
+    pub min_liquidity_weth: f64,
 }
 
 impl Default for EngineConfig {
@@ -106,6 +110,7 @@ impl Default for EngineConfig {
             slippage_bps: 100,
             max_parallel_sims: 4,
             gating: GatingConfig::default(),
+            min_liquidity_weth: 1.0,
         }
     }
 }
@@ -563,6 +568,18 @@ impl AetherEngine {
             // available, override these in fetch_initial_reserves.
             graph.set_token_decimals(t0_idx, known_token_decimals(&token0).unwrap_or(18));
             graph.set_token_decimals(t1_idx, known_token_decimals(&token1).unwrap_or(18));
+            // Register the WETH vertex + min-liquidity floor so the snapshot
+            // carries correct `filtered` flags once reserves are seeded. This
+            // must run BEFORE fetch_initial_reserves (called by the caller) so
+            // that update_edge_from_reserves can apply the floor. Idempotent:
+            // safe to call on every WETH-paired registration.
+            if token0 == aether_common::types::addresses::WETH {
+                graph.set_weth_vertex(t0_idx);
+                graph.set_min_liquidity_weth(self.config.min_liquidity_weth);
+            } else if token1 == aether_common::types::addresses::WETH {
+                graph.set_weth_vertex(t1_idx);
+                graph.set_min_liquidity_weth(self.config.min_liquidity_weth);
+            }
             // Placeholder edges with rate 1.0 (neutral weight = 0).
             graph.add_edge(
                 t0_idx,

--- a/crates/grpc-server/src/lib.rs
+++ b/crates/grpc-server/src/lib.rs
@@ -5,6 +5,7 @@
 /// without depending on the binary entry point. The `metrics` module is
 /// crate-private; only the two types the binary and integration tests
 /// actually need are re-exported publicly.
+pub mod cycle_gating;
 pub mod historical;
 pub(crate) mod metrics;
 pub mod profitability_writer;

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -11,7 +11,6 @@ use tokio::net::UnixListener;
 #[cfg(unix)]
 use tokio_stream::wrappers::UnixListenerStream;
 
-mod cycle_gating;
 mod engine;
 mod mempool_pipeline;
 mod mempool_writer;

--- a/crates/state/src/price_graph.rs
+++ b/crates/state/src/price_graph.rs
@@ -29,6 +29,12 @@ pub struct PriceEdge {
     pub reserve_in: f64,
     /// Pool reserve on the output side (f64 approx). Zero when reserves are unknown.
     pub reserve_out: f64,
+    /// `true` when this edge is excluded from arbitrage detection because the
+    /// backing pool's liquidity is below the configured minimum-liquidity floor
+    /// (see [`PriceGraph::set_min_liquidity_weth`]). Bellman-Ford skips filtered
+    /// edges during relaxation, so dead/drained pools never produce phantom
+    /// cycles. Placeholder edges (no real reserves) are never filtered.
+    pub filtered: bool,
 }
 
 /// Directed price graph for arbitrage detection.
@@ -53,6 +59,15 @@ pub struct PriceGraph {
     /// ratios into human-unit exchange rates in [`update_edge_from_reserves`].
     /// Defaults to 18 (the ERC20 default) for any vertex not explicitly set.
     token_decimals: Vec<u8>,
+    /// Graph vertex index of WETH, when known. The minimum-liquidity floor uses
+    /// the WETH-side reserve of a WETH-paired pool as a no-oracle TVL proxy.
+    /// `None` disables the floor entirely (backward-compatible: synthetic graphs
+    /// that never register WETH behave exactly as before).
+    weth_vertex: Option<usize>,
+    /// Minimum WETH-side human reserve (≈ half a constant-product pool's TVL)
+    /// for a WETH-paired pool's edges to participate in detection. `0.0` (the
+    /// default) disables the floor.
+    min_liquidity_weth: f64,
 }
 
 impl PriceGraph {
@@ -65,6 +80,8 @@ impl PriceGraph {
             edge_index: HashMap::with_capacity(num_vertices * 8),
             dirty: Vec::new(),
             token_decimals: vec![DEFAULT_TOKEN_DECIMALS; num_vertices],
+            weth_vertex: None,
+            min_liquidity_weth: 0.0,
         }
     }
 
@@ -106,6 +123,9 @@ impl PriceGraph {
             liquidity,
             reserve_in: 0.0,
             reserve_out: 0.0,
+            // Placeholder edges carry no real reserves and are never floored;
+            // the follow-up `update_edge_from_reserves` sets the real flag.
+            filtered: false,
         };
 
         // Try to update an existing edge with matching (from, to, pool_id).
@@ -176,6 +196,30 @@ impl PriceGraph {
             .unwrap_or(DEFAULT_TOKEN_DECIMALS) as i32;
         let rate = (reserve_out / reserve_in) * fee_factor * 10f64.powi(dec_in - dec_out);
 
+        // Minimum-liquidity floor: exclude WETH-paired pools whose WETH-side
+        // human reserve is below the configured floor. For a constant-product
+        // pool both sides hold equal value, so the WETH-side reserve is a clean,
+        // oracle-free TVL proxy. Pools where neither endpoint is WETH are NOT
+        // subject to this floor (left to existing qualification gates). The
+        // floor is disabled when `weth_vertex` is unknown or the floor is 0.0.
+        let filtered = match self.weth_vertex {
+            Some(weth) if self.min_liquidity_weth > 0.0 => {
+                let weth_human = if from == weth {
+                    Some(reserve_in / 10f64.powi(self.token_decimals(from) as i32))
+                } else if to == weth {
+                    Some(reserve_out / 10f64.powi(self.token_decimals(to) as i32))
+                } else {
+                    // Pool not WETH-paired → not subject to this floor.
+                    None
+                };
+                match weth_human {
+                    Some(human) => human < self.min_liquidity_weth,
+                    None => false,
+                }
+            }
+            _ => false,
+        };
+
         if let Some(existing) = self.edges[from]
             .iter_mut()
             .find(|e| e.to == to && e.pool_id == pool_id)
@@ -183,6 +227,7 @@ impl PriceGraph {
             existing.weight = -rate.ln();
             existing.reserve_in = reserve_in;
             existing.reserve_out = reserve_out;
+            existing.filtered = filtered;
             // Mirror the update in the flat edge list via O(1) index lookup.
             // Direct indexing: panics if the key is missing, which is correct —
             // the adjacency list found the edge, so edge_index must agree.
@@ -190,6 +235,7 @@ impl PriceGraph {
             self.all_edges[idx].weight = existing.weight;
             self.all_edges[idx].reserve_in = reserve_in;
             self.all_edges[idx].reserve_out = reserve_out;
+            self.all_edges[idx].filtered = filtered;
             self.dirty[idx] = true;
         }
     }
@@ -319,6 +365,27 @@ impl PriceGraph {
             .get(vertex)
             .copied()
             .unwrap_or(DEFAULT_TOKEN_DECIMALS)
+    }
+
+    /// Register the graph vertex index of WETH. Enables the WETH-denominated
+    /// minimum-liquidity floor for WETH-paired pools (see
+    /// [`Self::set_min_liquidity_weth`]). Must be set before reserves are seeded
+    /// for the resulting `filtered` flags to be correct.
+    pub fn set_weth_vertex(&mut self, vertex: usize) {
+        self.weth_vertex = Some(vertex);
+    }
+
+    /// Set the minimum WETH-side human reserve a WETH-paired pool must hold for
+    /// its edges to participate in detection. `0.0` disables the floor. The
+    /// floor is only applied when [`Self::set_weth_vertex`] has also been set.
+    pub fn set_min_liquidity_weth(&mut self, floor: f64) {
+        self.min_liquidity_weth = floor;
+    }
+
+    /// The configured minimum WETH-side reserve floor (`0.0` when disabled).
+    #[inline]
+    pub fn min_liquidity_weth(&self) -> f64 {
+        self.min_liquidity_weth
     }
 }
 
@@ -1071,6 +1138,129 @@ mod tests {
         );
         // Sanity: a 1e12-off bug would put human_rate near 3.3e8; assert nowhere close.
         assert!(human_rate < 1.0, "human rate must be sub-1, got {human_rate}");
+    }
+
+    // --------------- Minimum-liquidity floor ---------------
+
+    /// Build a single WETH-paired V2 pool (vertex 0 = some token, vertex 1 =
+    /// WETH) with both directional placeholder edges in place, ready for a
+    /// `update_edge_from_reserves` call. Returns the graph and the pool_id.
+    fn build_weth_paired_pool(weth_decimals: u8) -> (PriceGraph, PoolId) {
+        let mut g = PriceGraph::new(2);
+        g.set_token_decimals(0, 18); // arbitrary token
+        g.set_token_decimals(1, weth_decimals); // WETH
+        let pool_id = make_pool_id(1, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 1.0, pool_id, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+        g.add_edge(1, 0, 1.0, pool_id, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+        (g, pool_id)
+    }
+
+    #[test]
+    fn test_floor_filters_low_weth_reserve() {
+        // WETH-side human reserve = 0.5 WETH < floor 1.0 → filtered.
+        let (mut g, pool_id) = build_weth_paired_pool(18);
+        g.set_weth_vertex(1);
+        g.set_min_liquidity_weth(1.0);
+
+        // 0.5 WETH raw = 5e17 wei on the WETH side (vertex 1 = `to` for 0->1).
+        let token_reserve = 1_000_000_000_000_000_000.0_f64; // 1.0 token
+        let weth_reserve = 500_000_000_000_000_000.0_f64; // 0.5 WETH
+        g.update_edge_from_reserves(0, 1, pool_id, token_reserve, weth_reserve, 0.997);
+        g.update_edge_from_reserves(1, 0, pool_id, weth_reserve, token_reserve, 0.997);
+
+        // Both directions must be filtered (each carries the same dead pool).
+        assert!(g.edges_from(0)[0].filtered, "0->1 edge should be filtered");
+        assert!(g.edges_from(1)[0].filtered, "1->0 edge should be filtered");
+        // Mirror in all_edges must agree.
+        assert!(g.all_edges().iter().all(|e| e.filtered));
+    }
+
+    #[test]
+    fn test_floor_passes_high_weth_reserve() {
+        // WETH-side human reserve = 10 WETH > floor 1.0 → not filtered.
+        let (mut g, pool_id) = build_weth_paired_pool(18);
+        g.set_weth_vertex(1);
+        g.set_min_liquidity_weth(1.0);
+
+        let token_reserve = 30_000_000_000_000_000_000_000.0_f64; // 30000 token
+        let weth_reserve = 10_000_000_000_000_000_000.0_f64; // 10 WETH
+        g.update_edge_from_reserves(0, 1, pool_id, token_reserve, weth_reserve, 0.997);
+        g.update_edge_from_reserves(1, 0, pool_id, weth_reserve, token_reserve, 0.997);
+
+        assert!(!g.edges_from(0)[0].filtered, "0->1 edge should not be filtered");
+        assert!(!g.edges_from(1)[0].filtered, "1->0 edge should not be filtered");
+        assert!(g.all_edges().iter().all(|e| !e.filtered));
+    }
+
+    #[test]
+    fn test_floor_ignores_non_weth_pool() {
+        // Neither vertex is WETH (weth_vertex points at a third vertex) → never
+        // filtered regardless of how tiny the reserves are.
+        let mut g = PriceGraph::new(3);
+        g.set_token_decimals(0, 18);
+        g.set_token_decimals(1, 18);
+        g.set_weth_vertex(2); // WETH is vertex 2, not part of this pool
+        g.set_min_liquidity_weth(1.0);
+
+        let pool_id = make_pool_id(1, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 1.0, pool_id, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+        // Tiny reserves on both sides — would be filtered if this were WETH-paired.
+        g.update_edge_from_reserves(0, 1, pool_id, 1.0, 1.0, 0.997);
+
+        assert!(!g.edges_from(0)[0].filtered, "non-WETH pool must never be floored");
+    }
+
+    #[test]
+    fn test_floor_disabled_when_weth_vertex_unset() {
+        // weth_vertex None → backward-compatible, never filtered.
+        let (mut g, pool_id) = build_weth_paired_pool(18);
+        g.set_min_liquidity_weth(1.0); // floor set, but no weth_vertex
+        g.update_edge_from_reserves(0, 1, pool_id, 1.0, 1.0, 0.997);
+        assert!(!g.edges_from(0)[0].filtered);
+    }
+
+    #[test]
+    fn test_floor_disabled_when_floor_zero() {
+        // min_liquidity_weth 0.0 (default) → never filtered even with weth_vertex.
+        let (mut g, pool_id) = build_weth_paired_pool(18);
+        g.set_weth_vertex(1);
+        // Leave floor at its 0.0 default.
+        assert_eq!(g.min_liquidity_weth(), 0.0);
+        g.update_edge_from_reserves(0, 1, pool_id, 1.0, 1.0, 0.997);
+        assert!(!g.edges_from(0)[0].filtered);
+    }
+
+    #[test]
+    fn test_floor_decimal_aware_conversion() {
+        // WETH is 18-dec: raw 5e17 wei = 0.5 WETH < floor 1.0 → filtered.
+        // Verifies the human conversion divides by 10^decimals correctly.
+        let (mut g, pool_id) = build_weth_paired_pool(18);
+        g.set_weth_vertex(1);
+        g.set_min_liquidity_weth(1.0);
+
+        // WETH side (vertex 1) is `to` for the 0->1 direction.
+        let weth_raw = 500_000_000_000_000_000.0_f64; // 5e17 wei = 0.5 WETH
+        g.update_edge_from_reserves(0, 1, pool_id, 1.0e18, weth_raw, 0.997);
+        assert!(
+            g.edges_from(0)[0].filtered,
+            "0.5 WETH (raw 5e17) must be below floor 1.0 after decimal conversion"
+        );
+
+        // Bump just above the floor: 1.5 WETH = 1.5e18 wei → not filtered.
+        let weth_raw_ok = 1_500_000_000_000_000_000.0_f64;
+        g.update_edge_from_reserves(0, 1, pool_id, 1.0e18, weth_raw_ok, 0.997);
+        assert!(
+            !g.edges_from(0)[0].filtered,
+            "1.5 WETH must be above floor 1.0 after decimal conversion"
+        );
+    }
+
+    #[test]
+    fn test_add_edge_initializes_filtered_false() {
+        let mut g = PriceGraph::new(2);
+        let pool_id = make_pool_id(1, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 2.0, pool_id, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+        assert!(!g.all_edges()[0].filtered, "placeholder edge must start unfiltered");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Third defense-in-depth layer after the decimal-correctness fix (#151), targeting **dead / drained pools** that produce graph-math phantom cycles (wasted simulation compute, polluted detection metrics).

### 1. WETH-denominated minimum-liquidity floor (graph-level)
A constant-product pool holds equal value on both sides, so for a WETH-paired pool the WETH-side reserve (in human WETH) is a clean, oracle-free TVL proxy.
- `PriceEdge` gains a `filtered` flag; `PriceGraph` gains `weth_vertex` + `min_liquidity_weth`.
- `update_edge_from_reserves` marks an edge `filtered` when its WETH-side human reserve is below the floor.
- Bellman-Ford skips filtered edges in both the full scan and the affected-subgraph scan, so dead edges never seed a cycle.
- Wired into the engine (`EngineConfig.min_liquidity_weth`, default 1.0 WETH; aligns with the >$10K qualification rule), the scorer, and the replay driver.
- Pools not paired with WETH are left to existing gates. Backward-compatible: graphs that never register WETH keep `weth_vertex = None` and behave identically.

### 2. Replay driver applies the engine's pre-sim gating
The `aether-replay` diagnostic detector printed every raw cycle without the gating the engine applies, surfacing phantoms (e.g. a 102873197% `WETH→AAVE→WETH` from a transiently corrupted fork pool in full-block replay) that the engine already drops at the `profit_factor_impossible` cap.
- Moved `cycle_gating` from the binary crate into the lib (its only crate-internal dep is `EngineMetrics`, already re-exported) so both binaries share one implementation. **Engine behavior unchanged — code only relocated.**
- The replay now filters each detected batch through the same `gate_pre_sim` before counting / printing / optimizing.

## Why a floor alone wasn't enough
The observed AAVE phantom is a *wrong-price* fork artifact (ample WETH, drained non-WETH side), not low WETH liquidity — a liquidity floor structurally can't catch it. The production engine already gated it (`candidates=0`); part 2 brings the diagnostic detector in line.

## Verification
Full-block replay of block 24643151:
- before: `WETH→AAVE→WETH` at **102873197%**, theoretical net **+336428 ETH** (phantom)
- after: **0 cycles >100%**, theoretical net **+0.0000 ETH**

Quality gates: `cargo build --workspace`, `cargo clippy -- -D warnings`, and `cargo test -p aether-state -p aether-detector -p aether-grpc-server` all green; new unit tests for the floor (price_graph) and filtered-edge skipping (bellman_ford).

## Commits
- `feat(state)`: add WETH-denominated min-liquidity floor to exclude dead pools from detection
- `fix(replay)`: apply engine pre-sim gating to the diagnostic detector