### PR TITLE
feat(simulator): revm reader for Curve + Balancer post-state replay

### DIFF
--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -30,13 +30,16 @@ use aether_detector::opportunity::DetectedCycle;
 use aether_ingestion::subscription::{EventChannels, PendingTxEvent};
 use aether_pools::router_decoder::{decode_pending, DecodeError, DecodedSwap, Protocol};
 use aether_pools::{
-    predict_post_state_with_replay, PoolStateCache, ReplayProtocol, UnifiedPostState,
+    predict_post_state_with_replay, PoolState, PoolStateCache, ReplayProtocol, UnifiedPostState,
 };
 use aether_simulator::calldata::build_execute_arb_calldata;
 use aether_simulator::mempool_backrun::{
     validate_backrun_rpc, ArbTx, RejectReason, ValidatorParams, VictimTx,
 };
-use aether_simulator::post_state_replay::{replay_v3_post_state_rpc, ReplayParams};
+use aether_simulator::post_state_replay::{
+    replay_balancer_post_state_rpc, replay_curve_post_state_rpc, replay_v3_post_state_rpc,
+    ReplayParams,
+};
 use aether_state::price_graph::PriceGraph;
 use aether_state::snapshot::SnapshotManager;
 use aether_state::token_index::TokenIndex;
@@ -711,7 +714,19 @@ fn try_post_state_scan(
                 swap.token_in,
                 swap.amount_in,
                 |reason| metrics.inc_sim_evm_fallback(reason),
-                |proto| try_post_state_replay(metrics, ctx, proto, pool_addr, event, snapshot.block_number),
+                |proto| {
+                    try_post_state_replay(
+                        metrics,
+                        ctx,
+                        proto,
+                        pool_addr,
+                        state_arc.as_ref(),
+                        swap.token_in,
+                        swap.token_out,
+                        event,
+                        snapshot.block_number,
+                    )
+                },
             );
             let Some(unified) = post else {
                 metrics.inc_pending_arb_sim_skipped("predictor_low_confidence");
@@ -834,34 +849,39 @@ fn try_post_state_scan(
 ///
 /// Returns `Some(UnifiedPostState)` when the replay produced a usable
 /// post-state, `None` otherwise (replay dormant, provider unavailable,
-/// victim reverted, unimplemented protocol, etc.). All outcomes bump
+/// victim reverted, etc.). All outcomes bump
 /// `aether_mempool_post_state_replay_total{outcome}` and observe the
 /// per-attempt latency on
 /// `aether_mempool_post_state_replay_latency_ms` so dashboards can
 /// decompose the analytical-vs-revm path mix without re-parsing logs.
 ///
 /// Concurrency is bounded by the same semaphore the backrun validator
-/// uses — saturating it bumps `unimplemented_protocol` so the caller
-/// path stays consistent with other no-op exits. Curve and Balancer
-/// always short-circuit to `unimplemented_protocol` until the reader
-/// hooks in `aether_simulator::post_state_replay` land.
+/// uses — saturating it bumps `sim_error` so the caller path stays
+/// consistent with other no-op exits.
+///
+/// Protocol dispatch: V3 routes through the `slot0() + liquidity()`
+/// reader, Curve routes through the `balances(i)` reader (using the
+/// cached `CurvePool.tokens` index to resolve `(i, j)` from the swap's
+/// `token_in` / `token_out`), Balancer routes through the
+/// `getPoolId() → Vault.getPoolTokens(poolId)` reader (passing the
+/// cached `BalancerPool.token0` / `token1` so post-balances are
+/// position-aligned with the consumer's existing convention). Bancor
+/// is not surfaced — its analytical predictor is closed-form for the
+/// single-pool case, and the multi-hop branch routes through a
+/// separate path.
+#[allow(clippy::too_many_arguments)]
 fn try_post_state_replay(
     metrics: &EngineMetrics,
     ctx: &SimContext,
     protocol: ReplayProtocol,
     pool_addr: Address,
+    pool_state: &PoolState,
+    swap_token_in: Address,
+    swap_token_out: Address,
     event: &PendingTxEvent,
     block_number: u64,
 ) -> Option<UnifiedPostState> {
     if !ctx.post_state_replay_enabled {
-        metrics.inc_mempool_post_state_replay("unimplemented_protocol");
-        return None;
-    }
-    // Protocol check runs before provider availability so Curve and
-    // Balancer always count as `unimplemented_protocol` regardless of
-    // whether the RPC provider was wired this build. Their replay path
-    // does not exist yet — provider state is irrelevant.
-    if !matches!(protocol, ReplayProtocol::UniswapV3) {
         metrics.inc_mempool_post_state_replay("unimplemented_protocol");
         return None;
     }
@@ -878,18 +898,6 @@ fn try_post_state_replay(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
-        provider.clone(),
-        block_number,
-        now_secs,
-        1_000_000_000,
-    ) {
-        Some(s) => s,
-        None => {
-            metrics.inc_mempool_post_state_replay("sim_error");
-            return None;
-        }
-    };
     let victim = VictimTx {
         from: event.from,
         to: event.to?,
@@ -904,11 +912,111 @@ fn try_post_state_replay(
         base_fee: 1_000_000_000,
         chain_id: cfg.chain_id,
     };
+
+    // Build a fresh `RpcForkedState` per replay. Cloning the provider's
+    // Arc handle is cheap; the underlying `AlloyDB` cache is per-state and
+    // fills lazily on the first read. Errors here surface as `sim_error`
+    // so the dashboard separates dispatch-time failures from per-protocol
+    // reader failures.
     let started = Instant::now();
-    let outcome = replay_v3_post_state_rpc(state, &victim, pool_addr, &params);
+    let result: Result<UnifiedPostState, &'static str> = match protocol {
+        ReplayProtocol::UniswapV3 => {
+            let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
+                provider.clone(),
+                block_number,
+                now_secs,
+                1_000_000_000,
+            ) {
+                Some(s) => s,
+                None => {
+                    metrics.inc_mempool_post_state_replay("sim_error");
+                    return None;
+                }
+            };
+            match replay_v3_post_state_rpc(state, &victim, pool_addr, &params) {
+                Ok(post) => Ok(UnifiedPostState::UniswapV3(post)),
+                Err(e) => Err(e.as_str()),
+            }
+        }
+        ReplayProtocol::Curve => {
+            // Coin indices come from the cached `CurvePool.tokens`
+            // ordering — the on-chain `balances(uint256 i)` view is
+            // keyed on that same index. If either token is unknown the
+            // replay can't read post-balances; surface `decode_failed`
+            // so the metric label matches downstream reader failures.
+            let PoolState::Curve(curve) = pool_state else {
+                metrics.inc_mempool_post_state_replay("decode_failed");
+                return None;
+            };
+            let Some(i) = curve.tokens.iter().position(|t| *t == swap_token_in) else {
+                metrics.inc_mempool_post_state_replay("decode_failed");
+                return None;
+            };
+            let Some(j) = curve.tokens.iter().position(|t| *t == swap_token_out) else {
+                metrics.inc_mempool_post_state_replay("decode_failed");
+                return None;
+            };
+            let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
+                provider.clone(),
+                block_number,
+                now_secs,
+                1_000_000_000,
+            ) {
+                Some(s) => s,
+                None => {
+                    metrics.inc_mempool_post_state_replay("sim_error");
+                    return None;
+                }
+            };
+            match replay_curve_post_state_rpc(
+                state,
+                &victim,
+                pool_addr,
+                i as u8,
+                j as u8,
+                &params,
+            ) {
+                Ok(post) => Ok(UnifiedPostState::Curve(post)),
+                Err(e) => Err(e.as_str()),
+            }
+        }
+        ReplayProtocol::Balancer => {
+            // Use the pool's canonical `(token0, token1)` ordering so
+            // `BalancerPostState.new_balance0` aligns with `meta.token0`
+            // — the consumer's `unified_to_post_reserves` re-derives
+            // swap direction from that convention.
+            let PoolState::Balancer(bal) = pool_state else {
+                metrics.inc_mempool_post_state_replay("decode_failed");
+                return None;
+            };
+            let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
+                provider.clone(),
+                block_number,
+                now_secs,
+                1_000_000_000,
+            ) {
+                Some(s) => s,
+                None => {
+                    metrics.inc_mempool_post_state_replay("sim_error");
+                    return None;
+                }
+            };
+            match replay_balancer_post_state_rpc(
+                state,
+                &victim,
+                pool_addr,
+                bal.token0,
+                bal.token1,
+                &params,
+            ) {
+                Ok(post) => Ok(UnifiedPostState::Balancer(post)),
+                Err(e) => Err(e.as_str()),
+            }
+        }
+    };
     let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
     metrics.observe_mempool_post_state_replay_latency_ms(elapsed_ms);
-    match outcome {
+    match result {
         Ok(post) => {
             metrics.inc_mempool_post_state_replay("success");
             debug!(
@@ -916,28 +1024,27 @@ fn try_post_state_replay(
                 tx_hash = %event.tx_hash,
                 pool = %pool_addr,
                 elapsed_ms,
+                ?protocol,
                 "POST-STATE REPLAY succeeded"
             );
-            Some(UnifiedPostState::UniswapV3(post))
+            Some(post)
         }
-        Err(err) => {
-            metrics.inc_mempool_post_state_replay(err.as_str());
+        Err(reason) => {
+            metrics.inc_mempool_post_state_replay(reason);
             debug!(
                 target: "aether::mempool",
                 tx_hash = %event.tx_hash,
                 pool = %pool_addr,
-                reason = err.as_str(),
+                reason,
                 elapsed_ms,
+                ?protocol,
                 "POST-STATE REPLAY failed"
             );
-            // Treat any non-success outcome — including ReplayError variants we
-            // already mapped — as no-replay so the caller short-circuits the
-            // candidate the same way it would have before this PR.
-            let _ = err;
             None
         }
     }
 }
+
 
 /// Orchestrate the revm validator for one profitable cycle and publish a
 /// `ValidatedArb` on accept.
@@ -1714,16 +1821,61 @@ mod tests {
         }
     }
 
+    /// Build a synthetic V3 `PoolState` for use as the
+    /// `try_post_state_replay` `pool_state` parameter in tests. The V3
+    /// variant carries no pool-state fields the V3 reader inspects, so
+    /// `Default::default()`-shaped values are sufficient.
+    fn synthetic_v3_pool_state() -> PoolState {
+        use aether_pools::uniswap_v3::UniswapV3Pool;
+        PoolState::UniswapV3(UniswapV3Pool::new(
+            address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            30,
+            60,
+        ))
+    }
+
+    /// Build a synthetic 2-coin Curve `PoolState`. Tokens populated so
+    /// the dispatcher can resolve `(i, j)` from a swap direction.
+    fn synthetic_curve_pool_state(tokens: [Address; 2]) -> PoolState {
+        use aether_pools::curve::CurvePool;
+        PoolState::Curve(CurvePool::new(
+            address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7"),
+            tokens.to_vec(),
+            100,
+            4,
+        ))
+    }
+
+    /// Build a synthetic 80/20-weight Balancer `PoolState` so the
+    /// dispatcher reads `bal.token0` / `bal.token1` cleanly.
+    fn synthetic_balancer_pool_state(token0: Address, token1: Address) -> PoolState {
+        use aether_pools::balancer::BalancerPool;
+        PoolState::Balancer(BalancerPool::new(
+            address!("5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56"),
+            token0,
+            token1,
+            200_000,
+            800_000,
+            10,
+        ))
+    }
+
     #[test]
     fn try_post_state_replay_dormant_when_flag_disabled() {
         let metrics = EngineMetrics::new();
         let ctx = empty_sim_ctx();
         assert!(!ctx.post_state_replay_enabled);
+        let pool_state = synthetic_v3_pool_state();
         let result = try_post_state_replay(
             &metrics,
             &ctx,
             ReplayProtocol::UniswapV3,
             address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            &pool_state,
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
             &fake_pending_event(address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D")),
             18_000_000,
         );
@@ -1764,11 +1916,15 @@ mod tests {
         // without bumping success and without panicking.
         let ctx = Arc::new(unwrap_empty_sim_ctx().with_post_state_replay(true));
         let before = metrics.mempool_post_state_replay_count("success");
+        let pool_state = synthetic_v3_pool_state();
         let result = try_post_state_replay(
             &metrics,
             &ctx,
             ReplayProtocol::UniswapV3,
             address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            &pool_state,
+            address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+            address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
             &fake_pending_event(address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D")),
             18_000_000,
         );
@@ -1777,31 +1933,52 @@ mod tests {
     }
 
     #[test]
-    fn try_post_state_replay_curve_balancer_short_circuit_as_unimplemented() {
+    fn try_post_state_replay_curve_balancer_reach_provider_check() {
         let metrics = EngineMetrics::new();
-        // BackrunValidatorConfig with no provider — passes the
-        // `cfg = ctx.backrun.as_ref()?` line so the protocol dispatch
-        // is reached.
+        // Curve and Balancer are now wired into the replay path. With
+        // `provider = None` on the backrun config, the dispatcher
+        // short-circuits at `cfg.provider.as_ref()?` *before* it bumps
+        // any metric — confirming the dispatch path reaches the
+        // protocol-specific branch rather than being routed through the
+        // older `unimplemented_protocol` exit. The unchanged
+        // `unimplemented_protocol` counter is the explicit witness.
         let ctx = Arc::new(
             unwrap_empty_sim_ctx()
                 .with_backrun_validator(dummy_backrun_cfg())
                 .with_post_state_replay(true),
         );
-        for proto in [ReplayProtocol::Curve, ReplayProtocol::Balancer] {
+        let usdc = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let usdt = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let curve_state = synthetic_curve_pool_state([usdc, usdt]);
+        let bal_state = synthetic_balancer_pool_state(usdc, usdt);
+        let cases: [(ReplayProtocol, &PoolState); 2] = [
+            (ReplayProtocol::Curve, &curve_state),
+            (ReplayProtocol::Balancer, &bal_state),
+        ];
+        for (proto, state) in cases {
             let before = metrics.mempool_post_state_replay_count("unimplemented_protocol");
+            let before_sim = metrics.mempool_post_state_replay_count("sim_error");
             let result = try_post_state_replay(
                 &metrics,
                 &ctx,
                 proto,
                 address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+                state,
+                usdc,
+                usdt,
                 &fake_pending_event(address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D")),
                 18_000_000,
             );
             assert!(result.is_none());
             assert_eq!(
                 metrics.mempool_post_state_replay_count("unimplemented_protocol"),
-                before + 1,
-                "{proto:?} must bump unimplemented_protocol"
+                before,
+                "{proto:?} must not bump unimplemented_protocol"
+            );
+            assert_eq!(
+                metrics.mempool_post_state_replay_count("sim_error"),
+                before_sim,
+                "{proto:?} provider-missing path must not bump sim_error either"
             );
         }
     }

--- a/crates/simulator/src/post_state_replay.rs
+++ b/crates/simulator/src/post_state_replay.rs
@@ -9,19 +9,22 @@
 //! a low-confidence flag — replaying the victim against a real forked
 //! EVM and reading the pool's new storage gives an exact answer.
 //!
-//! Curve and Balancer reader hooks intentionally stubbed in this module
-//! and surface `UnimplementedProtocol` to the metric. Adding them is a
-//! follow-up PR: each one needs an `alloy::sol!` view interface plus
-//! decode of the protocol-specific post-state shape; the EVM commit
-//! step is identical.
+//! The Uniswap V3 reader pulls `slot0()` + `liquidity()` after the
+//! victim commits. The Curve reader pulls `balances(uint256 i)` for the
+//! two coin indices involved in the swap. The Balancer V2 reader resolves
+//! the pool's `bytes32 poolId` via `getPoolId()` on the pool contract
+//! then calls `IVault.getPoolTokens(poolId)` on the canonical mainnet
+//! Vault, picking out the two balances aligned with `(token_in, token_out)`.
 //!
 //! Like `mempool_backrun`, this module is a synchronous pure function
 //! so callers can run it on `spawn_blocking` workers without leaking
 //! async dependencies.
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{address, Address, FixedBytes, U256};
 use alloy::sol;
 use alloy::sol_types::SolCall;
+use aether_pools::balancer::BalancerPostState;
+use aether_pools::curve::CurvePostState;
 use aether_pools::uniswap_v3::V3PostState;
 use revm::context::result::ExecutionResult;
 use revm::context::{BlockEnv, TxEnv};
@@ -35,6 +38,12 @@ use tracing::debug;
 use crate::fork::{ForkedState, RpcForkedState};
 use crate::mempool_backrun::VictimTx;
 
+/// Canonical Balancer V2 Vault on Ethereum mainnet. Every weighted /
+/// stable / linear pool routes its balance bookkeeping through this
+/// singleton; the replay reader calls `getPoolTokens(poolId)` on it
+/// to recover post-swap balances.
+pub const BALANCER_V2_VAULT: Address = address!("BA12222222228d8Ba445958a75a0704d566BF2C8");
+
 sol! {
     interface IUniswapV3PoolReader {
         function slot0() external view returns (
@@ -47,6 +56,21 @@ sol! {
             bool unlocked
         );
         function liquidity() external view returns (uint128);
+    }
+
+    interface ICurvePoolReader {
+        function balances(uint256 i) external view returns (uint256);
+    }
+
+    interface IBalancerPoolReader {
+        function getPoolId() external view returns (bytes32);
+    }
+
+    interface IBalancerVaultReader {
+        function getPoolTokens(bytes32 poolId)
+            external
+            view
+            returns (address[] memory tokens, uint256[] memory balances, uint256 lastChangeBlock);
     }
 }
 
@@ -127,29 +151,83 @@ pub fn replay_v3_post_state_cache(
     replay_v3_inner(state.db, victim, pool, params)
 }
 
-/// Curve post-state replay — currently unimplemented. The follow-up PR
-/// adds a `sol!` `balances(uint256 i)` view interface and decodes the
-/// returned uint256 for both coin indices.
+/// Replay the victim tx against an RPC-backed fork and read a 2-coin
+/// Curve pool's `balances(i)` and `balances(j)` post-execution. The
+/// caller supplies the coin indices because Curve V1 pools store
+/// `tokens` and `balances` as parallel arrays and the on-chain
+/// `balances(uint256)` view is keyed on that index, not on a token
+/// address — the `CurvePool` cached state in `aether-pools` already
+/// knows the index for both ends of the swap.
+///
+/// `amount_out` is the difference between the pre-swap `balances(j)`
+/// (read off the cached `CurvePool` by the caller) and the post-swap
+/// value returned here. The reader does not re-derive it because the
+/// caller has the pre-state already and feeding the pre-balance through
+/// here would only duplicate that information.
 pub fn replay_curve_post_state_rpc(
-    _state: RpcForkedState,
-    _victim: &VictimTx,
-    _pool: Address,
-    _params: &ReplayParams,
-) -> Result<(), ReplayError> {
-    Err(ReplayError::UnimplementedProtocol("curve"))
+    state: RpcForkedState,
+    victim: &VictimTx,
+    pool: Address,
+    coin_idx_in: u8,
+    coin_idx_out: u8,
+    params: &ReplayParams,
+) -> Result<CurvePostState, ReplayError> {
+    let RpcForkedState { db, .. } = state;
+    replay_curve_inner(db, victim, pool, coin_idx_in, coin_idx_out, params)
 }
 
-/// Balancer post-state replay — currently unimplemented. The follow-up
-/// PR adds a `getPoolTokens(bytes32 poolId)` view call against the
-/// BalancerV2 Vault contract and decodes the returned balances array.
+/// Cache-backed sibling of [`replay_curve_post_state_rpc`] for tests that
+/// pre-populate a synthetic `ForkedState` instead of standing up a real
+/// RPC fork.
+pub fn replay_curve_post_state_cache(
+    state: ForkedState,
+    victim: &VictimTx,
+    pool: Address,
+    coin_idx_in: u8,
+    coin_idx_out: u8,
+    params: &ReplayParams,
+) -> Result<CurvePostState, ReplayError> {
+    replay_curve_inner(state.db, victim, pool, coin_idx_in, coin_idx_out, params)
+}
+
+/// Replay the victim tx against an RPC-backed fork and read a Balancer
+/// V2 pool's post-swap balances via the canonical Vault. The pool
+/// contract is queried for its `bytes32 poolId`, then
+/// `IVault.getPoolTokens(poolId)` is called on the Vault — both reads
+/// run against the same post-commit EVM context so they always reflect
+/// the victim's effect.
+///
+/// `token0` / `token1` are the pool's canonical token ordering (as
+/// stored on the cached `BalancerPool`). The returned `BalancerPostState`
+/// keeps `new_balance0` aligned with `token0` and `new_balance1` with
+/// `token1`, matching the analytical-path convention so the consumer's
+/// `unified_to_post_reserves` helper can re-derive swap direction
+/// uniformly across analytical and replay branches.
 pub fn replay_balancer_post_state_rpc(
-    _state: RpcForkedState,
-    _victim: &VictimTx,
-    _vault: Address,
-    _pool_id: [u8; 32],
-    _params: &ReplayParams,
-) -> Result<(), ReplayError> {
-    Err(ReplayError::UnimplementedProtocol("balancer"))
+    state: RpcForkedState,
+    victim: &VictimTx,
+    pool: Address,
+    token0: Address,
+    token1: Address,
+    params: &ReplayParams,
+) -> Result<BalancerPostState, ReplayError> {
+    let RpcForkedState { db, .. } = state;
+    replay_balancer_inner(db, victim, pool, BALANCER_V2_VAULT, token0, token1, params)
+}
+
+/// Cache-backed sibling of [`replay_balancer_post_state_rpc`]. Tests
+/// supply both the pool address and the Vault address explicitly so a
+/// synthetic mock can stand in for the canonical mainnet Vault.
+pub fn replay_balancer_post_state_cache(
+    state: ForkedState,
+    victim: &VictimTx,
+    pool: Address,
+    vault: Address,
+    token0: Address,
+    token1: Address,
+    params: &ReplayParams,
+) -> Result<BalancerPostState, ReplayError> {
+    replay_balancer_inner(state.db, victim, pool, vault, token0, token1, params)
 }
 
 fn replay_v3_inner<DB>(
@@ -257,6 +335,212 @@ fn build_view_env(pool: Address, data: Vec<u8>, chain_id: u64) -> TxEnv {
         .build_fill()
 }
 
+fn replay_curve_inner<DB>(
+    db: CacheDB<DB>,
+    victim: &VictimTx,
+    pool: Address,
+    coin_idx_in: u8,
+    coin_idx_out: u8,
+    params: &ReplayParams,
+) -> Result<CurvePostState, ReplayError>
+where
+    DB: DatabaseRef,
+    CacheDB<DB>: Database<Error = <DB as DatabaseRef>::Error>,
+    <DB as DatabaseRef>::Error: std::fmt::Debug,
+{
+    let block = BlockEnv {
+        number: U256::from(params.block_number),
+        timestamp: U256::from(params.block_timestamp),
+        basefee: params.base_fee,
+        ..Default::default()
+    };
+    let ctx = Context::<BlockEnv, TxEnv, _, CacheDB<DB>, revm::context::Journal<CacheDB<DB>>, ()>::new(
+        db, SpecId::CANCUN,
+    )
+    .with_block(block)
+    .modify_cfg_chained(|cfg| {
+        cfg.chain_id = params.chain_id;
+        cfg.disable_nonce_check = true;
+        cfg.disable_balance_check = true;
+        cfg.disable_base_fee = true;
+    });
+    let mut evm = ctx.build_mainnet();
+
+    let victim_env = TxEnv::builder()
+        .caller(victim.from)
+        .kind(revm::primitives::TxKind::Call(victim.to))
+        .data(revm::primitives::Bytes::copy_from_slice(&victim.data))
+        .value(victim.value)
+        .gas_limit(victim.gas_limit)
+        .gas_price(victim.gas_price)
+        .nonce(0)
+        .chain_id(Some(params.chain_id))
+        .build_fill();
+
+    match evm.transact_commit(victim_env) {
+        Ok(ExecutionResult::Success { .. }) => {}
+        Ok(ExecutionResult::Revert { .. }) => return Err(ReplayError::VictimReverted),
+        Ok(ExecutionResult::Halt { .. }) => return Err(ReplayError::VictimHalted),
+        Err(e) => {
+            debug!(error = ?e, "post-state replay: victim sim error (curve)");
+            return Err(ReplayError::SimError);
+        }
+    }
+
+    // Read `balances(i)` against post-victim state for both coin indices.
+    let in_data = ICurvePoolReader::balancesCall { i: U256::from(coin_idx_in) }.abi_encode();
+    let in_env = build_view_env(pool, in_data, params.chain_id);
+    let in_output = match evm.transact(in_env) {
+        Ok(rs) => match rs.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            _ => return Err(ReplayError::ReadCallFailed("balances")),
+        },
+        Err(_) => return Err(ReplayError::ReadCallFailed("balances")),
+    };
+    let new_balance_in = ICurvePoolReader::balancesCall::abi_decode_returns(&in_output)
+        .map_err(|_| ReplayError::DecodeFailed("balances"))?;
+
+    let out_data = ICurvePoolReader::balancesCall { i: U256::from(coin_idx_out) }.abi_encode();
+    let out_env = build_view_env(pool, out_data, params.chain_id);
+    let out_output = match evm.transact(out_env) {
+        Ok(rs) => match rs.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            _ => return Err(ReplayError::ReadCallFailed("balances")),
+        },
+        Err(_) => return Err(ReplayError::ReadCallFailed("balances")),
+    };
+    let new_balance_out = ICurvePoolReader::balancesCall::abi_decode_returns(&out_output)
+        .map_err(|_| ReplayError::DecodeFailed("balances"))?;
+
+    // `i`/`j` here are usize-widened from the caller-supplied coin indices
+    // (Curve V1 pools index coins as a uint256 on-chain but the index
+    // always fits in a u8 in practice — 2- and 3-coin pools dominate).
+    // `amount_out` is intentionally `U256::ZERO`: `unified_to_post_reserves`
+    // in the mempool pipeline only consumes `new_balance_in`/`new_balance_out`
+    // for Curve and never reads `amount_out`. Setting `analytical = false`
+    // preserves the existing label space — the replay path is the
+    // non-analytical branch by definition.
+    Ok(CurvePostState {
+        i: coin_idx_in as usize,
+        j: coin_idx_out as usize,
+        new_balance_in,
+        new_balance_out,
+        amount_out: U256::ZERO,
+        analytical: false,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn replay_balancer_inner<DB>(
+    db: CacheDB<DB>,
+    victim: &VictimTx,
+    pool: Address,
+    vault: Address,
+    token0: Address,
+    token1: Address,
+    params: &ReplayParams,
+) -> Result<BalancerPostState, ReplayError>
+where
+    DB: DatabaseRef,
+    CacheDB<DB>: Database<Error = <DB as DatabaseRef>::Error>,
+    <DB as DatabaseRef>::Error: std::fmt::Debug,
+{
+    let block = BlockEnv {
+        number: U256::from(params.block_number),
+        timestamp: U256::from(params.block_timestamp),
+        basefee: params.base_fee,
+        ..Default::default()
+    };
+    let ctx = Context::<BlockEnv, TxEnv, _, CacheDB<DB>, revm::context::Journal<CacheDB<DB>>, ()>::new(
+        db, SpecId::CANCUN,
+    )
+    .with_block(block)
+    .modify_cfg_chained(|cfg| {
+        cfg.chain_id = params.chain_id;
+        cfg.disable_nonce_check = true;
+        cfg.disable_balance_check = true;
+        cfg.disable_base_fee = true;
+    });
+    let mut evm = ctx.build_mainnet();
+
+    let victim_env = TxEnv::builder()
+        .caller(victim.from)
+        .kind(revm::primitives::TxKind::Call(victim.to))
+        .data(revm::primitives::Bytes::copy_from_slice(&victim.data))
+        .value(victim.value)
+        .gas_limit(victim.gas_limit)
+        .gas_price(victim.gas_price)
+        .nonce(0)
+        .chain_id(Some(params.chain_id))
+        .build_fill();
+
+    match evm.transact_commit(victim_env) {
+        Ok(ExecutionResult::Success { .. }) => {}
+        Ok(ExecutionResult::Revert { .. }) => return Err(ReplayError::VictimReverted),
+        Ok(ExecutionResult::Halt { .. }) => return Err(ReplayError::VictimHalted),
+        Err(e) => {
+            debug!(error = ?e, "post-state replay: victim sim error (balancer)");
+            return Err(ReplayError::SimError);
+        }
+    }
+
+    // Step 1: resolve poolId by calling `getPoolId()` on the pool contract.
+    let pool_id_data = IBalancerPoolReader::getPoolIdCall {}.abi_encode();
+    let pool_id_env = build_view_env(pool, pool_id_data, params.chain_id);
+    let pool_id_output = match evm.transact(pool_id_env) {
+        Ok(rs) => match rs.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            _ => return Err(ReplayError::ReadCallFailed("getPoolId")),
+        },
+        Err(_) => return Err(ReplayError::ReadCallFailed("getPoolId")),
+    };
+    let pool_id: FixedBytes<32> = IBalancerPoolReader::getPoolIdCall::abi_decode_returns(&pool_id_output)
+        .map_err(|_| ReplayError::DecodeFailed("getPoolId"))?;
+
+    // Step 2: call `getPoolTokens(poolId)` on the Vault.
+    let tokens_data = IBalancerVaultReader::getPoolTokensCall { poolId: pool_id }.abi_encode();
+    let tokens_env = build_view_env(vault, tokens_data, params.chain_id);
+    let tokens_output = match evm.transact(tokens_env) {
+        Ok(rs) => match rs.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            _ => return Err(ReplayError::ReadCallFailed("getPoolTokens")),
+        },
+        Err(_) => return Err(ReplayError::ReadCallFailed("getPoolTokens")),
+    };
+    let decoded = IBalancerVaultReader::getPoolTokensCall::abi_decode_returns(&tokens_output)
+        .map_err(|_| ReplayError::DecodeFailed("getPoolTokens"))?;
+
+    // Walk the Vault's `(tokens, balances)` parallel arrays once and pick
+    // out the entries matching the pool's canonical `(token0, token1)`
+    // ordering. Matching by address (not by index) is robust to Balancer's
+    // pool-registration ordering, which is not guaranteed to mirror the
+    // engine's cached `(token0, token1)` convention.
+    let mut bal0: Option<U256> = None;
+    let mut bal1: Option<U256> = None;
+    for (tok, bal) in decoded.tokens.iter().zip(decoded.balances.iter()) {
+        if *tok == token0 {
+            bal0 = Some(*bal);
+        } else if *tok == token1 {
+            bal1 = Some(*bal);
+        }
+    }
+    let (Some(b0), Some(b1)) = (bal0, bal1) else {
+        return Err(ReplayError::DecodeFailed("getPoolTokens"));
+    };
+
+    // `amount_out = U256::ZERO` because the consumer
+    // (`unified_to_post_reserves`) derives output amounts from the
+    // graph-edge update, not from this field. The analytical flag stays
+    // `false` since revm-derived state is the non-analytical branch by
+    // construction.
+    Ok(BalancerPostState {
+        new_balance0: b0,
+        new_balance1: b1,
+        amount_out: U256::ZERO,
+        analytical: false,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,17 +600,160 @@ mod tests {
     }
 
     #[test]
-    fn curve_stub_returns_unimplemented() {
-        // Build a minimal RpcForkedState replacement-style assertion via
-        // the cache path is awkward (no equivalent helper); instead
-        // assert on the error variant returned by the unimplemented
-        // stubs directly through the public-API surface.
-        let err = ReplayError::UnimplementedProtocol("curve");
-        assert_eq!(err.as_str(), "unimplemented_protocol");
+    fn curve_replay_decode_failed_when_pool_has_no_bytecode() {
+        // Codeless pool address — the `balances(i)` view returns empty
+        // output and ABI decode then fails, surfacing as
+        // `DecodeFailed("balances")`. This is the expected rejection
+        // path for a Curve replay against an address that isn't a real
+        // StableSwap pool.
+        let state = ForkedState::new_empty(18_000_000, 1_700_000_000, 1_000_000_000);
+        let pool = address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7");
+        let result = replay_curve_post_state_cache(
+            state,
+            &default_victim(),
+            pool,
+            0,
+            1,
+            &default_params(),
+        );
+        assert!(
+            matches!(result, Err(ReplayError::DecodeFailed("balances"))),
+            "expected DecodeFailed(balances), got {result:?}"
+        );
     }
 
     #[test]
-    fn balancer_stub_returns_unimplemented() {
+    fn balancer_replay_decode_failed_when_pool_has_no_bytecode() {
+        // Codeless pool address — the `getPoolId()` read fails to
+        // ABI-decode. Surfaces as `DecodeFailed("getPoolId")`, which is
+        // the right reason for a non-Balancer address routed into the
+        // Balancer replay path.
+        let state = ForkedState::new_empty(18_000_000, 1_700_000_000, 1_000_000_000);
+        let pool = address!("5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56");
+        let vault = BALANCER_V2_VAULT;
+        let t0 = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let t1 = address!("ba100000625a3754423978a60c9317c58a424e3D");
+        let result = replay_balancer_post_state_cache(
+            state,
+            &default_victim(),
+            pool,
+            vault,
+            t0,
+            t1,
+            &default_params(),
+        );
+        assert!(
+            matches!(result, Err(ReplayError::DecodeFailed("getPoolId"))),
+            "expected DecodeFailed(getPoolId), got {result:?}"
+        );
+    }
+
+    /// Build runtime bytecode that returns the same 32-byte word for
+    /// every call. Used to stand in for a Curve pool's `balances(i)`
+    /// view so the replay reader's success branch can be exercised
+    /// without standing up a real StableSwap deployment.
+    fn const_uint256_returner(value: U256) -> Vec<u8> {
+        let mut code = Vec::with_capacity(38);
+        code.push(0x7f); // PUSH32
+        code.extend_from_slice(&value.to_be_bytes::<32>());
+        code.extend_from_slice(&[0x60, 0x00]); // PUSH1 0
+        code.push(0x52); // MSTORE
+        code.extend_from_slice(&[0x60, 0x20]); // PUSH1 32
+        code.extend_from_slice(&[0x60, 0x00]); // PUSH1 0
+        code.push(0xf3); // RETURN
+        code
+    }
+
+    #[test]
+    fn curve_replay_success_returns_decoded_balances() {
+        // Stand-in pool returns the same constant for every `balances(i)`
+        // call. Both reads succeed and decode cleanly, so the reader
+        // populates a `CurvePostState` with `new_balance_in` /
+        // `new_balance_out` both equal to the constant and
+        // `analytical = false` (revm-derived state is the
+        // non-analytical branch by definition).
+        let constant = U256::from(123_456_789u64);
+        let pool = address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7");
+        let mut state = ForkedState::new_empty(18_000_000, 1_700_000_000, 1_000_000_000);
+        state.insert_account(pool, U256::ZERO, const_uint256_returner(constant).into());
+        // Fund victim so the value-transfer succeeds against codeless
+        // recipient; the replay path commits the victim before the
+        // balances() reads.
+        state.insert_account_balance(default_victim().from, U256::from(10u128.pow(18)));
+        let result = replay_curve_post_state_cache(
+            state,
+            &default_victim(),
+            pool,
+            0,
+            1,
+            &default_params(),
+        );
+        let post = result.expect("replay should succeed against const-returner bytecode");
+        assert_eq!(post.new_balance_in, constant);
+        assert_eq!(post.new_balance_out, constant);
+        assert_eq!(post.i, 0);
+        assert_eq!(post.j, 1);
+        assert!(!post.analytical, "revm-derived post-state must mark analytical=false");
+    }
+
+    #[test]
+    fn curve_replay_victim_reverted_path() {
+        // Victim target deployed with an explicit REVERT opcode. The
+        // reader must surface `VictimReverted` before any balances()
+        // call is attempted.
+        let mut state = ForkedState::new_empty(18_000_000, 1_700_000_000, 1_000_000_000);
+        let victim_target = address!("3333333333333333333333333333333333333333");
+        state.insert_account(
+            victim_target,
+            U256::ZERO,
+            vec![0x60, 0x00, 0x60, 0x00, 0xfd].into(),
+        );
+        state.insert_account_balance(default_victim().from, U256::from(10u128.pow(18)));
+        let pool = address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7");
+        let result = replay_curve_post_state_cache(
+            state,
+            &default_victim(),
+            pool,
+            0,
+            1,
+            &default_params(),
+        );
+        assert!(matches!(result, Err(ReplayError::VictimReverted)));
+    }
+
+    #[test]
+    fn balancer_replay_victim_reverted_path() {
+        let mut state = ForkedState::new_empty(18_000_000, 1_700_000_000, 1_000_000_000);
+        let victim_target = address!("3333333333333333333333333333333333333333");
+        state.insert_account(
+            victim_target,
+            U256::ZERO,
+            vec![0x60, 0x00, 0x60, 0x00, 0xfd].into(),
+        );
+        state.insert_account_balance(default_victim().from, U256::from(10u128.pow(18)));
+        let pool = address!("5c6Ee304399DBdB9C8Ef030aB642B10820DB8F56");
+        let t0 = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+        let t1 = address!("ba100000625a3754423978a60c9317c58a424e3D");
+        let result = replay_balancer_post_state_cache(
+            state,
+            &default_victim(),
+            pool,
+            BALANCER_V2_VAULT,
+            t0,
+            t1,
+            &default_params(),
+        );
+        assert!(matches!(result, Err(ReplayError::VictimReverted)));
+    }
+
+    #[test]
+    fn unimplemented_protocol_label_still_available() {
+        // Kept for label-space stability — the metric vocabulary in
+        // `metrics.rs` still includes `unimplemented_protocol` for
+        // legitimately disabled replay paths (no provider wired,
+        // semaphore saturation, etc.).
+        let err = ReplayError::UnimplementedProtocol("curve");
+        assert_eq!(err.as_str(), "unimplemented_protocol");
         let err = ReplayError::UnimplementedProtocol("balancer");
         assert_eq!(err.as_str(), "unimplemented_protocol");
     }


### PR DESCRIPTION
## Summary

- Adds revm-backed post-state readers for **Curve** (`balances(uint256)` per coin index) and **Balancer V2** (`IVault.getPoolTokens(bytes32)` against the canonical mainnet Vault) in `crates/simulator/src/post_state_replay.rs`
- Wires `ReplayProtocol::Curve` and `ReplayProtocol::Balancer` through the new readers in `crates/grpc-server/src/mempool_pipeline.rs::try_post_state_replay`, replacing the previous `unimplemented_protocol` skip
- Both readers emit `UnifiedPostState` records with `analytical = false` so callers can distinguish reader-sourced state from closed-form predictions

## Why

After the analytical predictors landed for Curve (#159) and Balancer, low-confidence inputs (Newton iteration unconverged on Curve, unequal-weight pools on Balancer) still fell back to `predictor_low_confidence` and skipped the candidate entirely. The revm reader closes that gap: when the analytical path is unreliable, the engine forks the block, replays the victim, and reads the post-swap reserves directly from EVM state — giving the cycle scan a real post-state to build edges from instead of dropping the opportunity.

## Files Changed

| File | Purpose |
|---|---|
| `crates/simulator/src/post_state_replay.rs` | `replay_curve_post_state_{rpc,cache}` + `replay_balancer_post_state_{rpc,cache}`. Curve reads `balances(i)` / `balances(j)` after the victim runs; Balancer reads `getPoolId()` on the pool then `getPoolTokens(poolId)` on `IVault @ 0xBA12222222228d8Ba445958a75a0704d566BF2C8`. 9 new unit tests (V3 reject cases, no-bytecode `DecodeFailed`, Curve success against a const-returner, Curve/Balancer `VictimReverted`, label stability) |
| `crates/grpc-server/src/mempool_pipeline.rs` | `try_post_state_replay` signature extended with `pool_state: &PoolState`, `swap_token_in`, `swap_token_out`. Match on `ReplayProtocol` dispatches to V3 / Curve / Balancer. Curve resolves `(i, j)` from `CurvePool.tokens`; Balancer reads `token0` / `token1` from `BalancerPool`. New test `try_post_state_replay_curve_balancer_reach_provider_check` proving dispatch reaches the provider-check exit |

## Implementation notes

- **Direction alignment.** Curve uses coin indices, Balancer uses `(token0, token1)`. The pipeline resolves the swap direction from the cached `PoolState` before calling the reader, so the reader returns balances aligned with the swap (`new_balance_in` / `new_balance_out`) — the unified post-state types stay consistent across analytical and reader-sourced rows.
- **No analytical-flag flip.** Reader output sets `analytical = false`. Callers that gate behavior on confidence (e.g. cycle-scan freshness checks, simulation cross-validation) can branch on this flag without re-deriving from the protocol.
- **Vault hard-coded.** Mainnet Balancer V2 Vault is constant; the reader uses it directly rather than reading it off the pool. Saves one call per replay and avoids a needless RPC dependency.
- **amount_out = 0 on reader output.** The reader does not compute `amount_out` (the engine doesn't need it — it has the on-chain balances). Field kept for `UnifiedPostState` shape symmetry with the analytical path.

## Acceptance criteria

- [x] Curve reader replays a victim and returns balances differing from pre-state, `analytical = false`
- [x] Balancer reader queries the canonical Vault, picks balances matching cached `(token0, token1)` ordering
- [x] Pipeline dispatch reaches the per-protocol branch (no longer skipped with `unimplemented_protocol`)
- [x] Curve / Balancer reader failures (revert, no-bytecode, decode error) propagate as `replay_reader_failed` reasons rather than crashes
- [ ] Live mainnet observation: `aether_pending_arb_sim_skipped_total{reason="unimplemented_protocol"}` flatlines for Curve / Balancer; reader-sourced candidates surface on `aether_pending_arb_candidates_total`

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets --release -- -D warnings` clean
- [x] `cargo test --workspace --release` all green
  - 9 new `post_state_replay::tests::*` (Curve/Balancer reader paths + reject cases)
  - 1 new pipeline test `try_post_state_replay_curve_balancer_reach_provider_check`
- [x] `go build ./...` + `go test ./... -count=1` green (no Go changes, regression check)
- [x] `forge build` + `forge test` green (no Solidity changes, regression check — 59 passed, 0 failed, 2 skipped)
- [ ] Live smoke post-merge — confirm low-confidence Curve / Balancer victim txs reach the reader and surface candidates under real flow