### PR TITLE
feat(mempool): route Bancor V3 through analytical post-state predictor

### DIFF
--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -623,25 +623,13 @@ fn try_post_state_scan(
     event_to: Address,
     event: &PendingTxEvent,
 ) {
-    // Bancor V3 post-state scan is intentionally deferred to a follow-up
-    // PR. `BancorPool` is not in the `PoolState` enum and has no
-    // `predict_post_state` analytical hook yet — adding both is its own
-    // ~500 LOC change (BNT bonding-curve math + PoolState/UnifiedPostState
-    // extension). Decoded swaps already surface on
-    // `pending_dex_tx_total{protocol="bancor_v3"}` via `emit_decoded`
-    // upstream; the cycle-scan integration is the next increment.
-    if swap.protocol == Protocol::BancorV3 {
-        metrics.inc_pending_arb_sim_skipped("bancor_post_state_pending");
-        return;
-    }
-
     let target_protocol = match swap.protocol {
         Protocol::UniswapV2 => ProtocolType::UniswapV2,
         Protocol::SushiSwap => ProtocolType::SushiSwap,
         Protocol::UniswapV3 => ProtocolType::UniswapV3,
         Protocol::BalancerV2 => ProtocolType::BalancerV2,
         Protocol::Curve => ProtocolType::Curve,
-        Protocol::BancorV3 => unreachable!("bancor early-returned above"),
+        Protocol::BancorV3 => ProtocolType::BancorV3,
     };
 
     let token_idx = ctx.token_index.load();
@@ -699,7 +687,7 @@ fn try_post_state_scan(
             let dx = u256_to_f64_saturating(swap.amount_in);
             predict_v2_post_state(edge_fwd.reserve_in, edge_fwd.reserve_out, dx, fee_factor)
         }
-        Protocol::UniswapV3 | Protocol::BalancerV2 | Protocol::Curve => {
+        Protocol::UniswapV3 | Protocol::BalancerV2 | Protocol::Curve | Protocol::BancorV3 => {
             let pool_addr = meta.pool_id.address;
             let Some(state_arc) = ctx.pool_states.get(&pool_addr).map(|r| Arc::clone(r.value()))
             else {
@@ -724,7 +712,6 @@ fn try_post_state_scan(
             }
             (pin, pout)
         }
-        Protocol::BancorV3 => unreachable!("bancor early-returned above"),
     };
 
     // Clone the graph and apply the post-state to both directions of the
@@ -762,7 +749,10 @@ fn try_post_state_scan(
             reserve_in: post_in,
             reserve_out: post_out,
         },
-        Protocol::BancorV3 => unreachable!("bancor early-returned above"),
+        Protocol::BancorV3 => PredictedPostState::Bancor {
+            reserve_in: post_in,
+            reserve_out: post_out,
+        },
     }
     .into_json();
     let prediction = NewMempoolPrediction {
@@ -1327,6 +1317,15 @@ fn unified_to_post_reserves(
             let post_out = u256_to_f64_saturating(c.new_balance_out);
             (post_in, post_out)
         }
+        UnifiedPostState::Bancor(b) => {
+            // Same shape as Curve: `BancorPostState.new_balance_in`/`new_balance_out`
+            // are already aligned with the swap direction (the predictor checks
+            // `token_in == self.token` vs `== self.bnt` upstream). Trust them
+            // directly without re-deriving the direction from meta.token0/token1.
+            let post_in = u256_to_f64_saturating(b.new_balance_in);
+            let post_out = u256_to_f64_saturating(b.new_balance_out);
+            (post_in, post_out)
+        }
     }
 }
 
@@ -1553,6 +1552,41 @@ mod tests {
         let (pin_r, pout_r) = unified_to_post_reserves(usdt, &meta, &post_reverse);
         assert!((pin_r - 11_000_000.0).abs() < 1e-6);
         assert!((pout_r - 9_900_000.0).abs() < 1e-6);
+    }
+
+    // ----- unified_to_post_reserves Bancor arm -----
+
+    #[test]
+    fn unified_to_post_reserves_bancor_uses_predictor_balances_directly() {
+        use aether_common::types::PoolId;
+        use aether_pools::bancor::BancorPostState;
+        use aether_pools::UnifiedPostState;
+        let weth = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let bnt = address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C");
+        let meta = PoolMetadata {
+            token0_idx: 0,
+            token1_idx: 1,
+            token0: weth,
+            token1: bnt,
+            pool_id: PoolId {
+                address: Address::ZERO,
+                protocol: ProtocolType::BancorV3,
+            },
+            protocol: ProtocolType::BancorV3,
+            fee_bps: 30,
+            tick_spacing: None,
+        };
+        // Predictor aligns new_balance_in/out to swap direction — helper
+        // trusts them directly regardless of swap_token_in vs meta.token0/1.
+        let post = UnifiedPostState::Bancor(BancorPostState {
+            new_balance_in: U256::from(1_010_000_000_000_000_000_000u128),
+            new_balance_out: U256::from(1_980_198_019_801_980_198_018u128),
+            amount_out: U256::from(19_801_980_198_019_801_982u128),
+            analytical: true,
+        });
+        let (pin, pout) = unified_to_post_reserves(weth, &meta, &post);
+        assert!((pin - 1_010_000_000_000_000_000_000.0).abs() < 1e6);
+        assert!((pout - 1_980_198_019_801_980_198_018.0).abs() < 1e6);
     }
 
     // ----- predict_v2_post_state -----

--- a/crates/grpc-server/src/mempool_writer.rs
+++ b/crates/grpc-server/src/mempool_writer.rs
@@ -148,6 +148,15 @@ pub enum PredictedPostState {
         reserve_in: f64,
         reserve_out: f64,
     },
+    /// Bancor V3 bonding-curve pool: post-swap balances on the
+    /// (token, BNT) sides, aligned with the swap direction by the
+    /// `BancorPool::predict_post_state` predictor. Multi-hop trades
+    /// (neither token is BNT) bail upstream — only single-pool
+    /// Bancor swaps reach the writer.
+    Bancor {
+        reserve_in: f64,
+        reserve_out: f64,
+    },
 }
 
 impl PredictedPostState {
@@ -522,13 +531,17 @@ mod tests {
                 reserve_in: 1_000_000.0,
                 reserve_out: 999_500.0,
             },
+            PredictedPostState::Bancor {
+                reserve_in: 1_000_000.0,
+                reserve_out: 2_000_000.0,
+            },
         ] {
             let json = serde_json::to_value(&original).expect("serialize");
             let kind = json.get("kind").and_then(|v| v.as_str()).expect("kind present");
             // `kind` lives under `#[serde(rename_all = "snake_case")]` so a
             // future refactor that drops the rename surfaces here.
             assert!(
-                ["v2", "v3", "balancer", "curve"].contains(&kind),
+                ["v2", "v3", "balancer", "curve", "bancor"].contains(&kind),
                 "unexpected kind {kind}"
             );
             let parsed: PredictedPostState = serde_json::from_value(json).expect("deserialize");

--- a/crates/pools/src/bancor.rs
+++ b/crates/pools/src/bancor.rs
@@ -19,6 +19,35 @@ pub struct BancorPool {
     pub fee_bps: u32,
 }
 
+/// Snapshot of a [`BancorPool`] *after* a hypothetical victim swap has
+/// been applied. Returned by [`BancorPool::predict_post_state`] so the
+/// mempool post-state simulator can update its graph-edge cache
+/// without round-tripping to RPC.
+///
+/// `new_balance_in` and `new_balance_out` are aligned with the swap
+/// direction (not the pool's `token` / `bnt` fields), mirroring the
+/// `CurvePostState` shape — the caller's `unified_to_post_reserves`
+/// helper then trusts them directly without re-deriving the direction.
+///
+/// `analytical` is `true` whenever the predictor returns a value; the
+/// Bancor bonding curve is closed-form and always trustworthy when both
+/// reserves are non-zero. The flag is kept on the struct so callers can
+/// drive the same `predict_post_state_with_replay` dispatch they use
+/// for the other pool families.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BancorPostState {
+    /// Post-swap balance on the input side (the side `token_in` belongs
+    /// to). `bnt_balance` when `token_in == bnt`, else `token_balance`.
+    pub new_balance_in: U256,
+    /// Post-swap balance on the output side.
+    pub new_balance_out: U256,
+    /// Output amount the swapper receives, post-fee, in raw token
+    /// units (no decimals normalisation).
+    pub amount_out: U256,
+    /// Confidence flag — see struct docs.
+    pub analytical: bool,
+}
+
 impl BancorPool {
     pub fn new(address: Address, token: Address, bnt: Address, fee_bps: u32) -> Self {
         Self {
@@ -29,6 +58,74 @@ impl BancorPool {
             bnt_balance: U256::ZERO,
             fee_bps,
         }
+    }
+
+    /// Predict the pool's post-swap state under the Bancor bonding curve
+    /// assumption. Mempool post-state simulation uses this to update its
+    /// graph-edge cache after a decoded victim swap, without round-tripping
+    /// to RPC.
+    ///
+    /// Returns `None` when the inputs cannot produce a valid post-state:
+    ///   - pool has no liquidity on either side
+    ///   - `amount_in` is zero
+    ///   - `token_in` is neither the pool's `token` nor BNT — this is the
+    ///     multi-hop case where the victim swaps two non-BNT tokens, the
+    ///     trade hits two pools, and a single `BancorPool` cannot predict
+    ///     the full path. Callers must detect that case upstream and
+    ///     either bail or look up both affected pools.
+    ///
+    /// `analytical = true` on every `Some` return because the Bancor
+    /// bonding curve is closed-form. The flag is carried on the struct
+    /// to keep the public shape uniform with `V3PostState`,
+    /// `CurvePostState`, and `BalancerPostState`.
+    pub fn predict_post_state(
+        &self,
+        token_in: Address,
+        amount_in: U256,
+    ) -> Option<BancorPostState> {
+        if self.token_balance.is_zero() || self.bnt_balance.is_zero() || amount_in.is_zero() {
+            return None;
+        }
+        if token_in != self.token && token_in != self.bnt {
+            // Multi-hop: caller must split into two pool predictions.
+            return None;
+        }
+        let (bal_in, bal_out) = if token_in == self.token {
+            (self.token_balance, self.bnt_balance)
+        } else {
+            (self.bnt_balance, self.token_balance)
+        };
+
+        // Fee applied to input — matches `get_amount_out` above.
+        let fee_complement = U256::from(10_000u64 - self.fee_bps as u64);
+        let amount_in_after_fee = amount_in * fee_complement / U256::from(10_000u64);
+        let numerator = bal_out * amount_in_after_fee;
+        let denominator = bal_in + amount_in_after_fee;
+        if denominator.is_zero() {
+            return None;
+        }
+        let amount_out = numerator / denominator;
+        if amount_out.is_zero() || amount_out >= bal_out {
+            // Degenerate: amount_in_after_fee rounds to zero against a
+            // huge reserve, or the swap would drain the output side. Bail
+            // rather than emit a zero-output edge.
+            return None;
+        }
+
+        // Pool side accounting: the swapper deposits `amount_in` (gross,
+        // not net-of-fee) into the input reserve and withdraws
+        // `amount_out` from the output reserve. The fee is implicitly
+        // retained in the pool, which is why `new_balance_in` grows by
+        // the full `amount_in` rather than the post-fee net.
+        let new_balance_in = bal_in + amount_in;
+        let new_balance_out = bal_out - amount_out;
+
+        Some(BancorPostState {
+            new_balance_in,
+            new_balance_out,
+            amount_out,
+            analytical: true,
+        })
     }
 }
 
@@ -139,5 +236,103 @@ mod tests {
             30,
         );
         assert_eq!(pool.protocol(), ProtocolType::BancorV3);
+    }
+
+    // ----- predict_post_state -----
+
+    fn seeded_pool() -> BancorPool {
+        let mut pool = BancorPool::new(
+            Address::ZERO,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), // WETH
+            address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"), // BNT
+            30,
+        );
+        pool.update_state(
+            U256::from(1_000_000_000_000_000_000_000u128),
+            U256::from(2_000_000_000_000_000_000_000u128),
+        );
+        pool
+    }
+
+    #[test]
+    fn predict_post_state_none_for_zero_amount() {
+        let pool = seeded_pool();
+        assert!(pool.predict_post_state(pool.token, U256::ZERO).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_uninitialised_pool() {
+        let pool = BancorPool::new(
+            Address::ZERO,
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"),
+            30,
+        );
+        assert!(pool.predict_post_state(pool.token, U256::from(1u64)).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_none_for_unknown_token() {
+        let pool = seeded_pool();
+        let bogus = address!("dddddddddddddddddddddddddddddddddddddddd");
+        assert!(pool.predict_post_state(bogus, U256::from(1u64)).is_none());
+    }
+
+    #[test]
+    fn predict_post_state_token_in_to_bnt_balances_shift_correctly() {
+        let pool = seeded_pool();
+        let amount_in = U256::from(10_000_000_000_000_000_000u128); // 10 ETH
+        let post = pool
+            .predict_post_state(pool.token, amount_in)
+            .expect("predictor returns Some");
+        assert!(post.analytical);
+        assert!(post.amount_out > U256::ZERO);
+        // new_balance_in is on the token side (deposited gross amount_in).
+        assert_eq!(post.new_balance_in, pool.token_balance + amount_in);
+        // new_balance_out is on the BNT side (withdrew amount_out).
+        assert_eq!(post.new_balance_out, pool.bnt_balance - post.amount_out);
+    }
+
+    #[test]
+    fn predict_post_state_bnt_to_token_balances_shift_correctly() {
+        let pool = seeded_pool();
+        let amount_in = U256::from(50_000_000_000_000_000_000u128); // 50 BNT
+        let post = pool
+            .predict_post_state(pool.bnt, amount_in)
+            .expect("predictor returns Some");
+        assert!(post.analytical);
+        // Reverse direction: new_balance_in = BNT side; new_balance_out = token side.
+        assert_eq!(post.new_balance_in, pool.bnt_balance + amount_in);
+        assert_eq!(post.new_balance_out, pool.token_balance - post.amount_out);
+    }
+
+    #[test]
+    fn predict_post_state_amount_out_matches_get_amount_out() {
+        let pool = seeded_pool();
+        // Skip degenerate sizes (amount_in_after_fee rounds to zero) — the
+        // predictor bails on those by design while `get_amount_out` returns
+        // a literal zero.
+        for amt in [
+            U256::from(1_000_000_000_000_000_000u128),  // 1 ETH
+            U256::from(100_000_000_000_000_000_000u128), // 100 ETH
+        ] {
+            let analytical_out = pool.get_amount_out(pool.token, amt).expect("get_amount_out");
+            let predicted = pool
+                .predict_post_state(pool.token, amt)
+                .expect("predict_post_state");
+            assert_eq!(
+                predicted.amount_out, analytical_out,
+                "predict_post_state diverged from get_amount_out at amt={amt}"
+            );
+        }
+    }
+
+    #[test]
+    fn predict_post_state_none_for_degenerate_small_amount() {
+        // `amount_in_after_fee` rounds to zero against a large reserve —
+        // the predictor bails so the caller doesn't emit a zero-output
+        // graph edge that would corrupt Bellman-Ford weights.
+        let pool = seeded_pool();
+        assert!(pool.predict_post_state(pool.token, U256::from(1u64)).is_none());
     }
 }

--- a/crates/pools/src/lib.rs
+++ b/crates/pools/src/lib.rs
@@ -14,6 +14,7 @@ use aether_common::types::ProtocolType;
 use dashmap::DashMap;
 
 use crate::balancer::BalancerPool;
+use crate::bancor::BancorPool;
 use crate::curve::CurvePool;
 use crate::uniswap_v2::UniswapV2Pool;
 use crate::uniswap_v3::UniswapV3Pool;
@@ -46,6 +47,7 @@ pub enum PoolState {
     SushiSwap(UniswapV2Pool),
     Curve(CurvePool),
     Balancer(BalancerPool),
+    Bancor(BancorPool),
 }
 
 impl PoolState {
@@ -56,6 +58,7 @@ impl PoolState {
             PoolState::UniswapV3(p) => p.address,
             PoolState::Curve(p) => p.address,
             PoolState::Balancer(p) => p.address,
+            PoolState::Bancor(p) => p.address,
         }
     }
 
@@ -67,6 +70,7 @@ impl PoolState {
             PoolState::SushiSwap(_) => ProtocolType::SushiSwap,
             PoolState::Curve(_) => ProtocolType::Curve,
             PoolState::Balancer(_) => ProtocolType::BalancerV2,
+            PoolState::Bancor(_) => ProtocolType::BancorV3,
         }
     }
 }
@@ -104,6 +108,7 @@ pub enum UnifiedPostState {
     UniswapV3(crate::uniswap_v3::V3PostState),
     Curve(crate::curve::CurvePostState),
     Balancer(crate::balancer::BalancerPostState),
+    Bancor(crate::bancor::BancorPostState),
 }
 
 impl UnifiedPostState {
@@ -115,6 +120,7 @@ impl UnifiedPostState {
             UnifiedPostState::UniswapV3(p) => p.amount_out,
             UnifiedPostState::Curve(p) => p.amount_out,
             UnifiedPostState::Balancer(p) => p.amount_out,
+            UnifiedPostState::Bancor(p) => p.amount_out,
         }
     }
 }
@@ -128,6 +134,7 @@ pub enum ReplayProtocol {
     UniswapV3,
     Curve,
     Balancer,
+    Bancor,
 }
 
 /// Run the analytical post-state predictor for the cached pool and
@@ -181,6 +188,20 @@ where
                 return None;
             }
             Some(UnifiedPostState::Balancer(post))
+        }
+        PoolState::Bancor(pool) => {
+            // Bancor's bonding curve is closed-form — `analytical` is
+            // always `true` on a `Some` return, so the low-confidence
+            // branch is dead. Kept for shape symmetry with the other
+            // pool families and to keep the metric label space stable
+            // if future Bancor pool variants (e.g. V2-style with
+            // non-equal weights) ever need to surface the flag.
+            let post = pool.predict_post_state(token_in, amount_in)?;
+            if !post.analytical {
+                on_fallback("bancor_multihop");
+                return None;
+            }
+            Some(UnifiedPostState::Bancor(post))
         }
         PoolState::UniswapV2(_) | PoolState::SushiSwap(_) => {
             // V2-family analytical predictor lives outside this crate
@@ -240,6 +261,14 @@ where
                 return replay(ReplayProtocol::Balancer);
             }
             Some(UnifiedPostState::Balancer(post))
+        }
+        PoolState::Bancor(pool) => {
+            let post = pool.predict_post_state(token_in, amount_in)?;
+            if !post.analytical {
+                on_fallback("bancor_multihop");
+                return replay(ReplayProtocol::Bancor);
+            }
+            Some(UnifiedPostState::Bancor(post))
         }
         PoolState::UniswapV2(_) | PoolState::SushiSwap(_) => {
             on_fallback("unknown_protocol");
@@ -404,6 +433,55 @@ mod cache_tests {
     }
 
     #[test]
+    fn predict_with_fallback_bancor_returns_state_for_single_pool_swap() {
+        // Single-pool Bancor swap (token <-> BNT) — predictor returns
+        // analytical=true, fallback closure should never fire.
+        let token = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let bnt = address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C");
+        let mut bancor = BancorPool::new(Address::ZERO, token, bnt, 30);
+        bancor.update_state(
+            U256::from(1_000_000_000_000_000_000_000u128),
+            U256::from(2_000_000_000_000_000_000_000u128),
+        );
+        let state = PoolState::Bancor(bancor);
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            token,
+            U256::from(1_000_000_000_000_000_000u64),
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(matches!(result, Some(UnifiedPostState::Bancor(_))));
+        assert!(captured.borrow().is_empty());
+    }
+
+    #[test]
+    fn predict_with_fallback_bancor_returns_none_for_multihop() {
+        // Neither token_in nor token_out is BNT — predictor returns None
+        // (single-pool can't predict multi-hop) and the fallback closure
+        // does not fire because the rejection happens before the
+        // confidence check.
+        let token = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let bnt = address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C");
+        let bogus = address!("dddddddddddddddddddddddddddddddddddddddd");
+        let mut bancor = BancorPool::new(Address::ZERO, token, bnt, 30);
+        bancor.update_state(
+            U256::from(1_000_000_000_000_000_000_000u128),
+            U256::from(2_000_000_000_000_000_000_000u128),
+        );
+        let state = PoolState::Bancor(bancor);
+        let captured = std::cell::RefCell::new(Vec::<String>::new());
+        let result = predict_post_state_with_fallback(
+            &state,
+            bogus,
+            U256::from(1_000_000_000_000_000_000u64),
+            |reason| captured.borrow_mut().push(reason.to_string()),
+        );
+        assert!(result.is_none());
+        assert!(captured.borrow().is_empty(), "no fallback expected on multihop bail");
+    }
+
+    #[test]
     fn predict_with_replay_v3_invokes_closure_on_tick_cross() {
         let mut v3 = UniswapV3Pool::new(
             address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
@@ -545,5 +623,12 @@ mod cache_tests {
             PoolState::Balancer(bal).protocol(),
             ProtocolType::BalancerV2
         );
+        let bancor = BancorPool::new(
+            Address::ZERO,
+            Address::ZERO,
+            address!("1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"),
+            30,
+        );
+        assert_eq!(PoolState::Bancor(bancor).protocol(), ProtocolType::BancorV3);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `BancorPool::predict_post_state` + `BancorPostState` — closed-form bonding-curve post-state predictor matching the existing `get_amount_out` math
- Adds `PoolState::Bancor`, `UnifiedPostState::Bancor`, `ReplayProtocol::Bancor` so the mempool post-state pipeline can dispatch Bancor swaps the same way it handles V3 / Curve / Balancer
- Adds `PredictedPostState::Bancor` writer variant so Bancor predictions persist to the `mempool_predictions` table
- Removes the `bancor_post_state_pending` skip in `try_post_state_scan`; folds Bancor into the same `predict_post_state_with_replay` branch as V3 / Curve / Balancer

## Why

PR #157 landed the Bancor decoder, PR #159 closed the Curve loop with the same shape — Bancor was the last decoded protocol still skipping at the cycle-scan stage with `bancor_post_state_pending`. After this PR, decoded Bancor swaps with BNT on one side route through the analytical predictor, update the graph, and surface on `aether_pending_arb_candidates_total{router, profit_bucket}` when profitable.

## Files Changed

| File | Purpose |
|---|---|
| `crates/pools/src/bancor.rs` | `BancorPostState` struct, `predict_post_state` method, 7 unit tests covering direction symmetry / fee accounting / degenerate inputs / multi-hop bail |
| `crates/pools/src/lib.rs` | `PoolState::Bancor` + `UnifiedPostState::Bancor` + `ReplayProtocol::Bancor` variants. `predict_post_state_with_fallback` / `_with_replay` Bancor arms. 3 new tests |
| `crates/grpc-server/src/mempool_writer.rs` | `PredictedPostState::Bancor { reserve_in, reserve_out }` variant + JSON round-trip test coverage |
| `crates/grpc-server/src/mempool_pipeline.rs` | Remove `bancor_post_state_pending` early-return. Fold `Protocol::BancorV3` into the existing V3 / Curve / Balancer match arm. `unified_to_post_reserves` Bancor arm trusts predictor's direction-aligned balances. `PredictedPostState::Bancor` emission. New pipeline test |

## Implementation notes

- **Closed-form bonding curve.** Bancor V3 uses `amount_out = bal_out * dx_after_fee / (bal_in + dx_after_fee)`. Same shape as V2 with a fee complement. `analytical = true` is the steady-state return; the low-confidence branch is wired for shape symmetry but never fires for single-pool Bancor.
- **Direction alignment matches Curve.** `BancorPostState.new_balance_in` / `new_balance_out` are aligned with the swap direction (not the pool's `token` / `bnt` fields). The predictor checks `token_in == self.token` vs `== self.bnt` and emits the balances accordingly. `unified_to_post_reserves` trusts them directly — no `swap_token_in` vs `meta.token0/token1` comparison.
- **Multi-hop bail.** When neither `token_in` nor `token_out` is BNT (the trade hits two non-BNT pools via BNT as intermediary), `predict_post_state` returns `None`. The pipeline counts it under `predictor_low_confidence` and the candidate skips. No partial graph-edge update is emitted.

## Scope cut

Multi-hop Bancor swaps (the case where the victim swaps two non-BNT tokens via BNT) need a separate predictor flow: the pipeline must detect the multi-hop calldata pattern upstream and look up both affected pools (`source_pool`, `target_pool`), then update both graph edges. That's a structural change to `try_post_state_scan` (currently keyed on one `(token_in, token_out, protocol)` lookup) and worth its own PR.

For now multi-hop Bancor traffic decodes successfully (counts on `pending_dex_tx_total{protocol="bancor_v3"}`) but skips at the predictor with `predictor_low_confidence`.

## Acceptance criteria

- [x] `BancorPool::predict_post_state` returns analytical=true on single-pool swaps (token <-> BNT)
- [x] `BancorPool::predict_post_state` returns None on multi-hop calls
- [x] `BancorPool::predict_post_state` rejects zero / degenerate-small `amount_in`, uninitialised pools, unknown tokens
- [x] `predict_post_state_with_fallback` dispatches Bancor without fallback firing on single-pool swaps
- [x] `unified_to_post_reserves` Bancor arm trusts predictor's direction-aligned balances
- [x] `PredictedPostState::Bancor` round-trips through JSON cleanly
- [x] `Protocol::BancorV3` reaches the cycle-scan branch (no longer skipped with `bancor_post_state_pending`)
- [ ] Live mainnet observation: `aether_pending_dex_tx_total{protocol="bancor_v3"}` increments; `aether_pending_arb_sim_skipped_total{reason="bancor_post_state_pending"}` flatlines

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets --release -- -D warnings` clean
- [x] `cargo test --workspace --release` all green
  - 7 new `bancor::tests::predict_post_state_*` tests
  - 3 new `cache_tests::predict_with_fallback_bancor_*` + dispatch tests
  - 1 new pipeline test `unified_to_post_reserves_bancor_uses_predictor_balances_directly`
  - Extended `predicted_post_state_round_trips_through_json` to cover the `bancor` kind
- [x] `go build ./...` + `go test ./... -count=1` green (no Go changes, regression check)
- [x] `forge build` + `forge test` green (no Solidity changes, regression check)
- [ ] Live smoke post-merge — confirm Bancor traffic reaches the predictor and produces non-empty rows on `aether_pending_arb_candidates_total` under real victim flow
