### PR TITLE
feat(mempool): inject prewarmed state into shadow-sim path

### DIFF
--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -213,9 +213,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),
                 Arc::clone(&metrics),
-                Some(sim_ctx),
+                Some(Arc::clone(&sim_ctx)),
                 shutdown_rx.clone(),
             );
+            // Pre-warm refresher: rebuilds the long-lived
+            // PrewarmedState (tracked-pool bytecode + V2 reserve slot
+            // 8) every Nth new block. Without this each per-pending-tx
+            // shadow-sim builds an empty CacheDB and re-fetches the
+            // same bytecode from Alchemy. The refresher only spawns
+            // when an RPC provider is available — without one
+            // `prewarm_state` has nowhere to fetch from.
+            if let Some(provider) = engine.rpc_provider() {
+                let prewarm_interval = std::env::var("AETHER_MEMPOOL_PREWARM_INTERVAL_BLOCKS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(8);
+                let _prewarm_handle = mempool_pipeline::spawn_mempool_prewarm_refresher(
+                    Arc::clone(&sim_ctx),
+                    provider,
+                    Arc::clone(engine.event_channels()),
+                    Arc::clone(&metrics),
+                    prewarm_interval,
+                    shutdown_rx.clone(),
+                );
+            } else {
+                info!(
+                    "Mempool prewarm refresher disabled — no RPC provider configured (set ETH_RPC_URL)"
+                );
+            }
             // First-seen → inclusion latency tracker. Pure observability —
             // listens on the same broadcast channels, never publishes
             // anything outward. Spawned alongside the mempool pipeline so
@@ -383,5 +408,9 @@ fn build_backrun_validator_config(
         input_amount_wei,
         sim_semaphore: Arc::new(tokio::sync::Semaphore::new(sim_concurrency)),
         provider,
+        // Placeholder — `SimContext::with_backrun_validator` overwrites this
+        // with the SimContext's shared handle so the validator and the
+        // background refresher rotate the same `ArcSwap`.
+        mempool_prewarm: Arc::new(arc_swap::ArcSwap::from_pointee(None)),
     })
 }

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -109,6 +109,14 @@ pub struct BackrunValidatorConfig {
     /// `provider_unavailable` reject and the analytical-only behaviour
     /// from `develop` is preserved.
     pub provider: Option<DynProvider<Ethereum>>,
+    /// Shared handle to the long-lived pre-warmed bytecode + storage
+    /// snapshot owned by the parent [`SimContext`]. Populated by
+    /// [`SimContext::with_backrun_validator`]; remains a fresh empty
+    /// `ArcSwap` when the validator is built outside a SimContext (only
+    /// happens in tests and via `build_backrun_validator_config` before
+    /// the SimContext attaches it). Atomic load on every shadow-sim.
+    pub mempool_prewarm:
+        Arc<ArcSwap<Option<Arc<aether_simulator::fork::PrewarmedState>>>>,
 }
 
 /// State the post-state simulator needs to run after a successful decode.
@@ -157,6 +165,13 @@ pub struct SimContext {
     /// hooks land in `aether_simulator::post_state_replay` — until then,
     /// flipping this flag only changes V3 behaviour.
     pub post_state_replay_enabled: bool,
+    /// Long-lived snapshot of pre-fetched contract code + V2 reserve slots
+    /// covering the tracked pool registry. Built and rotated by
+    /// [`spawn_mempool_prewarm_refresher`]; injected into each per-pending-tx
+    /// `RpcForkedState` so the mempool shadow-sim path stops re-fetching cold
+    /// bytecode on every attempt. `None` until the first refresh lands.
+    pub mempool_prewarm:
+        Arc<ArcSwap<Option<Arc<aether_simulator::fork::PrewarmedState>>>>,
 }
 
 impl SimContext {
@@ -182,6 +197,7 @@ impl SimContext {
             engine_git_sha,
             pair_index_cache: Mutex::new(None),
             post_state_replay_enabled: false,
+            mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
         }
     }
 
@@ -210,7 +226,11 @@ impl SimContext {
 
     /// Attach the revm validator configuration. The pipeline ignores this
     /// when [`SimContext::arb_publisher`] is also unset.
-    pub fn with_backrun_validator(mut self, cfg: BackrunValidatorConfig) -> Self {
+    ///
+    /// Shares the SimContext's `mempool_prewarm` handle into the cfg so the
+    /// validator and the background refresher rotate the same `ArcSwap`.
+    pub fn with_backrun_validator(mut self, mut cfg: BackrunValidatorConfig) -> Self {
+        cfg.mempool_prewarm = Arc::clone(&self.mempool_prewarm);
         self.backrun = Some(cfg);
         self
     }
@@ -293,6 +313,137 @@ pub fn spawn_mempool_pipeline(
             }
         }
     })
+}
+
+/// Spawn the background task that periodically refreshes
+/// [`SimContext::mempool_prewarm`].
+///
+/// Runs one best-effort refresh on startup, then on every
+/// `interval_blocks`-th `NewBlockEvent`. Each refresh snapshots the live
+/// pool registry, collects code + V2-reserve addresses, fans the RPC
+/// fetches out in parallel via
+/// [`aether_simulator::fork::prewarm_state`], and atomically swaps the
+/// result into the shared `ArcSwap`. Refresh failures are best-effort —
+/// the stale snapshot is preserved so the validator keeps running warm.
+///
+/// Setting `interval_blocks = 0` is treated as `1`: at minimum one
+/// refresh per new block. Tracked-pool bytecode rarely changes so the
+/// default cadence (8 blocks, ~96 s on mainnet) is sufficient to
+/// absorb registry growth without burning ~10 K RPCs/block on refresh.
+pub fn spawn_mempool_prewarm_refresher(
+    sim_ctx: Arc<SimContext>,
+    provider: DynProvider<Ethereum>,
+    channels: Arc<aether_ingestion::subscription::EventChannels>,
+    metrics: Arc<EngineMetrics>,
+    interval_blocks: u64,
+    mut shutdown: watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut new_blocks = channels.subscribe_new_blocks();
+        let interval = interval_blocks.max(1);
+        // First refresh on startup so the validator is warm before the
+        // first new-block tick lands. block_number = 0 is purely a log
+        // tag here; `prewarm_state` resolves storage via BlockId so
+        // value semantics don't depend on it.
+        run_prewarm_refresh(&sim_ctx, &provider, &metrics, 0).await;
+        let mut last_refresh_block: u64 = 0;
+        info!(
+            target: "aether::mempool",
+            interval_blocks = interval,
+            "mempool prewarm refresher started"
+        );
+
+        loop {
+            tokio::select! {
+                next = new_blocks.recv() => match next {
+                    Ok(block) => {
+                        if block.block_number.saturating_sub(last_refresh_block) >= interval
+                            || last_refresh_block == 0
+                        {
+                            run_prewarm_refresh(&sim_ctx, &provider, &metrics, block.block_number).await;
+                            last_refresh_block = block.block_number;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(
+                            target: "aether::mempool",
+                            lagged = n,
+                            "prewarm refresher lagged on new_blocks; resuming"
+                        );
+                        continue;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        info!(target: "aether::mempool", "new_blocks closed; prewarm refresher exiting");
+                        return;
+                    }
+                },
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() {
+                        info!(target: "aether::mempool", "shutdown signalled; prewarm refresher exiting");
+                        return;
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// One refresh cycle: snapshot the registry, fan out RPC fetches, swap
+/// the result into the shared `ArcSwap`. Errors inside `prewarm_state`
+/// are logged at warn level per-address; the cycle as a whole always
+/// produces a snapshot (possibly with fewer entries on partial failure).
+async fn run_prewarm_refresh(
+    sim_ctx: &Arc<SimContext>,
+    provider: &DynProvider<Ethereum>,
+    metrics: &EngineMetrics,
+    block_number: u64,
+) {
+    let started = Instant::now();
+    let registry_guard = sim_ctx.pool_registry.load();
+    let executor_addr = sim_ctx.backrun.as_ref().map(|c| c.executor_address);
+
+    let mut code_addrs: Vec<Address> = Vec::with_capacity(registry_guard.len() + 1);
+    if let Some(addr) = executor_addr {
+        code_addrs.push(addr);
+    }
+    let mut v2_addrs: Vec<Address> = Vec::new();
+
+    for meta in registry_guard.values() {
+        code_addrs.push(meta.pool_id.address);
+        if matches!(
+            meta.protocol,
+            ProtocolType::UniswapV2 | ProtocolType::SushiSwap,
+        ) {
+            v2_addrs.push(meta.pool_id.address);
+        }
+    }
+    code_addrs.sort_unstable();
+    code_addrs.dedup();
+    v2_addrs.sort_unstable();
+    v2_addrs.dedup();
+
+    let pool_count = registry_guard.len();
+    drop(registry_guard);
+
+    let fresh =
+        aether_simulator::fork::prewarm_state(provider, block_number, &code_addrs, &v2_addrs)
+            .await;
+
+    sim_ctx
+        .mempool_prewarm
+        .store(Arc::new(Some(Arc::new(fresh))));
+
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    metrics.inc_mempool_prewarm_refresh("ok");
+    metrics.observe_mempool_prewarm_refresh_duration_ms(elapsed_ms);
+    metrics.set_mempool_prewarm_warm_pools(pool_count as i64);
+    info!(
+        target: "aether::mempool",
+        block = block_number,
+        pools = pool_count,
+        elapsed_ms,
+        "mempool prewarm refreshed"
+    );
 }
 
 /// Decode one pending tx and update metrics + logs.
@@ -874,7 +1025,7 @@ fn run_backrun_validation(
     // Anvil fork; on real mainnet RPC the difference is invisible
     // because `latest` and the snapshot block are typically within one
     // slot of each other.
-    let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
+    let mut state = match aether_simulator::fork::RpcForkedState::new_at_latest(
         provider.clone(),
         block_number,
         now_secs,
@@ -890,6 +1041,20 @@ fn run_backrun_validation(
             return None;
         }
     };
+
+    // Inject the long-lived pre-warmed snapshot built by the refresher
+    // task. Without this each shadow-sim starts with an empty `CacheDB`
+    // → ~10-20 cold upstream-RPC round-trips per V2 swap (bytecode +
+    // slot 8). With it, tracked-pool bytecode + V2 reserve slots are
+    // served from the in-memory cache and only unknown addresses
+    // (router state, ERC20 balances/allowances) hit the network.
+    let warm_guard = cfg.mempool_prewarm.load();
+    if let Some(warm) = warm_guard.as_ref() {
+        warm.inject_into(&mut state);
+        metrics.inc_mempool_prewarm_hit();
+    } else {
+        metrics.inc_mempool_prewarm_miss();
+    }
 
     let victim = VictimTx {
         from: event.from,
@@ -1532,6 +1697,7 @@ mod tests {
             input_amount_wei: U256::ZERO,
             sim_semaphore: Arc::new(Semaphore::new(1)),
             provider: None,
+            mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
         }
     }
 
@@ -1583,6 +1749,80 @@ mod tests {
                 "{proto:?} must bump unimplemented_protocol"
             );
         }
+    }
+
+    #[test]
+    fn sim_context_mempool_prewarm_arcswap_round_trips() {
+        use aether_simulator::fork::PrewarmedState;
+
+        let ctx = empty_sim_ctx();
+        // Starts empty until the background refresher lands its first
+        // snapshot — validator path counts a `prewarm_miss` in this state.
+        assert!(ctx.mempool_prewarm.load().is_none());
+
+        let warm = Arc::new(PrewarmedState::default());
+        ctx.mempool_prewarm
+            .store(Arc::new(Some(Arc::clone(&warm))));
+        let loaded = ctx.mempool_prewarm.load();
+        assert!(loaded.is_some());
+        // Round-trip pointer-equality: same Arc instance came back out.
+        assert!(Arc::ptr_eq(loaded.as_ref().as_ref().unwrap(), &warm));
+    }
+
+    #[test]
+    fn with_backrun_validator_shares_prewarm_handle() {
+        use aether_simulator::fork::PrewarmedState;
+        use std::str::FromStr;
+
+        let ctx_inner = {
+            use crate::mempool_writer::NoopMempoolSink;
+            use aether_pools::new_pool_state_cache;
+            use aether_state::price_graph::PriceGraph;
+            SimContext::new(
+                Arc::new(ArcSwap::from_pointee(HashMap::<Address, PoolMetadata>::new())),
+                Arc::new(ArcSwap::from_pointee(TokenIndex::default())),
+                Arc::new(SnapshotManager::new(PriceGraph::new(0))),
+                BellmanFord::new(3, 1_000),
+                new_pool_state_cache(),
+                Arc::new(NoopMempoolSink::new()),
+                None,
+            )
+        };
+
+        // `cfg` arrives with a fresh independent ArcSwap (as if built by
+        // `build_backrun_validator_config_from_env`); `with_backrun_validator`
+        // must overwrite it with the SimContext's shared handle so the
+        // refresher and the validator rotate the same snapshot.
+        let cfg = BackrunValidatorConfig {
+            executor_address: Address::from_str("0x00000000000000000000000000000000000000aa").unwrap(),
+            searcher_caller: Address::ZERO,
+            profit_token: Address::ZERO,
+            balance_slot: U256::ZERO,
+            chain_id: 1,
+            min_profit_wei: U256::ZERO,
+            input_amount_wei: U256::ZERO,
+            sim_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+            provider: None,
+            mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
+        };
+
+        let shared_handle = Arc::clone(&ctx_inner.mempool_prewarm);
+        let ctx_inner = ctx_inner.with_backrun_validator(cfg);
+
+        let cfg_handle = Arc::clone(
+            &ctx_inner
+                .backrun
+                .as_ref()
+                .expect("backrun cfg installed")
+                .mempool_prewarm,
+        );
+        assert!(Arc::ptr_eq(&cfg_handle, &shared_handle));
+
+        // Refresher stores → validator-side load sees it.
+        ctx_inner
+            .mempool_prewarm
+            .store(Arc::new(Some(Arc::new(PrewarmedState::default()))));
+        assert!(cfg_handle.load().is_some());
     }
 
     #[test]

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -164,6 +164,24 @@ pub struct EngineMetrics {
     /// replay that hits an RPC stall on a cold storage slot looks very
     /// different from one served entirely from the warm `CacheDB`.
     mempool_post_state_replay_latency_ms: Histogram,
+    /// Counter for mempool-backrun shadow-sim attempts that received a
+    /// pre-warmed bytecode + storage payload before the revm sim ran.
+    /// `result=hit` when a `PrewarmedState` was loaded and injected,
+    /// `result=miss` when the long-lived `ArcSwap` is still empty (the
+    /// background refresher has not produced its first snapshot yet).
+    mempool_prewarm_inject_total: IntCounterVec,
+    /// Counter for the periodic mempool pre-warm refresh task. `result=ok`
+    /// on a successful registry snapshot + RPC fetch, `result=error` is
+    /// reserved for future refresh-side failures (the current implementation
+    /// only logs warnings inside `prewarm_state`).
+    mempool_prewarm_refresh_total: IntCounterVec,
+    /// Wall-clock latency of one refresh cycle, ms. Buckets mirror
+    /// `mempool_backrun_validation_latency_ms` so the two histograms share a
+    /// dashboard layout.
+    mempool_prewarm_refresh_duration_ms: Histogram,
+    /// Pools whose bytecode + V2 reserve slots were warmed by the most
+    /// recent refresh. Set to the snapshot's pool count on success.
+    mempool_prewarm_warm_pools: IntGauge,
 }
 
 impl EngineMetrics {
@@ -345,6 +363,37 @@ impl EngineMetrics {
             ]),
         )
         .expect("aether_mempool_post_state_replay_latency_ms histogram");
+        let mempool_prewarm_inject_total = IntCounterVec::new(
+            Opts::new(
+                "aether_mempool_prewarm_inject_total",
+                "Mempool-backrun shadow-sim attempts by pre-warm result (hit / miss)",
+            ),
+            &["result"],
+        )
+        .expect("aether_mempool_prewarm_inject_total counter vec");
+        let mempool_prewarm_refresh_total = IntCounterVec::new(
+            Opts::new(
+                "aether_mempool_prewarm_refresh_total",
+                "Periodic mempool pre-warm refresh attempts, by result (ok / error)",
+            ),
+            &["result"],
+        )
+        .expect("aether_mempool_prewarm_refresh_total counter vec");
+        let mempool_prewarm_refresh_duration_ms = Histogram::with_opts(
+            HistogramOpts::new(
+                "aether_mempool_prewarm_refresh_duration_ms",
+                "Wall-clock latency of one mempool pre-warm refresh cycle, ms",
+            )
+            .buckets(vec![
+                0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 250.0, 500.0,
+            ]),
+        )
+        .expect("aether_mempool_prewarm_refresh_duration_ms histogram");
+        let mempool_prewarm_warm_pools = IntGauge::new(
+            "aether_mempool_prewarm_warm_pools",
+            "Pools whose bytecode + V2 reserve slots were warmed by the most recent refresh",
+        )
+        .expect("aether_mempool_prewarm_warm_pools gauge");
 
         registry
             .register(Box::new(detection_latency_ms.clone()))
@@ -415,6 +464,18 @@ impl EngineMetrics {
         registry
             .register(Box::new(mempool_post_state_replay_latency_ms.clone()))
             .expect("register aether_mempool_post_state_replay_latency_ms");
+        registry
+            .register(Box::new(mempool_prewarm_inject_total.clone()))
+            .expect("register aether_mempool_prewarm_inject_total");
+        registry
+            .register(Box::new(mempool_prewarm_refresh_total.clone()))
+            .expect("register aether_mempool_prewarm_refresh_total");
+        registry
+            .register(Box::new(mempool_prewarm_refresh_duration_ms.clone()))
+            .expect("register aether_mempool_prewarm_refresh_duration_ms");
+        registry
+            .register(Box::new(mempool_prewarm_warm_pools.clone()))
+            .expect("register aether_mempool_prewarm_warm_pools");
 
         // Pre-touch every label so dashboards see zero rows from boot.
         for ev in &[
@@ -470,6 +531,10 @@ impl EngineMetrics {
             mempool_first_seen_events_total,
             mempool_post_state_replay_total,
             mempool_post_state_replay_latency_ms,
+            mempool_prewarm_inject_total,
+            mempool_prewarm_refresh_total,
+            mempool_prewarm_refresh_duration_ms,
+            mempool_prewarm_warm_pools,
         }
     }
 
@@ -688,6 +753,38 @@ impl EngineMetrics {
         self.mempool_backrun_rejected_total
             .with_label_values(&[reason])
             .inc();
+    }
+
+    /// Bump `aether_mempool_prewarm_inject_total{result="hit"}`.
+    pub fn inc_mempool_prewarm_hit(&self) {
+        self.mempool_prewarm_inject_total
+            .with_label_values(&["hit"])
+            .inc();
+    }
+
+    /// Bump `aether_mempool_prewarm_inject_total{result="miss"}`.
+    pub fn inc_mempool_prewarm_miss(&self) {
+        self.mempool_prewarm_inject_total
+            .with_label_values(&["miss"])
+            .inc();
+    }
+
+    /// Bump `aether_mempool_prewarm_refresh_total{result}`.
+    pub fn inc_mempool_prewarm_refresh(&self, result: &str) {
+        self.mempool_prewarm_refresh_total
+            .with_label_values(&[result])
+            .inc();
+    }
+
+    /// Observe wall-clock latency of one mempool pre-warm refresh cycle, ms.
+    pub fn observe_mempool_prewarm_refresh_duration_ms(&self, ms: f64) {
+        self.mempool_prewarm_refresh_duration_ms.observe(ms);
+    }
+
+    /// Set `aether_mempool_prewarm_warm_pools` to the most recent snapshot's
+    /// pool count.
+    pub fn set_mempool_prewarm_warm_pools(&self, n: i64) {
+        self.mempool_prewarm_warm_pools.set(n);
     }
 
     /// Increment the in-flight mempool-backrun sim gauge by one. Returns a

--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -17,6 +17,7 @@ use tracing::{debug, warn};
 /// Injected into each task's `RpcForkedState` cache so that per-task cold
 /// RPC fetches are eliminated — all simulations sharing the same block see
 /// the same contract state without redundant network round-trips.
+#[derive(Default)]
 pub struct PrewarmedState {
     /// Bytecode cache: (code_hash, bytecode) pairs for pre-fetched contracts.
     ///


### PR DESCRIPTION
## Summary

Cuts upstream RPC fan-out on the mempool shadow-sim path by injecting a long-lived `PrewarmedState` (tracked-pool bytecode + V2 reserve slot 8) into each per-pending-tx `RpcForkedState`. The block-driven path (`engine.rs:1707-1739`) already does this — only the mempool path was missing the wiring.

### What changed

- New `Arc<ArcSwap<Option<Arc<PrewarmedState>>>>` on `SimContext` and `BackrunValidatorConfig`, shared via `with_backrun_validator`
- Injection at `mempool_pipeline.rs:run_backrun_validation` right after `RpcForkedState::new_at_latest`; hit/miss counted on `aether_mempool_prewarm_inject_total{result}`
- `spawn_mempool_prewarm_refresher`: one refresh at startup, then every Nth new block (`AETHER_MEMPOOL_PREWARM_INTERVAL_BLOCKS`, default `8` ≈ 96 s on mainnet). Snapshots the live registry, fans `eth_getCode` + `eth_getStorageAt(slot=8)` out via the existing parallel `prewarm_state` helper, atomically rotates the snapshot. Refresh failures preserve the stale snapshot
- 4 new Prometheus metrics: `aether_mempool_prewarm_inject_total{result}`, `_refresh_total{result}`, `_refresh_duration_ms`, `_warm_pools`
- `#[derive(Default)]` on `PrewarmedState` to support unit-test construction

### Why

Each pending-tx mempool sim built a fresh empty `CacheDB`, so revm re-fetched tracked-pool bytecode + slot 8 from the upstream RPC on every attempt. With 50-200 pending swap candidates/sec and ~10-20 cold slots per V2/V3 sim, the fan-out was ~1-2 K upstream calls/sec at peak. Expected reduction once the first refresh lands: **60-80%** on mempool-driven RPC volume.

### Not in scope

Follow-ups identified during the design pass (separate PRs):
- Switch Anvil fork backend to local Reth IPC (kills the Alchemy bill on the remaining slots)
- Block-keyed L2 cache wrapping `AlloyDB` (de-dupes per-sim cold fetches at the same block)
- Self-served `revm::Database` from `PoolStateCache` (skip Anvil for tracked pools — needs shadow-mode validation first)

## Test plan

- [x] `cargo build -p aether-grpc-server` clean
- [x] `cargo clippy -p aether-grpc-server --tests -- -D warnings` clean
- [x] `cargo test -p aether-grpc-server --bins` — 130 passed, 0 failed
- [x] Two new unit tests cover the `ArcSwap` round-trip and the shared-handle wiring through `with_backrun_validator`
- [ ] Live verification: watch `aether_mempool_prewarm_inject_total{result="hit"}` climb after refresher starts; confirm upstream Alchemy QPS drops
- [ ] Verify `aether_mempool_prewarm_refresh_duration_ms` p99 stays under ~5 s with 5K pools (refresh cadence is 96 s, plenty of headroom)

## Env config

| Var | Default | Effect |
|---|---|---|
| `AETHER_MEMPOOL_PREWARM_INTERVAL_BLOCKS` | `8` | Blocks between refreshes (`max(1, value)`) |

Refresher auto-disables when no RPC provider is configured (`ETH_RPC_URL` unset).