### PR TITLE
feat(simulator): inject AetherExecutor bytecode into revm CacheDB for shadow runs

### DIFF
--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -398,6 +398,15 @@ fn build_backrun_validator_config(
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(8);
+    // Optional AetherExecutor runtime bytecode for demo / shadow runs
+    // against a forked chain where the contract is not deployed. Path
+    // points at forge's `out/AetherExecutor.sol/AetherExecutor.json` —
+    // the hex string under `.deployedBytecode.object` is loaded and
+    // injected into the revm CacheDB on every sim. Unset in production.
+    let executor_bytecode = std::env::var("AETHER_EXECUTOR_BYTECODE_PATH")
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p.trim()).ok())
+        .and_then(|s| load_executor_runtime_bytecode(&s).ok());
     Some(mempool_pipeline::BackrunValidatorConfig {
         executor_address,
         searcher_caller,
@@ -412,5 +421,24 @@ fn build_backrun_validator_config(
         // with the SimContext's shared handle so the validator and the
         // background refresher rotate the same `ArcSwap`.
         mempool_prewarm: Arc::new(arc_swap::ArcSwap::from_pointee(None)),
+        executor_bytecode,
     })
+}
+
+/// Pull the `deployedBytecode.object` hex string out of a forge artifact
+/// JSON and decode it. Returns `Err` for missing field, malformed JSON,
+/// or non-hex bytes — callers treat the error as "no bytecode override"
+/// and the sim falls back to the on-chain fetch path.
+fn load_executor_runtime_bytecode(
+    artifact_json: &str,
+) -> Result<alloy::primitives::Bytes, Box<dyn std::error::Error>> {
+    let v: serde_json::Value = serde_json::from_str(artifact_json)?;
+    let hex_str = v
+        .get("deployedBytecode")
+        .and_then(|d| d.get("object"))
+        .and_then(|o| o.as_str())
+        .ok_or("artifact missing deployedBytecode.object")?;
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = alloy::hex::decode(hex_str)?;
+    Ok(alloy::primitives::Bytes::from(bytes))
 }

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -121,6 +121,12 @@ pub struct BackrunValidatorConfig {
     /// the SimContext attaches it). Atomic load on every shadow-sim.
     pub mempool_prewarm:
         Arc<ArcSwap<Option<Arc<aether_simulator::fork::PrewarmedState>>>>,
+    /// Optional `AetherExecutor` runtime bytecode injected into the revm
+    /// CacheDB at `executor_address` before each arb sim. Populated when
+    /// running against a forked chain where the contract is not yet
+    /// deployed (demo / shadow runs). `None` for production runs where the
+    /// address resolves against on-chain bytecode.
+    pub executor_bytecode: Option<alloy::primitives::Bytes>,
 }
 
 /// State the post-state simulator needs to run after a successful decode.
@@ -1560,6 +1566,7 @@ fn run_backrun_validation(
         profit_token: cfg.profit_token,
         profit_recipient: cfg.searcher_caller,
         balance_slot: cfg.balance_slot,
+        executor_bytecode: cfg.executor_bytecode.clone(),
     };
 
     let result = validate_backrun_rpc(state, &victim, &arb, &params);
@@ -2338,6 +2345,7 @@ mod tests {
             sim_semaphore: Arc::new(Semaphore::new(1)),
             provider: None,
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
+            executor_bytecode: None,
         }
     }
 
@@ -2469,6 +2477,7 @@ mod tests {
             sim_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
             provider: None,
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
+            executor_bytecode: None,
         };
 
         let shared_handle = Arc::clone(&ctx_inner.mempool_prewarm);

--- a/crates/simulator/src/mempool_backrun.rs
+++ b/crates/simulator/src/mempool_backrun.rs
@@ -12,14 +12,14 @@
 //! tokio integration. This module is a synchronous pure function so it can
 //! run on `spawn_blocking` workers without leaking async dependencies.
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, Bytes, U256};
 use revm::context::result::ExecutionResult;
 use revm::context::{BlockEnv, TxEnv};
 use revm::database::{CacheDB, EmptyDB};
 use revm::database_interface::{Database, DatabaseRef};
 use revm::handler::{ExecuteCommitEvm, ExecuteEvm, MainBuilder};
 use revm::primitives::hardfork::SpecId;
-use revm::state::EvmState;
+use revm::state::{AccountInfo, Bytecode, EvmState};
 use revm::Context;
 use tracing::debug;
 
@@ -129,6 +129,14 @@ pub struct ValidatorParams {
     /// (WETH = 3, USDC = 9, USDT/DAI = 2). The caller resolves this from
     /// the static `aether_common` token table.
     pub balance_slot: U256,
+    /// Optional runtime bytecode to inject at `arb.to` before running the
+    /// arb tx. Used by demo / shadow-mode runs against a forked mainnet
+    /// where `AetherExecutor` has not been deployed: the pipeline loads
+    /// the compiled runtime bytecode from `contracts/out/AetherExecutor.sol`
+    /// and threads it through here so the revm sim's `executeArb` call
+    /// hits real bytecode instead of empty-account revert. `None` for
+    /// production runs where the contract is on-chain.
+    pub executor_bytecode: Option<Bytes>,
 }
 
 /// Run the two-tx sim against an RPC-backed fork. Production entry point.
@@ -168,7 +176,7 @@ pub fn validate_backrun_cache(
 /// `RpcForkedState` (CacheDB<SyncAlloyDb>) and `ForkedState`
 /// (CacheDB<EmptyDB>) flow through here.
 fn validate_backrun_inner<DB>(
-    db: CacheDB<DB>,
+    mut db: CacheDB<DB>,
     victim: &VictimTx,
     arb: &ArbTx,
     params: &ValidatorParams,
@@ -178,6 +186,27 @@ where
     CacheDB<DB>: Database<Error = <DB as DatabaseRef>::Error>,
     <DB as DatabaseRef>::Error: std::fmt::Debug,
 {
+    // Demo / shadow runs against a forked mainnet may target an
+    // AetherExecutor address that is not yet deployed on-chain. The
+    // pipeline threads the compiled runtime bytecode through
+    // `params.executor_bytecode` so we can inject it into the CacheDB at
+    // `arb.to`, making the subsequent `executeArb` call hit real bytecode
+    // instead of empty-account revert. Production runs pass `None` and
+    // the cache resolves the address via the forked DB.
+    if let Some(code) = params.executor_bytecode.as_ref() {
+        let bytecode = Bytecode::new_raw(code.clone());
+        db.insert_account_info(
+            arb.to,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 1,
+                code_hash: bytecode.hash_slow(),
+                code: Some(bytecode),
+                ..Default::default()
+            },
+        );
+    }
+
     // Compute the storage key for balanceOf(profit_recipient):
     //   slot = keccak256(pad32(recipient) ++ pad32(balance_slot))
     let mut key_input = [0u8; 64];
@@ -372,6 +401,7 @@ mod tests {
             profit_token: WETH,
             profit_recipient: RECIPIENT,
             balance_slot: U256::from(3u64), // WETH balances slot
+            executor_bytecode: None,
         }
     }
 
@@ -463,5 +493,52 @@ mod tests {
         // Sanity: the doc-hidden helper actually returns something the
         // generic core accepts. Used by downstream pipeline tests.
         let _: CacheDB<EmptyDB> = empty_cache_db();
+    }
+
+    #[test]
+    fn executor_bytecode_injection_makes_arb_to_execute_real_code() {
+        // Demo-mode override: no contract at ARB_TO on the forked DB.
+        // Without injection the arb call hits empty bytecode → succeeds
+        // with zero profit → NegativeAfterGas (covered by the
+        // `victim_with_no_code_succeeds...` test above).
+        //
+        // With `executor_bytecode = Some(REVERT)`, the same call now hits
+        // the injected REVERT opcode and the validator must propagate
+        // ArbReverted instead of NegativeAfterGas — proving the bytecode
+        // was actually installed at ARB_TO and the EVM dispatched to it.
+        let state = ForkedState::new_empty(18_000_000, 1_700_000_000, 0);
+        let mut params = default_params();
+        // PUSH1 0x00 PUSH1 0x00 REVERT — minimal explicit-revert program.
+        params.executor_bytecode = Some(Bytes::from(vec![0x60, 0x00, 0x60, 0x00, 0xfd]));
+        let result = validate_backrun_cache(state, &default_victim(), &default_arb(), &params);
+        assert!(!result.accepted);
+        assert_eq!(
+            result.reject,
+            Some(RejectReason::ArbReverted),
+            "injected REVERT must propagate as ArbReverted, not NegativeAfterGas"
+        );
+        assert!(
+            result.arb_gas_used > 0,
+            "arb leg must have actually executed the injected bytecode"
+        );
+    }
+
+    #[test]
+    fn executor_bytecode_none_preserves_pre_existing_arb_to_state() {
+        // When `executor_bytecode = None`, the injection branch is skipped
+        // and any bytecode already at ARB_TO on the forked DB is left
+        // untouched. This is the production path: the cache's on-chain
+        // bytecode is the source of truth.
+        let mut state = ForkedState::new_empty(18_000_000, 1_700_000_000, 0);
+        // Pre-populate ARB_TO with INVALID opcode → ArbHalted on call.
+        state.insert_account(ARB_TO, U256::ZERO, vec![0xfe].into());
+        let params = default_params(); // executor_bytecode = None
+        let result = validate_backrun_cache(state, &default_victim(), &default_arb(), &params);
+        assert!(!result.accepted);
+        assert_eq!(
+            result.reject,
+            Some(RejectReason::ArbHalted),
+            "pre-existing INVALID at ARB_TO must drive the reject reason"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `ValidatorParams` gains an `executor_bytecode: Option<Bytes>` field
- `validate_backrun_inner` injects the bytecode into the revm `CacheDB` at `arb.to` before running the arb leg when `Some`
- `BackrunValidatorConfig` threads the value through; `build_backrun_validator_config` reads `AETHER_EXECUTOR_BYTECODE_PATH` env var, expects a forge artifact JSON, extracts `deployedBytecode.object` and decodes
- 2 new simulator unit tests cover injection path + None no-op

## Why

Demo / shadow-mode runs target a forked mainnet RPC where `AetherExecutor` is not deployed. Without injection every backrun sim hits empty-account revert at `arb.to`, so the validator path never produces a real flashloan-included profit measurement — the demo's end-to-end flow stops short of step 6 (flashloan sim).

Three alternatives considered before going with bytecode injection:

| Option | Reason rejected |
|---|---|
| Deploy `AetherExecutor` to mainnet | Costs real ETH, exposes the contract before it's audited |
| Anvil with periodic re-fork loop | Brittle, contract address can drift across forks, race conditions during fork swap |
| Reth full sync (already in compose) | Mainnet sync takes 24h+ — not viable for tomorrow's demo |

Bytecode injection is the production-shaped fix: the binary stays the same, ops just sets one env var pointing at the forge artifact when running against a fork. Production sets nothing and the cache resolves on-chain bytecode as before.

## Files Changed

| File | Purpose |
|---|---|
| `crates/simulator/src/mempool_backrun.rs` | `ValidatorParams.executor_bytecode` field; `validate_backrun_inner` injects via `CacheDB::insert_account_info` with `Bytecode::new_raw` + computed `code_hash` before EVM context is built. 2 new tests: `executor_bytecode_injection_makes_arb_to_execute_real_code` (injected REVERT propagates as `ArbReverted`, not `NegativeAfterGas`) and `executor_bytecode_none_preserves_pre_existing_arb_to_state` (None case respects whatever bytecode the cache already holds) |
| `crates/grpc-server/src/mempool_pipeline.rs` | `BackrunValidatorConfig.executor_bytecode` field; clone into `ValidatorParams` on every sim attempt. Test fixtures default to `None` |
| `crates/grpc-server/src/main.rs` | `build_backrun_validator_config` reads `AETHER_EXECUTOR_BYTECODE_PATH`. `load_executor_runtime_bytecode` helper parses the forge artifact's `deployedBytecode.object` hex string. Failure modes (env unset, file unreadable, malformed JSON, non-hex bytes) all fall through to `None` so a typo can't break the production path |

## Implementation notes

- **`Bytecode::new_raw` + `hash_slow`.** revm's `AccountInfo` needs `code_hash` to match the bytecode for storage lookups. `Bytecode::hash_slow` computes the keccak — one extra hash per sim, negligible vs the EVM execution cost.
- **`db: CacheDB<DB>` → `mut db`.** The injection mutates the cache before it's moved into `Context::new`. No allocation on the `None` path — the `if let Some(...)` branch elides.
- **`load_executor_runtime_bytecode` is fail-open.** Any error returns `None` (treated as no override). Logging the failure path is a follow-up — for now the env var is opt-in and operators know whether they set it.
- **No production behaviour change.** Unset env → `executor_bytecode = None` → injection branch skipped → byte-identical to the pre-PR `validate_backrun_inner`.

## Acceptance criteria

- [x] `ValidatorParams.executor_bytecode = Some(bytecode)` results in the bytecode being executable at `arb.to` inside the sim
- [x] `executor_bytecode = None` preserves any pre-existing cache state at `arb.to`
- [x] `BackrunValidatorConfig` carries the field; pipeline threads it on every sim
- [x] `AETHER_EXECUTOR_BYTECODE_PATH` env reads + decodes forge artifact
- [x] Malformed / missing artifact falls through to None (no panic)
- [ ] Live smoke: demo.sh with the env set, forked mainnet, no on-chain deploy — confirm `validate_backrun_inner` produces non-zero `gross_profit_wei` on a profitable victim

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets --release -- -D warnings` clean
- [x] `cargo test --workspace --release` all green (654 passed, 0 failed)
  - 2 new `mempool_backrun::tests::executor_bytecode_*` tests
- [x] `go build ./...` + `go test ./... -count=1` green (regression check, no Go changes)
- [x] `forge build` + `forge test` green (regression check, no Solidity changes — 59 passed, 0 failed, 2 skipped)
- [ ] Demo smoke post-merge — run `demo.sh` for 30 min, confirm `bundles` rows accumulate under `is_shadow = true` with real-looking `profit_eth` values (not zeros)