### PR TITLE
feat(mempool): route Curve through analytical post-state predictor + filter pool addresses

### DIFF
--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -623,25 +623,13 @@ fn try_post_state_scan(
     event_to: Address,
     event: &PendingTxEvent,
 ) {
-    // Curve post-state scan is intentionally deferred to a follow-up PR
-    // (the V3/Balancer branch downstream needs a parallel Curve arm that
-    // routes through `unified_to_post_reserves`'s Curve variant + the
-    // PredictedPostState writer). For now, log the decoded swap via
-    // `emit_decoded` upstream so `pending_dex_tx_total{protocol="curve"}`
-    // climbs, then bail out with a dedicated skip reason. The decoder is
-    // the unblock that matters here; turning that signal into a cycle
-    // candidate is the next increment.
-    if swap.protocol == Protocol::Curve {
-        metrics.inc_pending_arb_sim_skipped("curve_post_state_pending");
-        return;
-    }
     // Bancor V3 post-state scan is intentionally deferred to a follow-up
-    // PR. The BancorPool predictor lives in `aether-pools` (BNT-
-    // intermediary swap math) but lacks an analytical post-state hook
-    // through `predict_post_state_with_fallback`. Decoded swaps already
-    // surface on `pending_dex_tx_total{protocol="bancor_v3"}` via
-    // `emit_decoded` upstream; the cycle-scan integration is the next
-    // increment. Same scope-cut as the Curve decoder PR.
+    // PR. `BancorPool` is not in the `PoolState` enum and has no
+    // `predict_post_state` analytical hook yet — adding both is its own
+    // ~500 LOC change (BNT bonding-curve math + PoolState/UnifiedPostState
+    // extension). Decoded swaps already surface on
+    // `pending_dex_tx_total{protocol="bancor_v3"}` via `emit_decoded`
+    // upstream; the cycle-scan integration is the next increment.
     if swap.protocol == Protocol::BancorV3 {
         metrics.inc_pending_arb_sim_skipped("bancor_post_state_pending");
         return;
@@ -652,7 +640,7 @@ fn try_post_state_scan(
         Protocol::SushiSwap => ProtocolType::SushiSwap,
         Protocol::UniswapV3 => ProtocolType::UniswapV3,
         Protocol::BalancerV2 => ProtocolType::BalancerV2,
-        Protocol::Curve => unreachable!("curve early-returned above"),
+        Protocol::Curve => ProtocolType::Curve,
         Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     };
 
@@ -711,7 +699,7 @@ fn try_post_state_scan(
             let dx = u256_to_f64_saturating(swap.amount_in);
             predict_v2_post_state(edge_fwd.reserve_in, edge_fwd.reserve_out, dx, fee_factor)
         }
-        Protocol::UniswapV3 | Protocol::BalancerV2 => {
+        Protocol::UniswapV3 | Protocol::BalancerV2 | Protocol::Curve => {
             let pool_addr = meta.pool_id.address;
             let Some(state_arc) = ctx.pool_states.get(&pool_addr).map(|r| Arc::clone(r.value()))
             else {
@@ -736,7 +724,6 @@ fn try_post_state_scan(
             }
             (pin, pout)
         }
-        Protocol::Curve => unreachable!("curve early-returned above"),
         Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     };
 
@@ -771,7 +758,10 @@ fn try_post_state_scan(
             reserve_in: post_in,
             reserve_out: post_out,
         },
-        Protocol::Curve => unreachable!("curve early-returned above"),
+        Protocol::Curve => PredictedPostState::Curve {
+            reserve_in: post_in,
+            reserve_out: post_out,
+        },
         Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     }
     .into_json();
@@ -1327,7 +1317,16 @@ fn unified_to_post_reserves(
                 (b1, b0)
             }
         }
-        UnifiedPostState::Curve(_) => (0.0, 0.0),
+        UnifiedPostState::Curve(c) => {
+            // `CurvePostState.i`/`.j` are the swap direction (token_in / token_out)
+            // *as the predictor saw it*, regardless of the pool's underlying
+            // token ordering — so `new_balance_in` is always for `swap_token_in`
+            // and `new_balance_out` is always for the other side. No swap_token_in
+            // vs meta.token0/token1 comparison is needed here.
+            let post_in = u256_to_f64_saturating(c.new_balance_in);
+            let post_out = u256_to_f64_saturating(c.new_balance_out);
+            (post_in, post_out)
+        }
     }
 }
 
@@ -1501,6 +1500,59 @@ mod tests {
             None,
             pending_event(None, vec![0x12, 0x34, 0x56, 0x78]),
         );
+    }
+
+    // ----- unified_to_post_reserves Curve arm -----
+
+    #[test]
+    fn unified_to_post_reserves_curve_uses_predictor_balances_directly() {
+        use aether_common::types::PoolId;
+        use aether_pools::curve::CurvePostState;
+        use aether_pools::UnifiedPostState;
+        let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let usdt = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let meta = PoolMetadata {
+            token0_idx: 0,
+            token1_idx: 1,
+            token0: usdc,
+            token1: usdt,
+            pool_id: PoolId {
+                address: Address::ZERO,
+                protocol: ProtocolType::Curve,
+            },
+            protocol: ProtocolType::Curve,
+            fee_bps: 4,
+            tick_spacing: None,
+        };
+        let post = UnifiedPostState::Curve(CurvePostState {
+            i: 0,
+            j: 1,
+            new_balance_in: U256::from(11_000_000u64),
+            new_balance_out: U256::from(9_900_000u64),
+            amount_out: U256::from(99_500u64),
+            analytical: true,
+        });
+        // Curve predictor already reports "in" and "out" relative to the
+        // swap direction — the helper must trust them directly, regardless
+        // of swap_token_in vs meta.token0/token1 ordering.
+        let (pin, pout) = unified_to_post_reserves(usdc, &meta, &post);
+        assert!((pin - 11_000_000.0).abs() < 1e-6);
+        assert!((pout - 9_900_000.0).abs() < 1e-6);
+
+        // Reverse direction: predictor would have flipped `i`/`j` upstream;
+        // helper still trusts `new_balance_in`/`new_balance_out` directly,
+        // which is the contract documented on the function.
+        let post_reverse = UnifiedPostState::Curve(CurvePostState {
+            i: 1,
+            j: 0,
+            new_balance_in: U256::from(11_000_000u64),
+            new_balance_out: U256::from(9_900_000u64),
+            amount_out: U256::from(99_500u64),
+            analytical: true,
+        });
+        let (pin_r, pout_r) = unified_to_post_reserves(usdt, &meta, &post_reverse);
+        assert!((pin_r - 11_000_000.0).abs() < 1e-6);
+        assert!((pout_r - 9_900_000.0).abs() < 1e-6);
     }
 
     // ----- predict_v2_post_state -----

--- a/crates/grpc-server/src/mempool_writer.rs
+++ b/crates/grpc-server/src/mempool_writer.rs
@@ -139,6 +139,15 @@ pub enum PredictedPostState {
         reserve_in: f64,
         reserve_out: f64,
     },
+    /// Curve StableSwap: balances of the (token_in, token_out) coin pair
+    /// post-swap, expressed as `f64` so the JSONB row matches what the
+    /// price graph holds. The full N-coin balance vector lives in the
+    /// `CurvePostState` predictor output but only the two coins the
+    /// victim touched matter for graph-edge accuracy here.
+    Curve {
+        reserve_in: f64,
+        reserve_out: f64,
+    },
 }
 
 impl PredictedPostState {
@@ -509,13 +518,17 @@ mod tests {
                 reserve_in: 10.0,
                 reserve_out: 20.0,
             },
+            PredictedPostState::Curve {
+                reserve_in: 1_000_000.0,
+                reserve_out: 999_500.0,
+            },
         ] {
             let json = serde_json::to_value(&original).expect("serialize");
             let kind = json.get("kind").and_then(|v| v.as_str()).expect("kind present");
             // `kind` lives under `#[serde(rename_all = "snake_case")]` so a
             // future refactor that drops the rename surfaces here.
             assert!(
-                ["v2", "v3", "balancer"].contains(&kind),
+                ["v2", "v3", "balancer", "curve"].contains(&kind),
                 "unexpected kind {kind}"
             );
             let parsed: PredictedPostState = serde_json::from_value(json).expect("deserialize");

--- a/crates/ingestion/src/mempool.rs
+++ b/crates/ingestion/src/mempool.rs
@@ -332,10 +332,14 @@ fn warn_if_non_alchemy_endpoint(ws_url: &str) {
 ///
 /// Curated for the testing scaffold: UniswapV2 Router02, UniswapV3
 /// SwapRouter, UniswapV3 SwapRouter02, SushiSwap Router02, Curve Router,
-/// Balancer Vault. 1inch v6 AggregationRouter is intentionally absent — its
-/// multi-step calldata does not decode against a simple `sol!` ABI and would
-/// inflate the decode-failure counter without yielding usable hits in the
-/// scaffold; revisit once the decoder has the multi-encode path.
+/// Balancer Vault, Bancor V3 BancorNetwork, plus the highest-volume Curve
+/// pool addresses (the pool-direct `exchange()` path skips the router so
+/// the router address alone misses Curve traffic — see
+/// `aether-pools::router_decoder::try_curve`). 1inch v6 AggregationRouter
+/// is intentionally absent — its multi-step calldata does not decode
+/// against a simple `sol!` ABI and would inflate the decode-failure
+/// counter without yielding usable hits in the scaffold; revisit once
+/// the decoder has the multi-encode path.
 pub fn default_router_addresses() -> Vec<Address> {
     use alloy::primitives::address;
     vec![
@@ -346,6 +350,19 @@ pub fn default_router_addresses() -> Vec<Address> {
         address!("99a58482BD75cbab83b27EC03CA68fF489b5788f"), // Curve Router
         address!("BA12222222228d8Ba445958a75a0704d566BF2C8"), // Balancer V2 Vault
         address!("eEF417e1D5CC832e619ae18D2F140De2999dD4fB"), // Bancor V3 BancorNetwork
+        // ── Curve pools (pool-direct `exchange()` traffic) ──
+        // Curve calls hit pool addresses directly when the user / aggregator
+        // skips the Curve Router. Without these in the `toAddress` filter
+        // Alchemy never forwards them and the decoder we just landed
+        // (PR #156) stays unreachable for the majority of Curve volume.
+        // List is the top-by-volume mainnet pools as of 2026-05; keep
+        // synced with `config/pools.toml` Curve entries.
+        address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7"), // Curve 3pool (DAI/USDC/USDT)
+        address!("DC24316b9AE028F1497c275EB9192a3Ea0f67022"), // Curve stETH/ETH
+        address!("D51a44d3FaE010294C616388b506AcdA1bfAAE46"), // Curve tricrypto2 (USDT/WBTC/WETH)
+        address!("a1F8A6807c402E4A15ef4EBa36528A3FED24E577"), // Curve frxETH/ETH
+        address!("4eBdF703948ddCEA3B11f675B4D1Fba9d2414A14"), // Curve tricryptoUSDC
+        address!("f5f5B97624542D72A9E06f04804Bf81baA15e2B4"), // Curve tricryptoUSDT
     ]
 }
 


### PR DESCRIPTION
## Summary

- Adds 6 top-by-volume Curve pool addresses to `default_router_addresses()` so Alchemy actually forwards pool-direct `exchange()` traffic to us
- Adds `PredictedPostState::Curve { reserve_in, reserve_out }` writer variant so Curve mempool predictions land on the `mempool_predictions` table
- Wires Curve into the same `try_post_state_scan` branch that already handles V3 / Balancer — removes the `curve_post_state_pending` skip introduced in #156 as a scope cut
- `unified_to_post_reserves` Curve arm reads `CurvePostState.new_balance_in` / `new_balance_out` directly

## Why

Three of the four pieces needed for Curve mempool coverage already landed (decoder in #156, `CurvePool::predict_post_state` since the v3/curve/balancer predictor PR, `UnifiedPostState::Curve` variant). What was missing:
1. The pool addresses in the Alchemy filter — without them, Curve traffic never reaches us in the first place
2. The pipeline arm to route decoded Curve swaps through the analytical predictor instead of skipping with `curve_post_state_pending`
3. The writer variant so Curve predictions persist to Postgres

This PR closes all three. Curve victims now flow through the same cycle-scan path as V3 / Balancer, populate `aether_pending_arb_candidates_total{router, profit_bucket}` when profitable, and persist to `mempool_predictions` with `protocol = "curve"`.

## Files Changed

| File | Purpose |
|---|---|
| `crates/ingestion/src/mempool.rs` | 6 Curve pool addresses (3pool, stETH/ETH, tricrypto2, frxETH/ETH, tricryptoUSDC, tricryptoUSDT) added to `default_router_addresses()` |
| `crates/grpc-server/src/mempool_writer.rs` | `PredictedPostState::Curve` variant + JSON round-trip test coverage |
| `crates/grpc-server/src/mempool_pipeline.rs` | Remove `curve_post_state_pending` early-return. Fold `Protocol::Curve` into the `Protocol::UniswapV3 \| Protocol::BalancerV2` match arm. `unified_to_post_reserves` Curve arm. `PredictedPostState::Curve` emission. New unit test covering the Curve unified mapping |

## Implementation notes

- **Curve predictor reports direction.** `CurvePostState` carries `i` / `j` indices that the predictor already used to align `new_balance_in` / `new_balance_out` with the swap direction (regardless of pool token ordering). `unified_to_post_reserves` trusts those directly — no `swap_token_in` vs `meta.token0` / `meta.token1` comparison is needed (unlike Balancer which keys off `b.new_balance0` / `b.new_balance1`).
- **Pool addresses curated for volume**, not coverage. The 6 included pools account for the majority of mainnet Curve `exchange()` volume; smaller pools can be added incrementally as the registry grows. Keep the filter sync'd with `config/pools.toml` Curve entries.
- **`amount_out = 0`** would not apply here — Curve predictor always populates `amount_out` because the analytical math gives the user-visible payout exactly.

## Scope cut

Bancor V3 still skips with `bancor_post_state_pending`. Adding Bancor through this path needs:
- `BancorPool::predict_post_state` implementation (BNT bonding-curve math, two-leg via BNT intermediary)
- `PoolState::Bancor` variant
- `UnifiedPostState::Bancor` variant
- `ReplayProtocol::BancorV3` (already exists as a label in the replay metric but no enum variant)
- Pipeline + writer wiring identical to what this PR does for Curve

~500 LOC of net-new work, primarily the bonding-curve predictor. Splitting keeps each review surface small and lets the Curve unblock land independently.

## Acceptance criteria

- [x] Curve decoded swaps route through `predict_post_state_with_replay` instead of skipping
- [x] `unified_to_post_reserves` Curve arm trusts `new_balance_in` / `new_balance_out` regardless of pool token ordering
- [x] `PredictedPostState::Curve` round-trips through JSON cleanly
- [x] Top-volume Curve pools added to Alchemy filter
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets --release -- -D warnings` clean
- [x] `cargo test --workspace --release` all green (1 new unified test + extended writer JSON test)
- [x] `go build ./...` + `go test ./... -count=1` green (no Go changes, regression check)
- [x] `forge build` + `forge test` green (no Solidity changes, regression check)
- [ ] Live mainnet observation: `aether_pending_dex_tx_total{protocol="curve"}` increments within minutes; `aether_pending_arb_sim_skipped_total{reason="curve_post_state_pending"}` flatlines

## Test plan

- [x] New unit test `unified_to_post_reserves_curve_uses_predictor_balances_directly` — verifies the helper trusts `CurvePostState`'s direction-aligned balances for both swap directions
- [x] Extended `predicted_post_state_round_trips_through_json` to cover the `curve` kind
- [ ] Live smoke post-merge — confirm Curve traffic reaches the predictor and produces non-empty `aether_pending_arb_candidates_total{router, profit_bucket}` rows under real victim flow
