### PR TITLE
feat(decoder): Bancor V3 BancorNetwork trade() decoder + protocol tagging

### DIFF
--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -51,7 +51,7 @@ use crate::service::aether_proto;
 use crate::engine::PoolMetadata;
 use crate::mempool_writer::{
     MempoolPredictionSink, NewMempoolPrediction, PredictedPostState, PROTOCOL_BALANCER,
-    PROTOCOL_CURVE, PROTOCOL_SUSHI, PROTOCOL_UNI_V2, PROTOCOL_UNI_V3,
+    PROTOCOL_BANCOR, PROTOCOL_CURVE, PROTOCOL_SUSHI, PROTOCOL_UNI_V2, PROTOCOL_UNI_V3,
 };
 use crate::EngineMetrics;
 
@@ -393,6 +393,7 @@ fn decoder_protocol_to_type(p: Protocol) -> Option<ProtocolType> {
         Protocol::UniswapV3 => Some(ProtocolType::UniswapV3),
         Protocol::BalancerV2 => Some(ProtocolType::BalancerV2),
         Protocol::Curve => Some(ProtocolType::Curve),
+        Protocol::BancorV3 => Some(ProtocolType::BancorV3),
     }
 }
 
@@ -459,6 +460,17 @@ fn try_post_state_scan(
         metrics.inc_pending_arb_sim_skipped("curve_post_state_pending");
         return;
     }
+    // Bancor V3 post-state scan is intentionally deferred to a follow-up
+    // PR. The BancorPool predictor lives in `aether-pools` (BNT-
+    // intermediary swap math) but lacks an analytical post-state hook
+    // through `predict_post_state_with_fallback`. Decoded swaps already
+    // surface on `pending_dex_tx_total{protocol="bancor_v3"}` via
+    // `emit_decoded` upstream; the cycle-scan integration is the next
+    // increment. Same scope-cut as the Curve decoder PR.
+    if swap.protocol == Protocol::BancorV3 {
+        metrics.inc_pending_arb_sim_skipped("bancor_post_state_pending");
+        return;
+    }
 
     let target_protocol = match swap.protocol {
         Protocol::UniswapV2 => ProtocolType::UniswapV2,
@@ -466,6 +478,7 @@ fn try_post_state_scan(
         Protocol::UniswapV3 => ProtocolType::UniswapV3,
         Protocol::BalancerV2 => ProtocolType::BalancerV2,
         Protocol::Curve => unreachable!("curve early-returned above"),
+        Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     };
 
     let token_idx = ctx.token_index.load();
@@ -548,6 +561,7 @@ fn try_post_state_scan(
             (pin, pout)
         }
         Protocol::Curve => unreachable!("curve early-returned above"),
+        Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     };
 
     // Clone the graph and apply the post-state to both directions of the
@@ -582,6 +596,7 @@ fn try_post_state_scan(
             reserve_out: post_out,
         },
         Protocol::Curve => unreachable!("curve early-returned above"),
+        Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     }
     .into_json();
     let prediction = NewMempoolPrediction {
@@ -958,6 +973,7 @@ fn decoder_protocol_label(p: Protocol) -> &'static str {
         Protocol::UniswapV3 => PROTOCOL_UNI_V3,
         Protocol::BalancerV2 => PROTOCOL_BALANCER,
         Protocol::Curve => PROTOCOL_CURVE,
+        Protocol::BancorV3 => PROTOCOL_BANCOR,
     }
 }
 
@@ -1090,6 +1106,7 @@ fn protocol_label(p: Protocol) -> &'static str {
         Protocol::SushiSwap => "sushiswap",
         Protocol::BalancerV2 => "balancer_v2",
         Protocol::Curve => "curve",
+        Protocol::BancorV3 => "bancor_v3",
     }
 }
 

--- a/crates/grpc-server/src/mempool_writer.rs
+++ b/crates/grpc-server/src/mempool_writer.rs
@@ -64,6 +64,11 @@ pub const PROTOCOL_UNI_V3: &str = "uni_v3";
 #[allow(dead_code)]
 pub const PROTOCOL_CURVE: &str = "curve";
 pub const PROTOCOL_BALANCER: &str = "balancer";
+/// Reserved for Bancor V3 decoder path. Like `PROTOCOL_CURVE`, listed
+/// here so the wire label is pinned even before the writer is wired up
+/// downstream.
+#[allow(dead_code)]
+pub const PROTOCOL_BANCOR: &str = "bancor";
 
 /// Insert payload for the `mempool_predictions` table. Field shapes mirror
 /// the SQL schema 1:1 so a sqlx bind is a straight enumeration.

--- a/crates/ingestion/src/mempool.rs
+++ b/crates/ingestion/src/mempool.rs
@@ -282,6 +282,7 @@ pub fn default_router_addresses() -> Vec<Address> {
         address!("d9e1cE17f2641f24aE83637ab66a2cca9C378B9F"), // SushiSwap Router02
         address!("99a58482BD75cbab83b27EC03CA68fF489b5788f"), // Curve Router
         address!("BA12222222228d8Ba445958a75a0704d566BF2C8"), // Balancer V2 Vault
+        address!("eEF417e1D5CC832e619ae18D2F140De2999dD4fB"), // Bancor V3 BancorNetwork
     ]
 }
 

--- a/crates/pools/src/router_decoder.rs
+++ b/crates/pools/src/router_decoder.rs
@@ -87,6 +87,11 @@ pub enum Protocol {
     /// from the pool registry using the indices in
     /// [`DecodedSwap.curve_indices`].
     Curve,
+    /// Bancor V3 `BancorNetwork.tradeBySourceAmount`. Unlike Curve, this
+    /// is router-mediated (not pool-direct), so `DecodedSwap.router` is
+    /// the BancorNetwork address and `token_in`/`token_out` are resolved
+    /// from calldata directly.
+    BancorV3,
 }
 
 /// Minimal swap shape produced by the decoder.
@@ -232,6 +237,18 @@ sol! {
         function exchange(uint256 i, uint256 j, uint256 dx, uint256 min_dy) external returns (uint256);
     }
 
+    /// Bancor V3 `BancorNetwork`. The dominant pending-tx shape is
+    /// `tradeBySourceAmount(source, target, sourceAmount, minReturn,
+    /// deadline, beneficiary)` — the user commits a known source amount
+    /// and accepts ≥ minReturn. The complementary `tradeByTargetAmount`
+    /// shape (commit a target amount, pay ≤ maxSource) is decoded with a
+    /// parallel arm so both flavours land in the same `DecodedSwap` shape.
+    #[allow(missing_docs)]
+    interface IBancorNetwork {
+        function tradeBySourceAmount(address sourceToken, address targetToken, uint256 sourceAmount, uint256 minReturnAmount, uint256 deadline, address beneficiary) external payable returns (uint256);
+        function tradeByTargetAmount(address sourceToken, address targetToken, uint256 targetAmount, uint256 maxSourceAmount, uint256 deadline, address beneficiary) external payable returns (uint256);
+    }
+
     /// Balancer V2 Vault `swap` for the SingleSwap shape.
     #[allow(missing_docs)]
     interface IBalancerVault {
@@ -286,6 +303,10 @@ pub fn decode_pending(to: Address, calldata: &[u8]) -> Result<DecodedSwap, Decod
     }
     // ── Curve StableSwap pool-direct exchange() ──
     if let Some(swap) = try_curve(selector, calldata, to)? {
+        return Ok(swap);
+    }
+    // ── Bancor V3 BancorNetwork ──
+    if let Some(swap) = try_bancor(selector, calldata, to)? {
         return Ok(swap);
     }
 
@@ -607,6 +628,61 @@ fn try_curve(
     Ok(None)
 }
 
+/// Bancor V3 `BancorNetwork` decoder.
+///
+/// Routes both `tradeBySourceAmount` (commit source, accept min target)
+/// and `tradeByTargetAmount` (commit target, pay max source). The two
+/// shapes carry the same `(source, target)` token pair so collapse to a
+/// single `DecodedSwap` body — the `amount_in` / `amount_out_min`
+/// semantics differ slightly (`tradeByTargetAmount` puts the user-
+/// committed *target* amount in `amount_in` and the *source ceiling* in
+/// `amount_out_min`), but both numbers are still actionable signal for
+/// the upstream post-state simulator.
+fn try_bancor(
+    selector: [u8; 4],
+    calldata: &[u8],
+    router: Address,
+) -> Result<Option<DecodedSwap>, DecodeError> {
+    use IBancorNetwork::*;
+    if selector == tradeBySourceAmountCall::SELECTOR {
+        let c = tradeBySourceAmountCall::abi_decode(calldata)
+            .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+        return Ok(Some(DecodedSwap {
+            protocol: Protocol::BancorV3,
+            router,
+            token_in: c.sourceToken,
+            token_out: c.targetToken,
+            amount_in: c.sourceAmount,
+            amount_out_min: c.minReturnAmount,
+            recipient: c.beneficiary,
+            fee_bps: 0,
+            path_extra: vec![],
+            curve_indices: None,
+        }));
+    }
+    if selector == tradeByTargetAmountCall::SELECTOR {
+        let c = tradeByTargetAmountCall::abi_decode(calldata)
+            .map_err(|e| DecodeError::AbiDecode(e.to_string()))?;
+        return Ok(Some(DecodedSwap {
+            protocol: Protocol::BancorV3,
+            router,
+            token_in: c.sourceToken,
+            token_out: c.targetToken,
+            // tradeByTargetAmount commits the target amount; surface it
+            // as amount_in so the predictor has a real magnitude rather
+            // than zero. The user-paid source ceiling lives in
+            // amount_out_min for symmetry.
+            amount_in: c.targetAmount,
+            amount_out_min: c.maxSourceAmount,
+            recipient: c.beneficiary,
+            fee_bps: 0,
+            path_extra: vec![],
+            curve_indices: None,
+        }));
+    }
+    Ok(None)
+}
+
 /// Narrow Curve `int128` index args to `u8`. Mainnet Curve pools are
 /// ≤ 8 coins so a value that doesn't fit `u8` (negative, > 255) is
 /// either malformed calldata or a non-standard pool we shouldn't be
@@ -912,5 +988,61 @@ mod tests {
         let err = decode_pending(pool, &calldata).unwrap_err();
         assert!(matches!(err, DecodeError::AbiDecode(_)),
             "index above u8::MAX should reject as AbiDecode, got {err:?}");
+    }
+
+    // ── Bancor V3 BancorNetwork decoder ──
+
+    #[test]
+    fn decode_bancor_trade_by_source_amount() {
+        let bancor = address!("eEF417e1D5CC832e619ae18D2F140De2999dD4fB");
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let bnt = address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C");
+        let beneficiary = address!("000000000000000000000000000000000000dEaD");
+        let calldata = IBancorNetwork::tradeBySourceAmountCall {
+            sourceToken: weth,
+            targetToken: bnt,
+            sourceAmount: U256::from(1_000_000_000_000_000_000u128), // 1 WETH
+            minReturnAmount: U256::from(2_500u64 * 10u64.pow(18)),    // 2500 BNT
+            deadline: U256::from(99_999_999_999u64),
+            beneficiary,
+        }
+        .abi_encode();
+        let decoded = decode_pending(bancor, &calldata).expect("should decode");
+        assert_eq!(decoded.protocol, Protocol::BancorV3);
+        assert_eq!(decoded.router, bancor);
+        assert_eq!(decoded.token_in, weth);
+        assert_eq!(decoded.token_out, bnt);
+        assert_eq!(decoded.amount_in, U256::from(1_000_000_000_000_000_000u128));
+        assert_eq!(decoded.amount_out_min, U256::from(2_500u64 * 10u64.pow(18)));
+        assert_eq!(decoded.recipient, beneficiary);
+        assert_eq!(decoded.fee_bps, 0);
+        assert!(decoded.path_extra.is_empty());
+    }
+
+    #[test]
+    fn decode_bancor_trade_by_target_amount() {
+        // Target-amount flavour: user commits a target amount, accepts up
+        // to maxSource. Decoder surfaces targetAmount as `amount_in` and
+        // maxSourceAmount as `amount_out_min` for symmetry with the
+        // source-amount path — both numbers are real magnitudes for the
+        // predictor.
+        let bancor = address!("eEF417e1D5CC832e619ae18D2F140De2999dD4fB");
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let bnt = address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C");
+        let calldata = IBancorNetwork::tradeByTargetAmountCall {
+            sourceToken: weth,
+            targetToken: bnt,
+            targetAmount: U256::from(5_000u64),
+            maxSourceAmount: U256::from(2_000u64),
+            deadline: U256::from(99u64),
+            beneficiary: Address::ZERO,
+        }
+        .abi_encode();
+        let decoded = decode_pending(bancor, &calldata).expect("should decode");
+        assert_eq!(decoded.protocol, Protocol::BancorV3);
+        assert_eq!(decoded.token_in, weth);
+        assert_eq!(decoded.token_out, bnt);
+        assert_eq!(decoded.amount_in, U256::from(5_000u64));
+        assert_eq!(decoded.amount_out_min, U256::from(2_000u64));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Protocol::BancorV3` enum variant + Bancor V3 `BancorNetwork` calldata decoder
- Covers both trade flavours: `tradeBySourceAmount` (commit source, accept min target) + `tradeByTargetAmount` (commit target, pay max source)
- Bancor router address (`0xeEF417e1D5CC832e619ae18D2F140De2999dD4fB`) joins `default_router_addresses` — Alchemy now actually forwards Bancor traffic to us
- `PROTOCOL_BANCOR` writer wire label registered so the schema stays pinned
- Pipeline tags decoded Bancor swaps via `protocol="bancor_v3"` on every mempool metric
- Post-state scan integration intentionally deferred (same pattern as the Curve PR #156) — kept reviewable

## Why

Bancor V3 has been in our `ProtocolType` enum + `BancorPool` predictor for months, but the decoder rejected every Bancor calldata path with `UnknownSelector`. This unblocks the observability for Bancor's BNT-intermediary swap volume — small relative to Uni V2/V3 but real and currently invisible.

## Files Changed

| File | Purpose |
|---|---|
| `crates/pools/src/router_decoder.rs` | `Protocol::BancorV3` variant, `IBancorNetwork` sol! interface, `try_bancor` dispatch, 2 unit tests |
| `crates/ingestion/src/mempool.rs` | Bancor router address in `default_router_addresses` |
| `crates/grpc-server/src/mempool_writer.rs` | `PROTOCOL_BANCOR` wire label constant (paired with the existing reserved `PROTOCOL_CURVE`) |
| `crates/grpc-server/src/mempool_pipeline.rs` | Bancor arms in `decoder_protocol_to_type`, `decoder_protocol_label`, `protocol_label`. Early-return at `try_post_state_scan` top with `bancor_post_state_pending` skip reason |

## Implementation notes

- **Router-mediated**, not pool-direct. Unlike Curve, Bancor swaps target the single `BancorNetwork` router — fits the existing decoder model without needing a parallel "pool-direct" code path. `token_in` and `token_out` come from calldata directly (`sourceToken` / `targetToken` args), no registry resolution needed.
- **Both trade shapes collapse to one `DecodedSwap` body.** `tradeByTargetAmount` puts the user-committed *target* amount in `DecodedSwap.amount_in` and the *source ceiling* in `amount_out_min`. Semantics slightly differ from the source-amount path but both numbers are real magnitudes — the upstream predictor gets actionable signal either way.
- **`fee_bps = 0`** for Bancor in the decoded swap. Bancor's fee is applied per-leg through the BNT intermediary and isn't visible in calldata; the predictor reads the on-chain fee from pool state.

## Scope cut

Same as Curve PR #156. The follow-up PR needs:
- `predict_post_state_with_fallback` Bancor arm (BancorPool currently has no analytical post-state hook through the unified fallback API)
- `PredictedPostState::Bancor { reserve_in, reserve_out }` variant in `mempool_writer`
- `unified_to_post_reserves` Bancor arm in pipeline

Splitting keeps each review surface ~150 LOC instead of ~500.

## Acceptance criteria

- [x] `tradeBySourceAmount` decodes with correct token + amount
- [x] `tradeByTargetAmount` decodes with target as `amount_in`, max source as `amount_out_min`
- [x] Bancor swaps tag `aether_pending_dex_tx_total{protocol="bancor_v3"}` instead of `decode_failure`
- [x] `aether_mempool_predictions` rows persist with `protocol="bancor"` once writer is reached (writer constant pinned, pipeline label wired)
- [ ] Bancor post-state cycles surface on `aether_pending_arb_candidates_total` (follow-up)

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --release -- --test-threads=1` all green
- [x] 2 unit tests in `router_decoder::tests::decode_bancor_*` covering both trade shapes
- [x] `go build ./...` + `go test ./... -count=1` green (no Go changes, regression check)
- [ ] Verify against live mainnet — `aether_pending_dex_tx_total{protocol="bancor_v3"}` should increment within an hour (Bancor volume is lower than Uniswap; expect ≥ 1 per few-min window)
