### PR TITLE
fix(mempool): include victim raw signed tx in backrun bundles

### DIFF
--- a/cmd/executor/bundle.go
+++ b/cmd/executor/bundle.go
@@ -16,13 +16,17 @@ import (
 
 // Bundle represents a Flashbots-style bundle with signed transactions.
 //
-// For mempool-backrun source, `VictimTxHashHex` is set to the pending
-// victim's tx hash; the submitter prepends it to the `txs` array so the
-// envelope becomes `[victim_hash, our_arb_signed, our_tip_signed?]`.
-// `RevertingTxHashes` is populated with the hashes that may revert
-// without dropping the whole bundle — for mempool path this is the
-// our-arb tx hash only; never the victim hash (we want the bundle to
-// drop if the victim itself reverts).
+// For mempool-backrun source, the victim's RAW SIGNED transaction is placed
+// as `RawTxs[0]` (and `Transactions[0]` is left nil for it, since we only
+// hold the victim's encoded bytes, not a decoded *types.Transaction). Our
+// signed arb tx follows as `RawTxs[1]`. The `txs` array shipped to every
+// builder is therefore `[victim_raw, our_arb_signed]` — all real EIP-2718
+// raw transactions, never a bare hash. `VictimTxHashHex` is still populated
+// for dedup / metrics / logging but is no longer placed in the envelope.
+// `RevertingTxHashes` is populated with the hashes that may revert without
+// dropping the whole bundle — for the mempool path this is the our-arb tx
+// hash only; never the victim hash (we want the bundle to drop if the victim
+// itself reverts).
 type Bundle struct {
 	Transactions []*types.Transaction // Signed go-ethereum transactions
 	RawTxs       [][]byte             // RLP-encoded signed bytes (for eth_sendBundle)
@@ -35,9 +39,17 @@ type Bundle struct {
 	// pre-date #139.
 	Source string
 
+	// VictimRawTx is the canonical EIP-2718 raw signed bytes of the pending
+	// victim transaction, captured from the mempool by the Rust engine and
+	// carried over gRPC. It is placed as `RawTxs[0]` so the builder includes
+	// our arb iff the victim is mined in the same block. Empty for
+	// non-mempool bundles.
+	VictimRawTx []byte
+
 	// VictimTxHashHex is "0x"-prefixed when the bundle backruns a
-	// pending mempool tx; empty otherwise. Submitter consumes this to
-	// prepend the victim reference in the `txs` envelope.
+	// pending mempool tx; empty otherwise. Retained for dedup, metrics,
+	// and logging only — it is NOT placed in the `txs` envelope (the
+	// victim travels as the raw tx in RawTxs[0] instead).
 	VictimTxHashHex string
 
 	// RevertingTxHashes is the list of `[]string` hashes the bundle
@@ -122,11 +134,13 @@ func (bc *BundleConstructor) BuildBundle(
 // BuildMempoolBackrunBundle constructs a bundle that backruns a pending
 // victim transaction.
 //
-// Envelope: `[victim_tx_hash, our_arb_signed]`. The submitter prepends
-// the victim hash in `submitToBuilder`; this function returns a Bundle
-// whose `RawTxs` contains only our signed arb tx and whose
-// `VictimTxHashHex` carries the hash the builder needs to fetch from
-// its mempool view.
+// Envelope: `[victim_raw, our_arb_signed]`. The victim's RAW SIGNED
+// transaction (EIP-2718 encoded bytes captured from the mempool) is placed
+// as `RawTxs[0]`; our signed arb tx follows as `RawTxs[1]`. Every builder we
+// target (flashbots/titan/eden/rsync) defines `txs` as raw signed RLP
+// transactions and rejects a bare hash, so the victim must travel as a real
+// raw tx — not as its hash. `VictimTxHashHex` is still populated for dedup,
+// metrics, and logging.
 //
 // `revertingTxHashes` includes only the arb tx hash — we tolerate the
 // arb reverting (the bundle still mines without polluting the block)
@@ -140,12 +154,16 @@ func (bc *BundleConstructor) BuildMempoolBackrunBundle(
 	gasEstimate uint64,
 	targetBlock uint64,
 	victimTxHashHex string,
+	victimRawTx []byte,
 ) (*Bundle, error) {
 	if !strings.HasPrefix(victimTxHashHex, "0x") {
 		return nil, fmt.Errorf("victim_tx_hash must be 0x-prefixed, got %q", victimTxHashHex)
 	}
 	if len(victimTxHashHex) != 66 {
 		return nil, fmt.Errorf("victim_tx_hash must be 32 bytes (66 hex chars incl. 0x), got %d chars", len(victimTxHashHex))
+	}
+	if len(victimRawTx) == 0 {
+		return nil, fmt.Errorf("victim_raw_tx must be non-empty for mempool-backrun bundle (cannot submit a backrun without the victim's raw signed tx as txs[0])")
 	}
 
 	gasFees := bc.gasOracle.MempoolFees()
@@ -165,12 +183,16 @@ func (bc *BundleConstructor) BuildMempoolBackrunBundle(
 	})
 
 	if bc.signer == nil {
-		// Unsigned path is test-only; tip flow still requires a signer.
+		// Unsigned path is test-only. We still seat the victim raw tx as
+		// RawTxs[0] so the envelope ordering is exercised; our arb tx is
+		// unsigned so it has no raw bytes to append.
 		return &Bundle{
 			Transactions:      []*types.Transaction{arbTx},
+			RawTxs:            [][]byte{victimRawTx},
 			BlockNumber:       targetBlock,
 			Timestamp:         time.Now(),
 			Source:            SourceMempoolBackrun,
+			VictimRawTx:       victimRawTx,
 			VictimTxHashHex:   victimTxHashHex,
 			RevertingTxHashes: []string{arbTx.Hash().Hex()},
 		}, nil
@@ -185,12 +207,14 @@ func (bc *BundleConstructor) BuildMempoolBackrunBundle(
 		return nil, fmt.Errorf("RLP-encode mempool-backrun arb tx: %w", err)
 	}
 
+	// Envelope ordering: victim raw signed tx first, then our signed arb.
 	return &Bundle{
 		Transactions:      []*types.Transaction{signed},
-		RawTxs:            [][]byte{raw},
+		RawTxs:            [][]byte{victimRawTx, raw},
 		BlockNumber:       targetBlock,
 		Timestamp:         time.Now(),
 		Source:            SourceMempoolBackrun,
+		VictimRawTx:       victimRawTx,
 		VictimTxHashHex:   victimTxHashHex,
 		RevertingTxHashes: []string{signed.Hash().Hex()},
 	}, nil

--- a/cmd/executor/bundle_test.go
+++ b/cmd/executor/bundle_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"math/big"
 	"testing"
@@ -182,6 +183,12 @@ func intETHToWei(t *testing.T, eth int64) *big.Int {
 
 const victimHashHex = "0xdeadbeef00000000000000000000000000000000000000000000000000000001"
 
+// victimRawTxBytes stands in for the canonical EIP-2718 raw signed bytes of
+// the pending victim tx that the Rust engine captures from the mempool and
+// ships over gRPC. The contents are opaque to the executor; only ordering
+// and presence matter here.
+var victimRawTxBytes = []byte{0x02, 0xF8, 0x6B, 0x01, 0x02, 0x03, 0x04}
+
 func newBundleConstructorForTest(t *testing.T) *BundleConstructor {
 	t.Helper()
 	nm := NewNonceManager(0)
@@ -203,6 +210,7 @@ func TestBuildMempoolBackrunBundle_HappyPath(t *testing.T) {
 		500000,
 		18_000_001,
 		victimHashHex,
+		victimRawTxBytes,
 	)
 	if err != nil {
 		t.Fatalf("BuildMempoolBackrunBundle: %v", err)
@@ -214,8 +222,21 @@ func TestBuildMempoolBackrunBundle_HappyPath(t *testing.T) {
 	if bundle.VictimTxHashHex != victimHashHex {
 		t.Errorf("VictimTxHashHex: want %s, got %s", victimHashHex, bundle.VictimTxHashHex)
 	}
-	if len(bundle.RawTxs) != 1 {
-		t.Fatalf("RawTxs: want 1 (just our arb), got %d", len(bundle.RawTxs))
+	// Envelope must be [victim_raw, our_arb_signed]: the victim's raw signed
+	// tx first, our signed arb second.
+	if len(bundle.RawTxs) != 2 {
+		t.Fatalf("RawTxs: want 2 ([victim_raw, our_arb]), got %d", len(bundle.RawTxs))
+	}
+	if !bytes.Equal(bundle.RawTxs[0], victimRawTxBytes) {
+		t.Fatalf("RawTxs[0] must be the supplied victim raw tx; want %x, got %x",
+			victimRawTxBytes, bundle.RawTxs[0])
+	}
+	arbRaw, err := bundle.Transactions[0].MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal arb tx: %v", err)
+	}
+	if !bytes.Equal(bundle.RawTxs[1], arbRaw) {
+		t.Fatalf("RawTxs[1] must be our signed arb tx raw bytes")
 	}
 	if len(bundle.RevertingTxHashes) != 1 {
 		t.Fatalf("RevertingTxHashes len: want 1, got %d", len(bundle.RevertingTxHashes))
@@ -229,6 +250,23 @@ func TestBuildMempoolBackrunBundle_HappyPath(t *testing.T) {
 	}
 	if bundle.BlockNumber != 18_000_001 {
 		t.Errorf("BlockNumber: want 18_000_001, got %d", bundle.BlockNumber)
+	}
+}
+
+func TestBuildMempoolBackrunBundle_RejectsEmptyVictimRawTx(t *testing.T) {
+	t.Parallel()
+
+	bc := newBundleConstructorForTest(t)
+	_, err := bc.BuildMempoolBackrunBundle(
+		[]byte{0xAB, 0xCD},
+		"0x1234567890abcdef1234567890abcdef12345678",
+		500000,
+		18_000_001,
+		victimHashHex,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for empty victim_raw_tx, got nil")
 	}
 }
 
@@ -248,7 +286,7 @@ func TestBuildMempoolBackrunBundle_RejectsBadVictimHash(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := bc.BuildMempoolBackrunBundle([]byte{0x01}, "0x1234567890abcdef1234567890abcdef12345678", 100000, 1, c.hash)
+			_, err := bc.BuildMempoolBackrunBundle([]byte{0x01}, "0x1234567890abcdef1234567890abcdef12345678", 100000, 1, c.hash, []byte{0x02})
 			if err == nil {
 				t.Fatalf("expected error for %s, got nil", c.name)
 			}
@@ -263,18 +301,25 @@ func TestBuildMempoolBackrunBundle_UnsignedFallback(t *testing.T) {
 	go_ := NewGasOracle(300.0)
 	bc := NewBundleConstructor(nm, go_, nil, 1)
 
+	victimRaw := []byte{0x02, 0xCA, 0xFE}
 	bundle, err := bc.BuildMempoolBackrunBundle(
 		[]byte{0xAB},
 		"0x1234567890abcdef1234567890abcdef12345678",
 		200000,
 		18_000_001,
 		victimHashHex,
+		victimRaw,
 	)
 	if err != nil {
 		t.Fatalf("unsigned BuildMempoolBackrunBundle: %v", err)
 	}
-	if len(bundle.RawTxs) != 0 {
-		t.Errorf("unsigned bundle should have no RawTxs, got %d", len(bundle.RawTxs))
+	// Even on the unsigned (test-only) path the victim raw tx is seated as
+	// RawTxs[0]; only our arb tx is unsigned and therefore has no raw bytes.
+	if len(bundle.RawTxs) != 1 {
+		t.Fatalf("unsigned bundle should carry only the victim raw tx, got %d RawTxs", len(bundle.RawTxs))
+	}
+	if !bytes.Equal(bundle.RawTxs[0], victimRaw) {
+		t.Errorf("RawTxs[0]: want victim raw %x, got %x", victimRaw, bundle.RawTxs[0])
 	}
 	if len(bundle.Transactions) != 1 {
 		t.Errorf("expected 1 unsigned transaction, got %d", len(bundle.Transactions))

--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -466,7 +466,23 @@ func processArb(
 	if sourceLbl == SourceMempoolBackrun {
 		buildStart := time.Now()
 		victimHex := "0x" + hex.EncodeToString(arb.VictimTxHash)
-		bundle, err = bundler.BuildMempoolBackrunBundle(arb.Calldata, executorAddr, arb.TotalGas, targetBlock, victimHex)
+		victimRawTx := arb.GetVictimRawTx()
+		// A mempool-backrun bundle MUST carry the victim's raw signed tx as
+		// txs[0]; without it the bundle would land our arb unconditionally
+		// (no victim coupling), which is the exact bug this path fixes.
+		if len(victimRawTx) == 0 {
+			recordMempoolMissingVictimRawTx()
+			buildSpan.SetStatus(codes.Error, "missing victim_raw_tx")
+			buildSpan.End()
+			slog.ErrorContext(ctx, "mempool arb missing victim_raw_tx, skipping",
+				"arb_id", arb.Id,
+				"victim_tx_hash", victimHex,
+				"target_block", targetBlock,
+			)
+			span.SetAttributes(attribute.String("outcome", "missing_victim_raw_tx"))
+			return false, nil
+		}
+		bundle, err = bundler.BuildMempoolBackrunBundle(arb.Calldata, executorAddr, arb.TotalGas, targetBlock, victimHex, victimRawTx)
 		recordMempoolBundleBuildLatency(time.Since(buildStart))
 		slog.InfoContext(ctx, "mempool_arb_received",
 			"arb_id", arb.Id,
@@ -988,10 +1004,10 @@ func dumpMempoolShadowBundle(
 	gasCostWei := new(big.Int).Mul(new(big.Int).SetUint64(arb.TotalGas), gasFees.MaxFeePerGas)
 	grossProfitWei := new(big.Int).Add(netProfitWei, gasCostWei)
 
-	envelopeTxs := make([]string, 0, 1+len(bundle.RawTxs))
-	if bundle.VictimTxHashHex != "" {
-		envelopeTxs = append(envelopeTxs, bundle.VictimTxHashHex)
-	}
+	// RawTxs[0] is already the victim's raw signed tx for mempool bundles,
+	// so the envelope is simply the hex of every RawTxs entry — no separate
+	// victim-hash prepend.
+	envelopeTxs := make([]string, 0, len(bundle.RawTxs))
 	for _, raw := range bundle.RawTxs {
 		envelopeTxs = append(envelopeTxs, fmt.Sprintf("0x%x", raw))
 	}

--- a/cmd/executor/mempool_risk_test.go
+++ b/cmd/executor/mempool_risk_test.go
@@ -350,9 +350,10 @@ func TestDumpMempoolShadowBundle_Schema(t *testing.T) {
 		TargetBlock:     24_000_001,
 	}
 	bundle := &Bundle{
-		RawTxs:            [][]byte{{0xf8, 0x6b}},
+		RawTxs:            [][]byte{{0x02, 0xbe, 0xef}, {0xf8, 0x6b}},
 		BlockNumber:       24_000_001,
 		Source:            SourceMempoolBackrun,
+		VictimRawTx:       []byte{0x02, 0xbe, 0xef},
 		VictimTxHashHex:   "0xdeadbeef",
 		RevertingTxHashes: []string{"0xarbtx"},
 	}
@@ -426,11 +427,17 @@ func TestDumpMempoolShadowBundle_Schema(t *testing.T) {
 		t.Errorf("first gate = %v", first)
 	}
 
-	// Envelope must lead with the victim hash, followed by our raw arb.
+	// Envelope must lead with the victim's RAW signed tx (never a bare hash —
+	// builders reject hashes in eth_sendBundle), followed by our raw arb.
 	env := payload["envelope"].(map[string]interface{})
 	txs := env["txs"].([]interface{})
-	if len(txs) != 2 || txs[0] != "0xdeadbeef" {
-		t.Errorf("envelope.txs = %v, want [victim_hash, raw_arb]", txs)
+	if len(txs) != 2 || txs[0] != "0x02beef" || txs[1] != "0xf86b" {
+		t.Errorf("envelope.txs = %v, want [victim_raw, raw_arb]", txs)
+	}
+	for _, tx := range txs {
+		if tx == "0xdeadbeef" {
+			t.Fatal("victim hash leaked into envelope.txs — builders reject bare hashes")
+		}
 	}
 	// revertingTxHashes must be the arb hash only — never the victim.
 	rev := env["revertingTxHashes"].([]interface{})

--- a/cmd/executor/metrics.go
+++ b/cmd/executor/metrics.go
@@ -66,6 +66,10 @@ var (
 		Name: "aether_executor_risk_rejections_total",
 		Help: "Total arbs rejected by preflight risk checks",
 	})
+	mempoolMissingVictimRawTx = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "aether_executor_mempool_missing_victim_raw_tx_total",
+		Help: "Mempool-backrun arbs skipped because the gRPC message carried an empty victim_raw_tx (cannot build a safe backrun bundle without it).",
+	})
 	endToEndLatencyMs = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "aether_end_to_end_latency_ms",
 		Help:    "End-to-end latency from arb detection to bundle submission in ms",
@@ -130,6 +134,7 @@ func init() {
 		profitTotalWei,
 		gasSpentWei,
 		riskRejections,
+		mempoolMissingVictimRawTx,
 		endToEndLatencyMs,
 		gasPriceGwei,
 		dailyPnlEth,
@@ -216,6 +221,10 @@ func recordMempoolBundleBuildLatency(d time.Duration) {
 
 func recordRiskRejection() {
 	riskRejections.Inc()
+}
+
+func recordMempoolMissingVictimRawTx() {
+	mempoolMissingVictimRawTx.Inc()
 }
 
 func recordBuilderResult(builder string, success bool, latency time.Duration) {

--- a/cmd/executor/submitter.go
+++ b/cmd/executor/submitter.go
@@ -227,19 +227,15 @@ func (s *Submitter) submitToBuilder(ctx context.Context, builder BuilderConfig, 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Hex-encode each raw signed transaction. Mempool-backrun bundles
-	// prepend the pending victim tx hash so the builder pulls the victim
-	// from its own mempool view; block-driven bundles ship only the
-	// signed RawTxs.
-	signedHexes := make([]string, len(bundle.RawTxs))
+	// Hex-encode each raw signed transaction. For mempool-backrun bundles,
+	// RawTxs[0] is already the victim's raw signed tx (seated by
+	// BuildMempoolBackrunBundle) followed by our signed arb; block-driven
+	// bundles ship only our signed RawTxs. Every entry is a full EIP-2718
+	// raw transaction — builders reject a bare hash.
+	txHexes := make([]string, len(bundle.RawTxs))
 	for i, raw := range bundle.RawTxs {
-		signedHexes[i] = "0x" + hex.EncodeToString(raw)
+		txHexes[i] = "0x" + hex.EncodeToString(raw)
 	}
-	var txHexes []string
-	if bundle.VictimTxHashHex != "" {
-		txHexes = append(txHexes, bundle.VictimTxHashHex)
-	}
-	txHexes = append(txHexes, signedHexes...)
 
 	params := map[string]interface{}{
 		"txs":         txHexes,

--- a/cmd/executor/submitter_test.go
+++ b/cmd/executor/submitter_test.go
@@ -639,10 +639,14 @@ func TestSubmitToBuilder_MempoolBackrunEnvelope(t *testing.T) {
 		t.Fatalf("NewSubmitter: %v", err)
 	}
 
+	// Victim's raw signed tx is seated as RawTxs[0]; our arb is RawTxs[1].
+	// The envelope must ship both as raw hex — never a bare victim hash.
+	victimRaw := []byte{0x02, 0xde, 0xad}
 	bundle := &Bundle{
 		BlockNumber:       0x112A881,
-		RawTxs:            [][]byte{{0xaa, 0xbb}},
+		RawTxs:            [][]byte{victimRaw, {0xaa, 0xbb}},
 		Source:            SourceMempoolBackrun,
+		VictimRawTx:       victimRaw,
 		VictimTxHashHex:   victimHash,
 		RevertingTxHashes: []string{"0x1111111111111111111111111111111111111111111111111111111111111111"},
 	}
@@ -661,13 +665,18 @@ func TestSubmitToBuilder_MempoolBackrunEnvelope(t *testing.T) {
 	params := req.Params[0]
 	txs := params["txs"].([]interface{})
 	if len(txs) != 2 {
-		t.Fatalf("expected [victim_hash, our_arb] (2 entries), got %d", len(txs))
+		t.Fatalf("expected [victim_raw, our_arb] (2 entries), got %d", len(txs))
 	}
-	if txs[0].(string) != victimHash {
-		t.Errorf("txs[0] = %s, want victim hash %s", txs[0], victimHash)
+	if txs[0].(string) != "0x02dead" {
+		t.Errorf("txs[0] = %s, want victim raw 0x02dead", txs[0])
 	}
 	if txs[1].(string) != "0xaabb" {
 		t.Errorf("txs[1] = %s, want our_arb 0xaabb", txs[1])
+	}
+	for i, tx := range txs {
+		if tx.(string) == victimHash {
+			t.Fatalf("victim hash leaked into txs[%d] — builders reject bare hashes in eth_sendBundle", i)
+		}
 	}
 	reverting, ok := params["revertingTxHashes"].([]interface{})
 	if !ok {

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -1133,6 +1133,7 @@ fn run_backrun_validation(
         source: aether_proto::ArbSource::MempoolBackrun as i32,
         victim_tx_hash: event.tx_hash.0.to_vec().into(),
         target_block: block_number.saturating_add(1),
+        victim_raw_tx: event.raw_tx.clone().into(),
     };
 
     if let Err(e) = publisher.send(proto) {
@@ -1436,6 +1437,7 @@ mod tests {
             input,
             gas_price: 0,
             first_seen_unix_nanos: 0,
+            raw_tx: vec![],
         }
     }
 

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -1658,6 +1658,7 @@ mod tests {
             input: vec![],
             gas_price: 0,
             first_seen_unix_nanos: 0,
+            raw_tx: vec![],
         }
     }
 

--- a/crates/grpc-server/src/pipeline.rs
+++ b/crates/grpc-server/src/pipeline.rs
@@ -106,6 +106,7 @@ pub fn validated_arb_to_proto(arb: &ValidatedArb) -> aether_proto::ValidatedArb 
         source: aether_proto::ArbSource::BlockDriven as i32,
         victim_tx_hash: Bytes::new(),
         target_block: arb.block_number.saturating_add(1),
+        victim_raw_tx: Bytes::new(),
     }
 }
 
@@ -160,6 +161,7 @@ pub fn build_validated_arb(
         source: aether_proto::ArbSource::BlockDriven as i32,
         victim_tx_hash: Bytes::new(),
         target_block: opportunity.block_number.saturating_add(1),
+        victim_raw_tx: Bytes::new(),
     }
 }
 

--- a/crates/ingestion/Cargo.toml
+++ b/crates/ingestion/Cargo.toml
@@ -13,5 +13,6 @@ dashmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
+prometheus = "0.13.4"
 async-trait = "0.1"
 futures = "0.3"

--- a/crates/ingestion/src/lib.rs
+++ b/crates/ingestion/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod event_decoder;
 pub mod mempool;
+pub mod metrics;
 pub mod node_pool;
 pub mod subscription;

--- a/crates/ingestion/src/mempool.rs
+++ b/crates/ingestion/src/mempool.rs
@@ -26,7 +26,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alloy::consensus::Transaction as TransactionTrait;
-use alloy::primitives::Address;
+use alloy::eips::eip2718::Encodable2718;
+use alloy::primitives::{keccak256, Address};
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
 use alloy::rpc::types::Transaction;
 use futures::StreamExt;
@@ -34,6 +35,7 @@ use serde_json::json;
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
 
+use crate::metrics::MempoolIngestMetrics;
 use crate::subscription::{EventChannels, PendingTxEvent};
 
 /// Default reconnect backoff after a transport error.
@@ -108,12 +110,31 @@ pub trait MempoolSource: Send + Sync {
 /// Alchemy `alchemy_pendingTransactions` WebSocket subscription.
 pub struct AlchemyMempool {
     config: AlchemyMempoolConfig,
+    /// Ingestion metrics. `None` keeps the source usable in tests / dev
+    /// without standing up a Prometheus registry; the re-encode mismatch
+    /// gate then surfaces only through the `warn!` log.
+    metrics: Option<Arc<MempoolIngestMetrics>>,
 }
 
 impl AlchemyMempool {
+    /// Construct without metrics. The re-encode mismatch gate still drops
+    /// bad events and logs a `warn!`, but no counter is incremented.
     pub fn new(config: AlchemyMempoolConfig) -> Self {
         warn_if_non_alchemy_endpoint(&config.ws_url);
-        Self { config }
+        Self {
+            config,
+            metrics: None,
+        }
+    }
+
+    /// Construct with an ingestion metrics handle so the re-encode mismatch
+    /// gate increments `aether_mempool_raw_reencode_mismatch_total`.
+    pub fn with_metrics(config: AlchemyMempoolConfig, metrics: Arc<MempoolIngestMetrics>) -> Self {
+        warn_if_non_alchemy_endpoint(&config.ws_url);
+        Self {
+            config,
+            metrics: Some(metrics),
+        }
     }
 
     /// One subscription attempt: connect, subscribe, drain, return on error.
@@ -169,11 +190,20 @@ impl AlchemyMempool {
     }
 
     /// Map an alloy [`Transaction`] into the workspace [`PendingTxEvent`] and
-    /// dispatch it. Lossy by design — any field we don't surface today (gas
-    /// limit, type, access list) is recoverable via the tx hash later.
+    /// dispatch it. Lossy for the scalar fields by design — anything we don't
+    /// surface today (gas limit, access list) is recoverable via the tx hash
+    /// later — but the canonical EIP-2718 signed bytes are captured verbatim
+    /// in `raw_tx` for the backrun bundle path.
+    ///
+    /// The raw bytes are re-encoded from the recovered envelope and gated by a
+    /// keccak256 round-trip: if `keccak256(raw_tx)` does not equal the
+    /// subscription-reported tx hash, the bytes are untrustworthy (we would
+    /// place the wrong tx as `txs[0]` in the bundle) so the event is dropped
+    /// and `aether_mempool_raw_reencode_mismatch_total` is incremented.
     fn forward(&self, channels: &EventChannels, tx: Transaction) {
         let from = tx.inner.signer();
         let envelope = tx.as_ref();
+        let tx_hash = *envelope.tx_hash();
         let to: Option<Address> = envelope.kind().to().copied();
         // Stamp first-seen at the moment we hand the event off so the
         // downstream tracker can compute inclusion latency against
@@ -184,24 +214,57 @@ impl AlchemyMempool {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos() as u64)
             .unwrap_or(0);
+        let value = envelope.value();
+        let input = envelope.input().to_vec();
+        let gas_price = envelope.max_fee_per_gas();
+
+        // Canonical EIP-2718 signed bytes, re-encoded from the recovered
+        // envelope, then verified against the reported hash.
+        let raw_tx = tx.inner.inner().encoded_2718();
+        if !raw_tx_matches_hash(&raw_tx, tx_hash) {
+            if let Some(metrics) = &self.metrics {
+                metrics.inc_raw_reencode_mismatch();
+            }
+            warn!(
+                target: "aether::mempool",
+                tx_hash = %tx_hash,
+                raw_len = raw_tx.len(),
+                "pending tx dropped: EIP-2718 re-encode did not hash back to reported tx hash"
+            );
+            return;
+        }
+
         let event = PendingTxEvent {
-            tx_hash: *envelope.tx_hash(),
+            tx_hash,
             from,
             to,
-            value: envelope.value(),
-            input: envelope.input().to_vec(),
-            gas_price: envelope.max_fee_per_gas(),
+            value,
+            input,
+            gas_price,
             first_seen_unix_nanos,
+            raw_tx,
         };
         debug!(
             target: "aether::mempool",
             tx_hash = %event.tx_hash,
             to = ?event.to,
             input_len = event.input.len(),
+            raw_len = event.raw_tx.len(),
             "pending tx forwarded"
         );
         channels.dispatch_pending_tx(event);
     }
+}
+
+/// Verify that canonical EIP-2718 signed bytes hash back to the expected tx
+/// hash. The tx hash of any typed/legacy Ethereum transaction is precisely
+/// `keccak256` of its canonical 2718 encoding, so this is a bit-exact gate on
+/// whether `raw_tx` is the genuine signed payload for `expected_hash`.
+///
+/// Extracted as a free function so it can be unit-tested against known
+/// signed-tx vectors without a live WebSocket source.
+fn raw_tx_matches_hash(raw_tx: &[u8], expected_hash: alloy::primitives::B256) -> bool {
+    keccak256(raw_tx) == expected_hash
 }
 
 #[async_trait::async_trait]
@@ -352,5 +415,87 @@ mod tests {
         sorted.sort();
         sorted.dedup();
         assert_eq!(sorted.len(), v.len(), "duplicate addresses in default set");
+    }
+
+    /// Build a real signed EIP-1559 transaction and return its canonical
+    /// EIP-2718 bytes alongside the envelope's own tx hash. This is the same
+    /// signing path a wallet uses, so the bytes and hash form a genuine vector
+    /// for exercising the re-encode gate.
+    fn signed_tx_vector() -> (Vec<u8>, alloy::primitives::B256) {
+        use alloy::consensus::{SignableTransaction, TxEip1559, TxEnvelope};
+        use alloy::primitives::{address, TxKind, U256 as AlloyU256};
+        use alloy::signers::{local::PrivateKeySigner, SignerSync};
+
+        // Deterministic key so the vector is stable across runs.
+        let signer: PrivateKeySigner = "0x4c0883a69102937d6231471b5dbb6204fe512961708279f2e3e8a5d4b8e3e3e3"
+            .parse()
+            .expect("valid private key hex");
+
+        let tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 7,
+            gas_limit: 21_000,
+            max_fee_per_gas: 30_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            to: TxKind::Call(address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D")),
+            value: AlloyU256::from(1_000_000_000_000_000_000u64),
+            access_list: Default::default(),
+            input: vec![0xde, 0xad, 0xbe, 0xef].into(),
+        };
+
+        let sig = signer
+            .sign_hash_sync(&tx.signature_hash())
+            .expect("sign tx");
+        let envelope: TxEnvelope = tx.into_signed(sig).into();
+        let raw = envelope.encoded_2718();
+        let hash = *envelope.tx_hash();
+        (raw, hash)
+    }
+
+    #[test]
+    fn raw_tx_matches_hash_accepts_genuine_signed_bytes() {
+        let (raw, hash) = signed_tx_vector();
+        // The reported tx hash is keccak256 of the canonical 2718 encoding.
+        assert_eq!(keccak256(&raw), hash);
+        assert!(
+            raw_tx_matches_hash(&raw, hash),
+            "genuine signed bytes must pass the re-encode gate"
+        );
+    }
+
+    #[test]
+    fn raw_tx_matches_hash_rejects_tampered_payload() {
+        let (mut raw, hash) = signed_tx_vector();
+        // Flip a byte in the signed payload: the hash no longer matches.
+        let last = raw.len() - 1;
+        raw[last] ^= 0xff;
+        assert!(
+            !raw_tx_matches_hash(&raw, hash),
+            "tampered payload must fail the re-encode gate"
+        );
+    }
+
+    #[test]
+    fn mismatch_gate_bumps_counter_and_drops() {
+        // Simulate exactly what `forward` does on a mismatch: a tampered
+        // payload fails the gate, so the metrics counter is incremented and
+        // the event is dropped (never dispatched). We assert the counter
+        // accounting here because `forward` requires a live `Transaction`.
+        let registry = prometheus::Registry::new();
+        let metrics = MempoolIngestMetrics::register(&registry);
+
+        let (mut raw, hash) = signed_tx_vector();
+        let last = raw.len() - 1;
+        raw[last] ^= 0xff;
+
+        assert_eq!(metrics.raw_reencode_mismatch_count(), 0);
+        if !raw_tx_matches_hash(&raw, hash) {
+            metrics.inc_raw_reencode_mismatch();
+        }
+        assert_eq!(
+            metrics.raw_reencode_mismatch_count(),
+            1,
+            "mismatch must bump aether_mempool_raw_reencode_mismatch_total"
+        );
     }
 }

--- a/crates/ingestion/src/metrics.rs
+++ b/crates/ingestion/src/metrics.rs
@@ -1,0 +1,85 @@
+//! Prometheus surface for the mempool ingestion (subscription) layer.
+//!
+//! This is the metrics module the mempool *transport* path uses. The
+//! decode pipeline's funnel counters live downstream in the gRPC engine
+//! (`aether_grpc_server::metrics::EngineMetrics`), but a handful of signals
+//! can only be observed at the subscription boundary — before any
+//! `PendingTxEvent` is broadcast — and so must be counted here.
+//!
+//! Registered against the engine's shared `prometheus::Registry` exactly
+//! like [`aether_common::db::LedgerMetrics`] so a single `/metrics` endpoint
+//! emits everything. The struct is cheap to clone-via-`Arc` and is handed to
+//! [`crate::mempool::AlchemyMempool`] at construction.
+
+use std::sync::Arc;
+
+use prometheus::{IntCounter, Registry};
+
+/// Metric families owned by the mempool ingestion layer.
+pub struct MempoolIngestMetrics {
+    raw_reencode_mismatch_total: IntCounter,
+}
+
+impl MempoolIngestMetrics {
+    /// Register all ingestion metrics on the provided `Registry`.
+    ///
+    /// Panics on duplicate registration — this is startup code and a
+    /// duplicate indicates a programmer error, not a runtime condition.
+    pub fn register(registry: &Registry) -> Arc<Self> {
+        let raw_reencode_mismatch_total = IntCounter::new(
+            "aether_mempool_raw_reencode_mismatch_total",
+            "Pending victim txs dropped because the canonical EIP-2718 re-encode \
+             did not hash back to the subscription-reported tx hash",
+        )
+        .expect("aether_mempool_raw_reencode_mismatch_total counter");
+
+        registry
+            .register(Box::new(raw_reencode_mismatch_total.clone()))
+            .expect("register aether_mempool_raw_reencode_mismatch_total");
+
+        Arc::new(Self {
+            raw_reencode_mismatch_total,
+        })
+    }
+
+    /// Bump `aether_mempool_raw_reencode_mismatch_total`. Called when a
+    /// re-encoded raw tx fails the keccak256 round-trip gate and the event
+    /// is dropped at the subscription boundary.
+    pub fn inc_raw_reencode_mismatch(&self) {
+        self.raw_reencode_mismatch_total.inc();
+    }
+
+    /// Read the current value of `aether_mempool_raw_reencode_mismatch_total`.
+    /// Public so tests can assert the gate fires without re-implementing
+    /// Prometheus text parsing.
+    pub fn raw_reencode_mismatch_count(&self) -> u64 {
+        self.raw_reencode_mismatch_total.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_round_trips_and_increments() {
+        let registry = Registry::new();
+        let m = MempoolIngestMetrics::register(&registry);
+        assert_eq!(m.raw_reencode_mismatch_count(), 0);
+        m.inc_raw_reencode_mismatch();
+        m.inc_raw_reencode_mismatch();
+        assert_eq!(m.raw_reencode_mismatch_count(), 2);
+
+        let names: Vec<_> = registry
+            .gather()
+            .iter()
+            .map(|f| f.get_name().to_string())
+            .collect();
+        assert!(
+            names
+                .iter()
+                .any(|n| n == "aether_mempool_raw_reencode_mismatch_total"),
+            "missing metric family aether_mempool_raw_reencode_mismatch_total"
+        );
+    }
+}

--- a/crates/ingestion/src/subscription.rs
+++ b/crates/ingestion/src/subscription.rs
@@ -46,6 +46,12 @@ pub struct PendingTxEvent {
     pub input: Vec<u8>,
     pub gas_price: u128,
     pub first_seen_unix_nanos: u64,
+    /// Canonical EIP-2718 signed bytes of the pending tx, captured at the
+    /// subscription boundary. Used by the mempool-backrun path to place the
+    /// victim as `txs[0]` in the Flashbots bundle. Empty only when the source
+    /// could not produce verified raw bytes (such events are dropped before
+    /// dispatch on the backrun path).
+    pub raw_tx: Vec<u8>,
 }
 
 impl EventChannels {
@@ -209,6 +215,7 @@ mod tests {
             value: U256::from(1_000_000_000_000_000_000u64),
             input: vec![0xaa, 0xbb],
             gas_price: 50_000_000_000,
+            raw_tx: vec![0x02, 0xcc],
             ..Default::default()
         };
 
@@ -381,12 +388,14 @@ mod tests {
             value: U256::from(1u64),
             input: vec![0x01, 0x02],
             gas_price: 100,
+            raw_tx: vec![0x02, 0x03, 0x04],
             ..Default::default()
         };
         let cloned = event.clone();
         assert_eq!(cloned.tx_hash, event.tx_hash);
         assert_eq!(cloned.input, event.input);
         assert_eq!(cloned.gas_price, event.gas_price);
+        assert_eq!(cloned.raw_tx, event.raw_tx);
     }
 
     #[test]

--- a/internal/pb/aether.pb.go
+++ b/internal/pb/aether.pb.go
@@ -400,7 +400,12 @@ type ValidatedArb struct {
 	// Slot the bundle is targeting. For BLOCK_DRIVEN this matches
 	// block_number+1; for MEMPOOL_BACKRUN it matches the block the
 	// builder is currently constructing.
-	TargetBlock   uint64 `protobuf:"varint,15,opt,name=target_block,json=targetBlock,proto3" json:"target_block,omitempty"`
+	TargetBlock uint64 `protobuf:"varint,15,opt,name=target_block,json=targetBlock,proto3" json:"target_block,omitempty"`
+	// Canonical EIP-2718 raw signed bytes of the pending victim tx, captured
+	// at the mempool subscription boundary. Empty unless source is
+	// MEMPOOL_BACKRUN. The Go executor places this as txs[0] in the bundle so
+	// the builder includes our arb iff the victim is included in the same block.
+	VictimRawTx   []byte `protobuf:"bytes,16,opt,name=victim_raw_tx,json=victimRawTx,proto3" json:"victim_raw_tx,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -538,6 +543,13 @@ func (x *ValidatedArb) GetTargetBlock() uint64 {
 		return x.TargetBlock
 	}
 	return 0
+}
+
+func (x *ValidatedArb) GetVictimRawTx() []byte {
+	if x != nil {
+		return x.VictimRawTx
+	}
+	return nil
 }
 
 type SubmitArbResponse struct {
@@ -984,7 +996,7 @@ const file_proto_aether_proto_rawDesc = "" +
 	"\ttoken_out\x18\x04 \x01(\fR\btokenOut\x12\x1b\n" +
 	"\tamount_in\x18\x05 \x01(\fR\bamountIn\x12!\n" +
 	"\fexpected_out\x18\x06 \x01(\fR\vexpectedOut\x12#\n" +
-	"\restimated_gas\x18\a \x01(\x04R\festimatedGas\"\xa3\x04\n" +
+	"\restimated_gas\x18\a \x01(\x04R\festimatedGas\"\xc7\x04\n" +
 	"\fValidatedArb\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\"\n" +
 	"\x04hops\x18\x02 \x03(\v2\x0e.aether.ArbHopR\x04hops\x12(\n" +
@@ -1002,7 +1014,8 @@ const file_proto_aether_proto_rawDesc = "" +
 	"\bcalldata\x18\f \x01(\fR\bcalldata\x12)\n" +
 	"\x06source\x18\r \x01(\x0e2\x11.aether.ArbSourceR\x06source\x12$\n" +
 	"\x0evictim_tx_hash\x18\x0e \x01(\fR\fvictimTxHash\x12!\n" +
-	"\ftarget_block\x18\x0f \x01(\x04R\vtargetBlock\"f\n" +
+	"\ftarget_block\x18\x0f \x01(\x04R\vtargetBlock\x12\"\n" +
+	"\rvictim_raw_tx\x18\x10 \x01(\fR\vvictimRawTx\"f\n" +
 	"\x11SubmitArbResponse\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12\x1f\n" +
 	"\vbundle_hash\x18\x02 \x01(\tR\n" +

--- a/proto/aether.proto
+++ b/proto/aether.proto
@@ -92,6 +92,11 @@ message ValidatedArb {
     // block_number+1; for MEMPOOL_BACKRUN it matches the block the
     // builder is currently constructing.
     uint64 target_block = 15;
+    // Canonical EIP-2718 raw signed bytes of the pending victim tx, captured
+    // at the mempool subscription boundary. Empty unless source is
+    // MEMPOOL_BACKRUN. The Go executor places this as txs[0] in the bundle so
+    // the builder includes our arb iff the victim is included in the same block.
+    bytes victim_raw_tx = 16;
 }
 
 message SubmitArbResponse {


### PR DESCRIPTION
## Problem

The mempool-backrun path prepended only the victim's **tx hash** into the Flashbots `eth_sendBundle` `txs` array. All four configured builders (flashbots, titan, eden, rsync) define `txs` as a list of **raw signed RLP transactions** and reject bare hashes — so backrun bundles were malformed/rejected across the entire fan-out. Hash references are exclusively a `mev_sendBundle` (MEV-Share) feature, not part of the `eth_sendBundle` contract.

## Fix (ship the victim's raw signed tx as `txs[0]`)

The victim's signature was being discarded at ingestion (`PendingTxEvent` carried only from/to/value/input/gas_price). This PR captures the raw signed tx and threads it end-to-end so the bundle lands **iff** the victim lands — a builder/bundle-level guarantee, not something our own tx can express.

**Rust + proto** (`68464d0`)
- Re-encode the pending victim tx to canonical EIP-2718 bytes at the Alchemy subscription boundary via alloy `encoded_2718()`.
- Correctness gate: verify `keccak256(raw) == tx_hash`; on mismatch, drop the event and bump `aether_mempool_raw_reencode_mismatch_total`. No extra RPC — bytes derive from the subscription payload (hot-path safe).
- New field `ValidatedArb.victim_raw_tx = 16`; `raw_tx` threaded through `PendingTxEvent` into the publisher.

**Go** (`65bdc9e`)
- Place the victim's raw signed tx as `RawTxs[0]` ahead of our signed arb; drop the bare-hash prepend in the submitter and the shadow-dump envelope.
- `revertingTxHashes` still **excludes** the victim hash, so the bundle drops if the victim reverts (adverse-fill protection preserved).
- Skip MEMPOOL_BACKRUN arbs that arrive without `victim_raw_tx` rather than submit an uncoupled bundle.

## Behavior

- Victim pays its own gas (it's their signed tx).
- If the victim is mined elsewhere first, its nonce is consumed → our bundle is invalid → drops → arb never lands, no gas cost. Safe outcome.
- Works on all four builders with no per-builder branching.

## Testing

- Rust: `cargo clippy --workspace` clean; ingestion + grpc-server suites pass, including new tests for re-encode/hash-match and mismatch-drop.
- Go: `go build ./...` + `go vet ./...` clean; all `cmd/...` tests pass. Updated bundle/submitter/shadow-dump tests assert `RawTxs[0]==victim`, no bare hash in `txs`, victim excluded from `revertingTxHashes`, and empty-rawtx rejection.

## Follow-up (out of scope)

`config/builders.yaml` lists `eden` while the hardcoded fallback list in `cmd/executor/submitter.go` lists `beaver` — config/code drift to reconcile separately.