### PR TITLE
feat(decoder): Curve pool-direct exchange() decoder + protocol tagging

### DIFF
--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -2406,6 +2406,7 @@ mod tests {
             timestamp: 1_700_500_000,
             base_fee: 25_000_000_000,
             gas_limit: 30_000_000,
+            ..Default::default()
         };
 
         engine.handle_new_block(block_event).await;
@@ -2446,6 +2447,7 @@ mod tests {
             timestamp: 1_710_000_000,
             base_fee: 20_000_000_000,
             gas_limit: 30_000_000,
+            ..Default::default()
         });
 
         // Give the engine time to process.

--- a/crates/grpc-server/src/first_seen_tracker.rs
+++ b/crates/grpc-server/src/first_seen_tracker.rs
@@ -1,0 +1,390 @@
+//! First-seen → inclusion latency tracker for the mempool path.
+//!
+//! Stamps every pending tx hash with our local wall-clock first-seen time
+//! (provided by the ingestion layer via
+//! [`PendingTxEvent::first_seen_unix_nanos`]). When a block lands, the
+//! tracker walks the block's tx hash list and, for each hit, observes the
+//! `(block_received_at − first_seen_at)` delta on the
+//! `aether_mempool_first_seen_to_inclusion_ms` histogram.
+//!
+//! This is pure observability — no behaviour changes elsewhere depend on
+//! it. The point is to measure how far behind block-builder mempool
+//! visibility we run. If our p99 first-seen-to-inclusion delta is
+//! significantly larger than the actual block-propagation time, builders
+//! are seeing victims before us and we lose the auction.
+//!
+//! ## Capacity / eviction
+//!
+//! The tracker is a bounded insertion-order map keyed by tx hash. New
+//! entries displace the oldest when the capacity ceiling is hit so a
+//! sustained mempool burst can't grow it unboundedly. Default capacity
+//! (`DEFAULT_CAPACITY`) holds ~10× the average pending pool depth at the
+//! time of writing. Override via [`MempoolFirstSeenTracker::with_capacity`]
+//! if your environment differs.
+//!
+//! ## Concurrency
+//!
+//! Single [`std::sync::Mutex`]. Tracker operations are O(1) and the
+//! critical section is microseconds long; lock contention has not shown
+//! up in practice. Switch to a sharded structure only if perf data
+//! demands it.
+
+use crate::EngineMetrics;
+use aether_ingestion::subscription::EventChannels;
+use alloy::primitives::B256;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+/// Default ring buffer capacity. ~10× the typical Ethereum mainnet
+/// pending-pool depth so the tracker keeps everything we've seen across
+/// at least one block of normal activity.
+pub const DEFAULT_CAPACITY: usize = 50_000;
+
+/// Bounded first-seen → inclusion tracker. See module docs.
+pub struct MempoolFirstSeenTracker {
+    capacity: usize,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    /// Tx hash → first-seen unix nanos. Hash-keyed so block-side
+    /// lookups are O(1).
+    seen: HashMap<B256, u64>,
+    /// Insertion-order log so capacity-bound eviction drops the oldest
+    /// entry rather than an arbitrary one. Same length as `seen`.
+    order: VecDeque<B256>,
+}
+
+impl MempoolFirstSeenTracker {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        // capacity == 0 would treat every record as an immediate evict
+        // and the histogram would never fire; guard the test path.
+        let capacity = capacity.max(1);
+        Self {
+            capacity,
+            inner: Mutex::new(Inner {
+                seen: HashMap::with_capacity(capacity),
+                order: VecDeque::with_capacity(capacity),
+            }),
+        }
+    }
+
+    /// Stamp `hash` with `first_seen_unix_nanos`. Idempotent — a duplicate
+    /// hash keeps the earliest stamp so retransmissions don't artificially
+    /// shorten the delta. Bumps the `recorded` (or `evicted_capacity` on
+    /// the eviction edge) counter on `metrics`. Zero-stamp inputs are
+    /// rejected and bump the `unstamped` counter.
+    pub fn record(&self, hash: B256, first_seen_unix_nanos: u64, metrics: &EngineMetrics) {
+        if first_seen_unix_nanos == 0 {
+            metrics.inc_mempool_first_seen_event("unstamped");
+            return;
+        }
+        let mut inner = self.inner.lock().expect("first-seen tracker poisoned");
+
+        // Idempotent insert. Keep the earliest stamp so retransmits don't
+        // shrink the observed delta (we want the wall-clock first time
+        // *our* pipeline learned about the tx).
+        if inner.seen.contains_key(&hash) {
+            return;
+        }
+
+        // Capacity check before insert. Evict from the front of `order`
+        // so the oldest entry is the one that leaves.
+        while inner.order.len() >= self.capacity {
+            if let Some(old) = inner.order.pop_front() {
+                inner.seen.remove(&old);
+                metrics.inc_mempool_first_seen_event("evicted_capacity");
+            } else {
+                break;
+            }
+        }
+
+        inner.seen.insert(hash, first_seen_unix_nanos);
+        inner.order.push_back(hash);
+        metrics.inc_mempool_first_seen_event("recorded");
+    }
+
+    /// Block-side hook: walk a block's tx hash list and observe deltas
+    /// for every hash we tracked. Matched entries are removed so a single
+    /// inclusion only fires one histogram observation. Unmatched hashes
+    /// bump the `unmatched` event counter so dashboards can see hit-rate
+    /// (matched / (matched + unmatched)) at a glance.
+    ///
+    /// `now_unix_nanos` is the wall-clock instant the block reached this
+    /// process. Threading it through (rather than reading
+    /// `SystemTime::now()` inside) keeps the function testable.
+    pub fn observe_block(
+        &self,
+        block_tx_hashes: &[B256],
+        now_unix_nanos: u64,
+        metrics: &EngineMetrics,
+    ) {
+        if block_tx_hashes.is_empty() {
+            return;
+        }
+        let mut inner = self.inner.lock().expect("first-seen tracker poisoned");
+        for hash in block_tx_hashes {
+            match inner.seen.remove(hash) {
+                Some(first_seen) => {
+                    // Saturating sub guards against clock skew (e.g.
+                    // builder timestamp slightly behind our ingest). A
+                    // negative delta would be meaningless so we floor it
+                    // to zero rather than skip.
+                    let delta_nanos = now_unix_nanos.saturating_sub(first_seen);
+                    let delta_ms = delta_nanos as f64 / 1_000_000.0;
+                    metrics.observe_mempool_first_seen_to_inclusion_ms(delta_ms);
+                    metrics.inc_mempool_first_seen_event("matched");
+                    // No O(n) removal from `order`; let it carry the
+                    // stale entry forward. The eviction loop above will
+                    // GC it once capacity pressure hits. This avoids a
+                    // O(n) `VecDeque::retain` per block.
+                }
+                None => {
+                    metrics.inc_mempool_first_seen_event("unmatched");
+                }
+            }
+        }
+    }
+
+    /// Test helper: how many entries currently tracked.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner.lock().unwrap().seen.len()
+    }
+}
+
+impl Default for MempoolFirstSeenTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convenience: current wall-clock in unix nanos. Single source of truth
+/// for the time domain the tracker uses everywhere.
+pub fn now_unix_nanos() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
+/// Spawn the tracker subscriber. Listens on both the pending-tx and
+/// new-block broadcast channels; records first-seen on every pending,
+/// observes deltas on every block. Exits when `shutdown` flips true.
+///
+/// Returns the JoinHandle so the caller can await it on shutdown — the
+/// task will end after both subscriptions hang up OR the shutdown signal
+/// fires, whichever comes first.
+pub fn spawn_first_seen_tracker(
+    channels: Arc<EventChannels>,
+    metrics: Arc<EngineMetrics>,
+    mut shutdown: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    let tracker = Arc::new(MempoolFirstSeenTracker::new());
+    info!(
+        target: "aether::mempool",
+        capacity = DEFAULT_CAPACITY,
+        "first-seen tracker subscribed (pending + new-block channels)"
+    );
+
+    let mut pending_rx = channels.subscribe_pending_txs();
+    let mut block_rx = channels.subscribe_new_blocks();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                pending = pending_rx.recv() => {
+                    match pending {
+                        Ok(ev) => {
+                            tracker.record(ev.tx_hash, ev.first_seen_unix_nanos, &metrics);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Lagged events are already counted by the
+                            // pipeline-lag metric — log only at debug to
+                            // avoid double-counting via a tracker-side
+                            // metric.
+                            debug!(
+                                target: "aether::mempool",
+                                dropped = n,
+                                "first-seen tracker pending-tx receiver lagged"
+                            );
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            warn!(target: "aether::mempool", "pending-tx channel closed; first-seen tracker exiting");
+                            return;
+                        }
+                    }
+                }
+                block = block_rx.recv() => {
+                    match block {
+                        Ok(ev) => {
+                            // observe_block reads only the slice + the
+                            // tracker's own mutex; no other heavy work
+                            // here so this stays cheap per block.
+                            tracker.observe_block(&ev.tx_hashes, now_unix_nanos(), &metrics);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            debug!(
+                                target: "aether::mempool",
+                                dropped = n,
+                                "first-seen tracker new-block receiver lagged"
+                            );
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            warn!(target: "aether::mempool", "new-block channel closed; first-seen tracker exiting");
+                            return;
+                        }
+                    }
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!(target: "aether::mempool", "first-seen tracker received shutdown");
+                        return;
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::b256;
+
+    fn hashn(n: u8) -> B256 {
+        let mut h = [0u8; 32];
+        h[31] = n;
+        B256::from(h)
+    }
+
+    fn fresh_metrics() -> EngineMetrics {
+        EngineMetrics::new()
+    }
+
+    #[test]
+    fn record_and_observe_emits_delta() {
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(100);
+        let h = hashn(1);
+
+        let first_seen = 1_700_000_000_000_000_000u64; // 1.7e18 nanos
+        tracker.record(h, first_seen, &metrics);
+        assert_eq!(tracker.len(), 1);
+
+        let now = first_seen + 500_000_000; // +500ms
+        tracker.observe_block(&[h], now, &metrics);
+        // After matching the entry should be evicted from the seen map.
+        assert_eq!(tracker.len(), 0);
+    }
+
+    #[test]
+    fn unmatched_block_hash_does_not_panic() {
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(100);
+        tracker.observe_block(&[hashn(7)], 1_700_000_001_000_000_000, &metrics);
+        assert_eq!(tracker.len(), 0);
+    }
+
+    #[test]
+    fn zero_stamp_is_rejected_not_recorded() {
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(100);
+        tracker.record(hashn(1), 0, &metrics);
+        assert_eq!(tracker.len(), 0, "zero-stamp entries must not be tracked");
+    }
+
+    #[test]
+    fn duplicate_record_keeps_earliest_stamp() {
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(100);
+        let h = hashn(1);
+        let early = 1_700_000_000_000_000_000u64;
+        let late = early + 100_000_000;
+        tracker.record(h, early, &metrics);
+        tracker.record(h, late, &metrics);
+        // After observing, the delta should be computed against the
+        // *earliest* stamp (1700... s), not the later one.
+        let now = early + 200_000_000;
+        tracker.observe_block(&[h], now, &metrics);
+        // Tracker drained — second record was a no-op (the assertion
+        // here is implicit: no panic + len drops to 0 after one
+        // observe_block).
+        assert_eq!(tracker.len(), 0);
+    }
+
+    #[test]
+    fn capacity_evicts_oldest_first() {
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(3);
+        let now = 1_700_000_000_000_000_000u64;
+        tracker.record(hashn(1), now, &metrics);
+        tracker.record(hashn(2), now + 1, &metrics);
+        tracker.record(hashn(3), now + 2, &metrics);
+        // Capacity full; inserting a 4th should evict hash(1).
+        tracker.record(hashn(4), now + 3, &metrics);
+        assert_eq!(tracker.len(), 3);
+        // Observe all four hashes; (1) should be unmatched, others matched.
+        tracker.observe_block(
+            &[hashn(1), hashn(2), hashn(3), hashn(4)],
+            now + 1_000_000,
+            &metrics,
+        );
+        assert_eq!(tracker.len(), 0);
+    }
+
+    #[test]
+    fn empty_block_is_noop() {
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(100);
+        tracker.record(hashn(1), 1, &metrics);
+        tracker.observe_block(&[], 999, &metrics);
+        // Entry still present — empty block didn't drain anything.
+        assert_eq!(tracker.len(), 1);
+    }
+
+    #[test]
+    fn clock_skew_floors_delta_at_zero() {
+        // If block timestamp is somehow earlier than our first-seen
+        // (clock skew, NTP step, builder timestamp lag), the delta must
+        // floor at 0 rather than wrap.
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(100);
+        let h = hashn(1);
+        let first_seen = 1_700_000_001_000_000_000u64;
+        tracker.record(h, first_seen, &metrics);
+        let now = first_seen - 500_000_000; // 500ms BEFORE first-seen
+        tracker.observe_block(&[h], now, &metrics);
+        // No panic; entry consumed.
+        assert_eq!(tracker.len(), 0);
+    }
+
+    #[test]
+    fn capacity_zero_treated_as_one() {
+        // Guard the test-only "capacity 0" footgun: we floor at 1 so
+        // record-then-observe still works.
+        let metrics = fresh_metrics();
+        let tracker = MempoolFirstSeenTracker::with_capacity(0);
+        let h = hashn(1);
+        tracker.record(h, 1_000, &metrics);
+        // Even at capacity-1 the record + immediate observe should hit.
+        tracker.observe_block(&[h], 2_000, &metrics);
+        assert_eq!(tracker.len(), 0);
+    }
+
+    // Touch alloy's `b256!` macro so the import isn't unused if the file
+    // gets pared back to fewer tests.
+    #[allow(dead_code)]
+    fn _macro_touch() -> B256 {
+        b256!("0000000000000000000000000000000000000000000000000000000000000000")
+    }
+}

--- a/crates/grpc-server/src/lib.rs
+++ b/crates/grpc-server/src/lib.rs
@@ -6,6 +6,7 @@
 /// crate-private; only the two types the binary and integration tests
 /// actually need are re-exported publicly.
 pub mod cycle_gating;
+pub mod first_seen_tracker;
 pub mod historical;
 pub(crate) mod metrics;
 pub mod profitability_writer;

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -203,7 +203,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Some(sim_ctx),
                 shutdown_rx.clone(),
             );
-            Some((source_handle, pipeline_handle))
+            // First-seen → inclusion latency tracker. Pure observability —
+            // listens on the same broadcast channels, never publishes
+            // anything outward. Spawned alongside the mempool pipeline so
+            // its lifecycle matches `MEMPOOL_TRACKING=1`.
+            let first_seen_handle = aether_grpc_server::first_seen_tracker::spawn_first_seen_tracker(
+                Arc::clone(engine.event_channels()),
+                Arc::clone(&metrics),
+                shutdown_rx.clone(),
+            );
+            Some((source_handle, pipeline_handle, first_seen_handle))
         }
     } else {
         None
@@ -288,12 +297,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         error!(error = %e, "Provider task panicked");
     }
 
-    if let Some((source_handle, pipeline_handle)) = mempool_handles {
+    if let Some((source_handle, pipeline_handle, first_seen_handle)) = mempool_handles {
         if let Err(e) = source_handle.await {
             error!(error = %e, "Mempool source task panicked");
         }
         if let Err(e) = pipeline_handle.await {
             error!(error = %e, "Mempool pipeline task panicked");
+        }
+        if let Err(e) = first_seen_handle.await {
+            error!(error = %e, "First-seen tracker task panicked");
         }
     }
 

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -51,7 +51,7 @@ use crate::service::aether_proto;
 use crate::engine::PoolMetadata;
 use crate::mempool_writer::{
     MempoolPredictionSink, NewMempoolPrediction, PredictedPostState, PROTOCOL_BALANCER,
-    PROTOCOL_SUSHI, PROTOCOL_UNI_V2, PROTOCOL_UNI_V3,
+    PROTOCOL_CURVE, PROTOCOL_SUSHI, PROTOCOL_UNI_V2, PROTOCOL_UNI_V3,
 };
 use crate::EngineMetrics;
 
@@ -392,6 +392,7 @@ fn decoder_protocol_to_type(p: Protocol) -> Option<ProtocolType> {
         Protocol::SushiSwap => Some(ProtocolType::SushiSwap),
         Protocol::UniswapV3 => Some(ProtocolType::UniswapV3),
         Protocol::BalancerV2 => Some(ProtocolType::BalancerV2),
+        Protocol::Curve => Some(ProtocolType::Curve),
     }
 }
 
@@ -446,11 +447,25 @@ fn try_post_state_scan(
     event_to: Address,
     event: &PendingTxEvent,
 ) {
+    // Curve post-state scan is intentionally deferred to a follow-up PR
+    // (the V3/Balancer branch downstream needs a parallel Curve arm that
+    // routes through `unified_to_post_reserves`'s Curve variant + the
+    // PredictedPostState writer). For now, log the decoded swap via
+    // `emit_decoded` upstream so `pending_dex_tx_total{protocol="curve"}`
+    // climbs, then bail out with a dedicated skip reason. The decoder is
+    // the unblock that matters here; turning that signal into a cycle
+    // candidate is the next increment.
+    if swap.protocol == Protocol::Curve {
+        metrics.inc_pending_arb_sim_skipped("curve_post_state_pending");
+        return;
+    }
+
     let target_protocol = match swap.protocol {
         Protocol::UniswapV2 => ProtocolType::UniswapV2,
         Protocol::SushiSwap => ProtocolType::SushiSwap,
         Protocol::UniswapV3 => ProtocolType::UniswapV3,
         Protocol::BalancerV2 => ProtocolType::BalancerV2,
+        Protocol::Curve => unreachable!("curve early-returned above"),
     };
 
     let token_idx = ctx.token_index.load();
@@ -532,6 +547,7 @@ fn try_post_state_scan(
             }
             (pin, pout)
         }
+        Protocol::Curve => unreachable!("curve early-returned above"),
     };
 
     // Clone the graph and apply the post-state to both directions of the
@@ -565,6 +581,7 @@ fn try_post_state_scan(
             reserve_in: post_in,
             reserve_out: post_out,
         },
+        Protocol::Curve => unreachable!("curve early-returned above"),
     }
     .into_json();
     let prediction = NewMempoolPrediction {
@@ -940,6 +957,7 @@ fn decoder_protocol_label(p: Protocol) -> &'static str {
         Protocol::SushiSwap => PROTOCOL_SUSHI,
         Protocol::UniswapV3 => PROTOCOL_UNI_V3,
         Protocol::BalancerV2 => PROTOCOL_BALANCER,
+        Protocol::Curve => PROTOCOL_CURVE,
     }
 }
 
@@ -1071,6 +1089,7 @@ fn protocol_label(p: Protocol) -> &'static str {
         Protocol::UniswapV3 => "uniswap_v3",
         Protocol::SushiSwap => "sushiswap",
         Protocol::BalancerV2 => "balancer_v2",
+        Protocol::Curve => "curve",
     }
 }
 
@@ -1251,6 +1270,7 @@ mod tests {
             recipient: Address::ZERO,
             fee_bps: 0,
             path_extra: vec![],
+            curve_indices: None,
         }
     }
 

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -1099,6 +1099,7 @@ mod tests {
             value: U256::ZERO,
             input,
             gas_price: 0,
+            first_seen_unix_nanos: 0,
         }
     }
 

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -117,6 +117,28 @@ pub struct EngineMetrics {
     /// `AETHER_MEMPOOL_SIM_CONCURRENCY` semaphore; exposed so dashboards can
     /// alert on saturation (gauge at ceiling = victims being dropped).
     mempool_backrun_sim_concurrent: IntGauge,
+    /// Wall-clock delta between when this process first saw a pending tx
+    /// (`PendingTxEvent::first_seen_unix_nanos` stamp at the ingestion
+    /// boundary) and when that tx landed on chain (observed via
+    /// `NewBlockEvent::tx_hashes`). Lower is better — measures how far
+    /// behind block-builder mempool visibility we run. Tail latency
+    /// (p95, p99) is the operational signal; sustained p99 > 1s means
+    /// our gossip path is laggy vs. builders.
+    mempool_first_seen_to_inclusion_ms: Histogram,
+    /// Tracker-side bookkeeping so dashboards can sanity-check the
+    /// histogram before reading deltas from it.
+    ///
+    /// Stable label set:
+    ///   - `recorded` — pending tx stamped + inserted into the tracker
+    ///   - `evicted_capacity` — oldest entry dropped to honour the
+    ///     bounded-LRU capacity ceiling
+    ///   - `matched` — block tx hash hit a tracked entry and produced a
+    ///     histogram observation
+    ///   - `unmatched` — block tx hash with no tracker entry (either
+    ///     pre-tracker-start, private flow, or evicted before inclusion)
+    ///   - `unstamped` — pending tx arrived with `first_seen_unix_nanos
+    ///     == 0` (test fixture or upstream regression) and was skipped
+    mempool_first_seen_events_total: IntCounterVec,
 }
 
 impl EngineMetrics {
@@ -258,6 +280,28 @@ impl EngineMetrics {
             "In-flight mempool-backrun validation sims, bounded by the semaphore",
         )
         .expect("aether_mempool_backrun_sim_concurrent gauge");
+        let mempool_first_seen_to_inclusion_ms = Histogram::with_opts(
+            HistogramOpts::new(
+                "aether_mempool_first_seen_to_inclusion_ms",
+                "Wall-clock ms from local first-seen of a pending tx to its on-chain inclusion",
+            )
+            // Cover sub-block (<12 s) and "we were way behind" tails. Buckets
+            // hand-picked so the histogram is meaningful with as few as 200
+            // samples — production traffic fills it in seconds.
+            .buckets(vec![
+                50.0, 100.0, 250.0, 500.0, 1_000.0, 2_500.0, 5_000.0, 10_000.0, 30_000.0,
+                60_000.0,
+            ]),
+        )
+        .expect("aether_mempool_first_seen_to_inclusion_ms histogram");
+        let mempool_first_seen_events_total = IntCounterVec::new(
+            Opts::new(
+                "aether_mempool_first_seen_events_total",
+                "Tracker events for the mempool first-seen → inclusion histogram, by event kind",
+            ),
+            &["event"],
+        )
+        .expect("aether_mempool_first_seen_events_total counter vec");
 
         registry
             .register(Box::new(detection_latency_ms.clone()))
@@ -316,6 +360,22 @@ impl EngineMetrics {
         registry
             .register(Box::new(mempool_backrun_sim_concurrent.clone()))
             .expect("register aether_mempool_backrun_sim_concurrent");
+        registry
+            .register(Box::new(mempool_first_seen_to_inclusion_ms.clone()))
+            .expect("register aether_mempool_first_seen_to_inclusion_ms");
+        registry
+            .register(Box::new(mempool_first_seen_events_total.clone()))
+            .expect("register aether_mempool_first_seen_events_total");
+        // Pre-touch every label so dashboards see zero rows from boot.
+        for ev in &[
+            "recorded",
+            "evicted_capacity",
+            "matched",
+            "unmatched",
+            "unstamped",
+        ] {
+            mempool_first_seen_events_total.with_label_values(&[ev]);
+        }
 
         Self {
             registry,
@@ -338,7 +398,25 @@ impl EngineMetrics {
             mempool_backrun_validated_total,
             mempool_backrun_rejected_total,
             mempool_backrun_sim_concurrent,
+            mempool_first_seen_to_inclusion_ms,
+            mempool_first_seen_events_total,
         }
+    }
+
+    /// Observe a successful first-seen → inclusion latency in ms.
+    /// Caller is the [`first_seen_tracker`] block-side hook; do not call
+    /// directly from random sites — the tracker enforces the "stamp was
+    /// real, delta is positive" invariants.
+    pub fn observe_mempool_first_seen_to_inclusion_ms(&self, ms: f64) {
+        self.mempool_first_seen_to_inclusion_ms.observe(ms);
+    }
+
+    /// Bump `aether_mempool_first_seen_events_total{event="..."}`. See the
+    /// struct field doc for the stable label set.
+    pub fn inc_mempool_first_seen_event(&self, event: &str) {
+        self.mempool_first_seen_events_total
+            .with_label_values(&[event])
+            .inc();
     }
 
     pub fn observe_detection_latency_us(&self, us: u128) {

--- a/crates/grpc-server/src/provider.rs
+++ b/crates/grpc-server/src/provider.rs
@@ -331,7 +331,23 @@ impl RpcProvider {
                             let base_fee = block.inner.base_fee_per_gas.unwrap_or(0) as u128;
                             let gas_limit = block.inner.gas_limit;
                             debug!(block = number, "Block received via subscription");
-                            self.dispatch_block(number, timestamp, base_fee, gas_limit);
+                            // newHeads only carries header fields; fetch the
+                            // block (hashes-only — Full would inflate the
+                            // payload by 100×+) so the mempool first-seen
+                            // tracker has a tx list to diff against. A
+                            // failed fetch dispatches with an empty list —
+                            // the inclusion-latency histogram quietly skips
+                            // that block rather than crashing the loop.
+                            let tx_hashes = match provider
+                                .get_block_by_number(alloy::eips::BlockNumberOrTag::Number(number))
+                                .await
+                            {
+                                Ok(Some(b)) => {
+                                    std::sync::Arc::new(b.transactions.hashes().collect())
+                                }
+                                _ => std::sync::Arc::new(Vec::new()),
+                            };
+                            self.dispatch_block(number, timestamp, base_fee, gas_limit, tx_hashes);
                             node.write().await.record_success(0, number);
                         }
                         None => {
@@ -425,8 +441,14 @@ impl RpcProvider {
                         let timestamp = block.header.timestamp;
                         let base_fee = block.header.base_fee_per_gas.unwrap_or(0) as u128;
                         let gas_limit = block.header.gas_limit;
+                        // Tx hashes already in the polled block payload —
+                        // free for the mempool first-seen tracker.
+                        let tx_hashes =
+                            std::sync::Arc::new(block.transactions.hashes().collect());
 
-                        self.dispatch_block(current_block, timestamp, base_fee, gas_limit);
+                        self.dispatch_block(
+                            current_block, timestamp, base_fee, gas_limit, tx_hashes,
+                        );
                         node.write().await.record_success(0, current_block);
 
                         // Fetch logs for all blocks since last_block to avoid
@@ -506,12 +528,25 @@ impl RpcProvider {
     }
 
     /// Dispatch a new block event to the event channels.
-    pub fn dispatch_block(&self, number: u64, timestamp: u64, base_fee: u128, gas_limit: u64) {
+    ///
+    /// `tx_hashes` should hold the block's confirmed tx hash list when
+    /// available — the mempool first-seen tracker uses it to compute
+    /// inclusion latency. Pass `Arc::new(Vec::new())` when the source
+    /// can't provide the list (e.g. some WS notifications).
+    pub fn dispatch_block(
+        &self,
+        number: u64,
+        timestamp: u64,
+        base_fee: u128,
+        gas_limit: u64,
+        tx_hashes: std::sync::Arc<Vec<B256>>,
+    ) {
         self.event_channels.dispatch_new_block(NewBlockEvent {
             block_number: number,
             timestamp,
             base_fee,
             gas_limit,
+            tx_hashes,
         });
     }
 
@@ -690,7 +725,13 @@ mod tests {
         };
         let provider = RpcProvider::new(config, Arc::clone(&channels), test_metrics());
 
-        provider.dispatch_block(18_000_000, 1_700_000_000, 30_000_000_000, 30_000_000);
+        provider.dispatch_block(
+            18_000_000,
+            1_700_000_000,
+            30_000_000_000,
+            30_000_000,
+            std::sync::Arc::new(Vec::new()),
+        );
 
         let event = rx.try_recv().expect("should receive block event");
         assert_eq!(event.block_number, 18_000_000);

--- a/crates/ingestion/src/mempool.rs
+++ b/crates/ingestion/src/mempool.rs
@@ -175,6 +175,15 @@ impl AlchemyMempool {
         let from = tx.inner.signer();
         let envelope = tx.as_ref();
         let to: Option<Address> = envelope.kind().to().copied();
+        // Stamp first-seen at the moment we hand the event off so the
+        // downstream tracker can compute inclusion latency against
+        // wall-clock ingest time. SystemTime is intentional (not
+        // Instant): the tracker compares against block timestamps from
+        // chain, which are UNIX-time, not process-monotonic.
+        let first_seen_unix_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
         let event = PendingTxEvent {
             tx_hash: *envelope.tx_hash(),
             from,
@@ -182,6 +191,7 @@ impl AlchemyMempool {
             value: envelope.value(),
             input: envelope.input().to_vec(),
             gas_price: envelope.max_fee_per_gas(),
+            first_seen_unix_nanos,
         };
         debug!(
             target: "aether::mempool",

--- a/crates/ingestion/src/subscription.rs
+++ b/crates/ingestion/src/subscription.rs
@@ -1,4 +1,5 @@
 use crate::event_decoder::PoolEvent;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::warn;
 
@@ -13,16 +14,30 @@ pub struct EventChannels {
 }
 
 /// New block notification
-#[derive(Debug, Clone)]
+///
+/// `tx_hashes` is populated by the polling provider so downstream
+/// observers (e.g. the mempool first-seen tracker) can compute per-tx
+/// inclusion latency without issuing a separate `eth_getBlockByNumber`
+/// RPC. Empty `Arc<Vec<_>>` is the safe default when the hash list isn't
+/// available (e.g. some WS subscriptions, the unit-test stubs).
+#[derive(Debug, Clone, Default)]
 pub struct NewBlockEvent {
     pub block_number: u64,
     pub timestamp: u64,
     pub base_fee: u128,
     pub gas_limit: u64,
+    pub tx_hashes: Arc<Vec<alloy::primitives::B256>>,
 }
 
 /// Pending transaction notification
-#[derive(Debug, Clone)]
+///
+/// `first_seen_unix_nanos` is stamped at the moment the ingestion source
+/// (Alchemy WS, MEV-Share SSE, …) hands the tx to the broadcast layer.
+/// `0` means "not stamped" — downstream observers skip latency reporting
+/// for those events rather than emitting bogus 1970-epoch deltas. This
+/// keeps the field optional in spirit without paying for `Option`'s
+/// branch on the hot path.
+#[derive(Debug, Clone, Default)]
 pub struct PendingTxEvent {
     pub tx_hash: alloy::primitives::B256,
     pub from: alloy::primitives::Address,
@@ -30,6 +45,7 @@ pub struct PendingTxEvent {
     pub value: alloy::primitives::U256,
     pub input: Vec<u8>,
     pub gas_price: u128,
+    pub first_seen_unix_nanos: u64,
 }
 
 impl EventChannels {
@@ -167,6 +183,7 @@ mod tests {
             timestamp: 1_700_000_000,
             base_fee: 30_000_000_000, // 30 gwei
             gas_limit: 30_000_000,
+            ..Default::default()
         };
 
         channels.dispatch_new_block(event);
@@ -192,6 +209,7 @@ mod tests {
             value: U256::from(1_000_000_000_000_000_000u64),
             input: vec![0xaa, 0xbb],
             gas_price: 50_000_000_000,
+            ..Default::default()
         };
 
         channels.dispatch_pending_tx(event);
@@ -249,6 +267,7 @@ mod tests {
             timestamp: 100,
             base_fee: 10,
             gas_limit: 30_000_000,
+            ..Default::default()
         });
 
         let r1 = rx1.recv().await.unwrap();
@@ -315,6 +334,7 @@ mod tests {
             timestamp: 0,
             base_fee: 0,
             gas_limit: 0,
+            ..Default::default()
         });
         // Should not panic
     }
@@ -329,6 +349,7 @@ mod tests {
             value: U256::ZERO,
             input: vec![],
             gas_price: 0,
+            ..Default::default()
         });
         // Should not panic
     }
@@ -342,6 +363,7 @@ mod tests {
             timestamp: 1_700_000_000,
             base_fee: 30_000_000_000,
             gas_limit: 30_000_000,
+            ..Default::default()
         };
         let cloned = event.clone();
         assert_eq!(cloned.block_number, event.block_number);
@@ -359,6 +381,7 @@ mod tests {
             value: U256::from(1u64),
             input: vec![0x01, 0x02],
             gas_price: 100,
+            ..Default::default()
         };
         let cloned = event.clone();
         assert_eq!(cloned.tx_hash, event.tx_hash);
@@ -375,6 +398,7 @@ mod tests {
             value: U256::ZERO,
             input: vec![],
             gas_price: 0,
+            ..Default::default()
         };
         assert!(event.to.is_none());
     }

--- a/crates/pools/src/router_decoder.rs
+++ b/crates/pools/src/router_decoder.rs
@@ -80,6 +80,13 @@ pub enum Protocol {
     UniswapV3,
     SushiSwap,
     BalancerV2,
+    /// Curve StableSwap pool. Unlike the AMM families above, Curve swaps
+    /// call `exchange()` **directly on the pool address** (no router
+    /// indirection); `DecodedSwap.router` therefore carries the *pool*
+    /// address and the upstream pipeline must resolve token_in / token_out
+    /// from the pool registry using the indices in
+    /// [`DecodedSwap.curve_indices`].
+    Curve,
 }
 
 /// Minimal swap shape produced by the decoder.
@@ -107,6 +114,15 @@ pub struct DecodedSwap {
     /// Remaining path tokens past the first hop, in order. Empty for
     /// single-hop swaps.
     pub path_extra: Vec<Address>,
+    /// Curve-only: the `(i, j)` token indices from `exchange()` calldata.
+    /// `None` for non-Curve protocols. `token_in` / `token_out` are
+    /// emitted as `Address::ZERO` for Curve because the decoder cannot
+    /// resolve indices to addresses without the pool's coin list — the
+    /// pipeline does that via the pool registry. Index width is `u8`
+    /// because mainnet Curve pools are ≤ 8 coins, so `i128` source
+    /// values that overflow `u8` indicate a malformed or non-standard
+    /// pool and the decoder rejects them with `AbiDecode`.
+    pub curve_indices: Option<(u8, u8)>,
 }
 
 /// Reasons a pending tx might fail to decode. Caller maps these to a
@@ -197,6 +213,25 @@ sol! {
         function exactInput02(ExactInputParams02 params) external payable returns (uint256);
     }
 
+    /// Curve StableSwap pool — direct `exchange()` on the pool address.
+    /// The original Curve interface uses `int128` indices; newer
+    /// crypto-pool variants use `uint256`. Two interfaces because the
+    /// `sol!` macro can't generate two `exchange` functions with the same
+    /// Rust name from one interface; splitting also keeps each selector's
+    /// selector dispatch obvious. `exchange_underlying` (lending-pool
+    /// wrappers like Compound cTokens) shares the int128 signature with
+    /// a distinct selector and is decoded identically — we only care
+    /// about the indices + amount.
+    #[allow(missing_docs)]
+    interface ICurvePoolInt128 {
+        function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) external returns (uint256);
+        function exchange_underlying(int128 i, int128 j, uint256 dx, uint256 min_dy) external returns (uint256);
+    }
+    #[allow(missing_docs)]
+    interface ICurvePoolUint256 {
+        function exchange(uint256 i, uint256 j, uint256 dx, uint256 min_dy) external returns (uint256);
+    }
+
     /// Balancer V2 Vault `swap` for the SingleSwap shape.
     #[allow(missing_docs)]
     interface IBalancerVault {
@@ -247,6 +282,10 @@ pub fn decode_pending(to: Address, calldata: &[u8]) -> Result<DecodedSwap, Decod
     }
     // ── Balancer V2 Vault ──
     if let Some(swap) = try_balancer(selector, calldata, to)? {
+        return Ok(swap);
+    }
+    // ── Curve StableSwap pool-direct exchange() ──
+    if let Some(swap) = try_curve(selector, calldata, to)? {
         return Ok(swap);
     }
 
@@ -384,6 +423,7 @@ fn decode_v2_call(
         recipient: to,
         fee_bps: 0,
         path_extra,
+        curve_indices: None,
     })
 }
 
@@ -406,6 +446,7 @@ fn try_uni_v3_family(
             recipient: c.params.recipient,
             fee_bps: c.params.fee.to::<u32>(),
             path_extra: vec![],
+            curve_indices: None,
         }));
     }
     if selector == exactInputSingle02Call::SELECTOR {
@@ -421,6 +462,7 @@ fn try_uni_v3_family(
             recipient: c.params.recipient,
             fee_bps: c.params.fee.to::<u32>(),
             path_extra: vec![],
+            curve_indices: None,
         }));
     }
     if selector == exactInputCall::SELECTOR {
@@ -437,6 +479,7 @@ fn try_uni_v3_family(
             recipient: c.params.recipient,
             fee_bps: fee,
             path_extra: extras,
+            curve_indices: None,
         }));
     }
     if selector == exactInput02Call::SELECTOR {
@@ -453,6 +496,7 @@ fn try_uni_v3_family(
             recipient: c.params.recipient,
             fee_bps: fee,
             path_extra: extras,
+            curve_indices: None,
         }));
     }
     Ok(None)
@@ -513,9 +557,103 @@ fn try_balancer(
             recipient: c.funds.recipient,
             fee_bps: 0,
             path_extra: vec![],
+            curve_indices: None,
         }));
     }
     Ok(None)
+}
+
+/// Curve pool-direct `exchange` decoder. Covers the int128 (original) and
+/// uint256 (crypto-pool) shapes plus `exchange_underlying` (lending-pool
+/// wrappers like Compound cToken / Aave aToken Curve pools). All three
+/// share the `(i, j, dx, min_dy)` arg shape so they collapse to a single
+/// `DecodedSwap` body.
+///
+/// `to` is the pool address, not a router — Curve's design is direct
+/// pool calls. Token addresses can't be resolved here without the pool's
+/// coin list; `token_in`/`token_out` are left as `Address::ZERO` and the
+/// upstream pipeline resolves them via `pool_registry[to].token0/1` keyed
+/// off the `curve_indices` we emit.
+fn try_curve(
+    selector: [u8; 4],
+    calldata: &[u8],
+    pool: Address,
+) -> Result<Option<DecodedSwap>, DecodeError> {
+    // int128 variants first — much more common on mainnet (every
+    // stablecoin StableSwap pool).
+    if selector == ICurvePoolInt128::exchangeCall::SELECTOR
+        || selector == ICurvePoolInt128::exchange_underlyingCall::SELECTOR
+    {
+        // Both calls have identical layouts, so decode either.
+        let (i, j, dx) = if selector == ICurvePoolInt128::exchangeCall::SELECTOR {
+            let c = ICurvePoolInt128::exchangeCall::abi_decode(calldata)
+                .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+            (c.i, c.j, c.dx)
+        } else {
+            let c = ICurvePoolInt128::exchange_underlyingCall::abi_decode(calldata)
+                .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+            (c.i, c.j, c.dx)
+        };
+        let indices = curve_indices_from_int128(i, j)?;
+        return Ok(Some(curve_decoded_swap(pool, indices, dx)));
+    }
+    // uint256 variant (newer crypto pools, e.g. tricrypto).
+    if selector == ICurvePoolUint256::exchangeCall::SELECTOR {
+        let c = ICurvePoolUint256::exchangeCall::abi_decode(calldata)
+            .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+        let indices = curve_indices_from_uint256(c.i, c.j)?;
+        return Ok(Some(curve_decoded_swap(pool, indices, c.dx)));
+    }
+    Ok(None)
+}
+
+/// Narrow Curve `int128` index args to `u8`. Mainnet Curve pools are
+/// ≤ 8 coins so a value that doesn't fit `u8` (negative, > 255) is
+/// either malformed calldata or a non-standard pool we shouldn't be
+/// publishing; reject as `AbiDecode` so the decode-failure metric
+/// surfaces it. The Solidity ABI decoder returns Rust `i128` for
+/// `int128`, not alloy's `I256`.
+fn curve_indices_from_int128(i: i128, j: i128) -> Result<(u8, u8), DecodeError> {
+    let to_u8 = |v: i128| -> Result<u8, DecodeError> {
+        if v < 0 || v > u8::MAX as i128 {
+            return Err(DecodeError::AbiDecode(format!("curve index out of u8 range: {v}")));
+        }
+        Ok(v as u8)
+    };
+    Ok((to_u8(i)?, to_u8(j)?))
+}
+
+/// Narrow Curve `uint256` index args to `u8`. Same rationale as the
+/// `int128` variant — sane mainnet values fit, anything else gets
+/// rejected loudly.
+fn curve_indices_from_uint256(i: U256, j: U256) -> Result<(u8, u8), DecodeError> {
+    let to_u8 = |v: U256| -> Result<u8, DecodeError> {
+        if v > U256::from(u8::MAX) {
+            return Err(DecodeError::AbiDecode(format!("curve index out of u8 range: {v}")));
+        }
+        Ok(v.to::<u64>() as u8)
+    };
+    Ok((to_u8(i)?, to_u8(j)?))
+}
+
+/// Build the `DecodedSwap` shell for a Curve exchange. Token addresses
+/// stay `Address::ZERO`; the pipeline must resolve them via the pool
+/// registry using `curve_indices`. `recipient` is the tx sender (Curve
+/// pays the caller directly), but we don't have `from` in this scope so
+/// leave as ZERO — the field is unused on the Curve path.
+fn curve_decoded_swap(pool: Address, indices: (u8, u8), amount_in: U256) -> DecodedSwap {
+    DecodedSwap {
+        protocol: Protocol::Curve,
+        router: pool,
+        token_in: Address::ZERO,
+        token_out: Address::ZERO,
+        amount_in,
+        amount_out_min: U256::ZERO,
+        recipient: Address::ZERO,
+        fee_bps: 0,
+        path_extra: vec![],
+        curve_indices: Some(indices),
+    }
 }
 
 #[cfg(test)]
@@ -687,5 +825,92 @@ mod tests {
         .abi_encode();
         let err = decode_pending(Address::ZERO, &calldata).unwrap_err();
         assert!(matches!(err, DecodeError::EmptyPath));
+    }
+
+    // ── Curve pool-direct decoder ──
+
+    #[test]
+    fn decode_curve_exchange_int128_happy_path() {
+        // 3pool address; the decoder doesn't validate this is a real
+        // Curve pool, the upstream pool_registry filter does.
+        let pool = address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7");
+        let calldata = ICurvePoolInt128::exchangeCall {
+            i: 0,
+            j: 1,
+            dx: U256::from(1_000_000u64),    // 1 USDC
+            min_dy: U256::from(990_000u64),
+        }
+        .abi_encode();
+        let decoded = decode_pending(pool, &calldata).expect("should decode");
+        assert_eq!(decoded.protocol, Protocol::Curve);
+        assert_eq!(decoded.router, pool);
+        assert_eq!(decoded.token_in, Address::ZERO, "Curve must leave token addrs unresolved");
+        assert_eq!(decoded.token_out, Address::ZERO);
+        assert_eq!(decoded.amount_in, U256::from(1_000_000u64));
+        assert_eq!(decoded.curve_indices, Some((0, 1)));
+    }
+
+    #[test]
+    fn decode_curve_exchange_underlying_int128() {
+        let pool = address!("0000000000000000000000000000000000000000");
+        let calldata = ICurvePoolInt128::exchange_underlyingCall {
+            i: 2,
+            j: 0,
+            dx: U256::from(50_000u64),
+            min_dy: U256::from(49_500u64),
+        }
+        .abi_encode();
+        let decoded = decode_pending(pool, &calldata).expect("should decode");
+        assert_eq!(decoded.protocol, Protocol::Curve);
+        assert_eq!(decoded.curve_indices, Some((2, 0)));
+    }
+
+    #[test]
+    fn decode_curve_exchange_uint256() {
+        // Newer crypto-pool variant uses uint256 indices.
+        let pool = address!("D51a44d3FaE010294C616388b506AcdA1bfAAE46"); // tricrypto2
+        let calldata = ICurvePoolUint256::exchangeCall {
+            i: U256::from(1u64),
+            j: U256::from(2u64),
+            dx: U256::from(1_000_000_000_000_000_000u128),
+            min_dy: U256::from(900u64),
+        }
+        .abi_encode();
+        let decoded = decode_pending(pool, &calldata).expect("should decode");
+        assert_eq!(decoded.protocol, Protocol::Curve);
+        assert_eq!(decoded.curve_indices, Some((1, 2)));
+    }
+
+    #[test]
+    fn decode_curve_negative_index_rejected() {
+        // A negative `int128` index is either malformed calldata or a
+        // shape the decoder shouldn't be guessing at; reject loudly.
+        let pool = address!("0000000000000000000000000000000000000001");
+        let calldata = ICurvePoolInt128::exchangeCall {
+            i: -1,
+            j: 0,
+            dx: U256::from(1u64),
+            min_dy: U256::from(0u64),
+        }
+        .abi_encode();
+        let err = decode_pending(pool, &calldata).unwrap_err();
+        assert!(matches!(err, DecodeError::AbiDecode(_)),
+            "negative index should reject as AbiDecode, got {err:?}");
+    }
+
+    #[test]
+    fn decode_curve_index_above_u8_rejected() {
+        // uint256 index above 255 wouldn't fit our u8 narrowing.
+        let pool = address!("0000000000000000000000000000000000000002");
+        let calldata = ICurvePoolUint256::exchangeCall {
+            i: U256::from(256u64),
+            j: U256::from(0u64),
+            dx: U256::from(1u64),
+            min_dy: U256::from(0u64),
+        }
+        .abi_encode();
+        let err = decode_pending(pool, &calldata).unwrap_err();
+        assert!(matches!(err, DecodeError::AbiDecode(_)),
+            "index above u8::MAX should reject as AbiDecode, got {err:?}");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Protocol::Curve` enum variant + Curve pool-direct `exchange()` calldata decoder
- Covers three ABI shapes: `exchange(int128,int128,uint256,uint256)`, `exchange_underlying(int128,int128,uint256,uint256)`, `exchange(uint256,uint256,uint256,uint256)`
- Pipeline tags decoded Curve swaps via `protocol="curve"` on every mempool metric — unblocks observability for ~20% of mainnet swap volume that was previously dropped as `CurveUnsupported`
- Post-state scan integration intentionally deferred to follow-up PR — kept reviewable

## Why

Today the decoder rejects every Curve calldata path with `DecodeError::CurveUnsupported`, even though the analytical `CurvePool::predict_post_state` predictor has been shipped + tested for months. This PR removes the decode-layer block so the predictor becomes reachable from the mempool path.

## Files Changed

| File | Purpose |
|---|---|
| `crates/pools/src/router_decoder.rs` | `Protocol::Curve` variant, `DecodedSwap.curve_indices`, three `ICurvePool*` interfaces + `try_curve` dispatch, `curve_indices_from_int128/uint256` u8 narrowing, 5 unit tests |
| `crates/grpc-server/src/mempool_pipeline.rs` | Curve arm in `decoder_protocol_to_type`, `decoder_protocol_label`, `protocol_label`. Early-return at `try_post_state_scan` top with `curve_post_state_pending` skip reason (sim integration deferred) |

## Implementation notes

- **Curve is pool-direct, not router-based.** Unlike V2/V3/Balancer, Curve users send `exchange(...)` calldata directly to the pool address. `DecodedSwap.router` therefore carries the *pool* address for Curve. Upstream pipeline must resolve token addresses via `pool_registry[router]` keyed off `curve_indices` — done in the deferred follow-up PR.
- **`token_in` / `token_out` left as `Address::ZERO` for Curve.** Decoder can't resolve indices to addresses without the coin list. Documented in the field doc.
- **Index narrowing is strict.** Solidity `int128` indices that are negative or `> u8::MAX` reject as `AbiDecode` rather than silently truncating. Same for `uint256` overflow. Mainnet Curve pools are ≤ 8 coins, so any out-of-range value indicates malformed calldata or a non-standard pool the predictor shouldn't be touching.
- **Two interfaces for two `exchange` signatures.** The `sol!` macro can't generate two Rust functions named `exchange` in one interface block, so the int128 and uint256 flavours live in separate interfaces. Selectors are still derived from the on-chain solidity names.
- **`is_unsupported_curve_router` left in place.** That short-circuit catches calls to the Curve aggregator router (`exchange_multiple` shape), which this PR does not handle. Pool-direct calls bypass the short-circuit because they target pool addresses, not the router.

## Scope cut: post-state scan integration deferred

The full pipeline integration would require:
- Curve arm in `try_post_state_scan`'s V3/Balancer post-state branch (route through `predict_post_state_with_fallback` — which already handles Curve)
- `unified_to_post_reserves` Curve arm
- `PredictedPostState::Curve { reserve_in, reserve_out }` variant in `mempool_writer`
- 2-coin index → token-address resolution at scan time
- Curve pool addresses added to mempool router filter (otherwise Alchemy never delivers pool-direct txs to us)

That's a parallel-to-existing-code chunk that's better reviewed standalone. This PR ships the decoder + tagging so the unblock is visible on dashboards immediately; the follow-up turns that signal into a post-state cycle candidate.

## Acceptance criteria

- [x] `exchange(int128, int128, uint256, uint256)` decodes
- [x] `exchange_underlying(int128, int128, uint256, uint256)` decodes
- [x] `exchange(uint256, uint256, uint256, uint256)` decodes
- [x] Negative `int128` indices reject as `AbiDecode`
- [x] `uint256` indices above `u8::MAX` reject as `AbiDecode`
- [x] Curve swaps tag `aether_pending_dex_tx_total{protocol="curve"}` instead of `decode_failure`
- [x] `aether_mempool_predictions` rows persist with `protocol="curve"`
- [ ] Curve post-state cycles surface on `aether_pending_arb_candidates_total` (follow-up)

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --release -- --test-threads=1` all green (workspace test count +5)
- [x] 5 unit tests in `router_decoder::tests::decode_curve_*` covering happy path × 3 ABI shapes + 2 reject paths
- [x] `go build ./...` + `go test ./... -count=1` green (no Go changes, regression check)
- [ ] Verify against live mainnet — `aether_pending_dex_tx_total{protocol="curve"}` should increment within minutes of boot (Curve TVL is high; pool-direct exchanges are common)