### PR TITLE
fix(decoder): u64 overflow in bancor test minReturnAmount

### DIFF
--- a/crates/pools/src/router_decoder.rs
+++ b/crates/pools/src/router_decoder.rs
@@ -2812,7 +2812,7 @@ mod tests {
             sourceToken: weth,
             targetToken: bnt,
             sourceAmount: U256::from(1_000_000_000_000_000_000u128), // 1 WETH
-            minReturnAmount: U256::from(2_500u64 * 10u64.pow(18)),    // 2500 BNT
+            minReturnAmount: U256::from(2_500u64) * U256::from(1_000_000_000_000_000_000u128),    // 2500 BNT
             deadline: U256::from(99_999_999_999u64),
             beneficiary,
         }
@@ -2823,7 +2823,7 @@ mod tests {
         assert_eq!(decoded.token_in, weth);
         assert_eq!(decoded.token_out, bnt);
         assert_eq!(decoded.amount_in, U256::from(1_000_000_000_000_000_000u128));
-        assert_eq!(decoded.amount_out_min, U256::from(2_500u64 * 10u64.pow(18)));
+        assert_eq!(decoded.amount_out_min, U256::from(2_500u64) * U256::from(1_000_000_000_000_000_000u128));
         assert_eq!(decoded.recipient, beneficiary);
         assert_eq!(decoded.fee_bps, 0);
         assert!(decoded.path_extra.is_empty());


### PR DESCRIPTION
## Summary

- Fix `attempt to multiply with overflow` panic in `decode_bancor_trade_by_source_amount` test.
- The literal `2_500u64 * 10u64.pow(18)` evaluates to 2.5e21, which exceeds `u64::MAX` (~1.84e19) and panics under debug-mode arithmetic-overflow checks.
- Lift the constant into U256 arithmetic: `U256::from(2_500u64) * U256::from(1_000_000_000_000_000_000u128)` — same value, no intermediate u64 multiplication.

## Files Changed

| File | Change |
|---|---|
| `crates/pools/src/router_decoder.rs` | Replace overflowing `u64` literal with U256 arithmetic in bancor test |

## Acceptance Criteria

- [x] `cargo test -p aether-pools --lib router_decoder` passes (55/55)
- [x] `cargo clippy -p aether-pools --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green
- [x] No production code path changed — test-only constant fix

## Test plan

- [x] Reproduced the panic on develop tip before the fix
- [x] Verified the post-fix test asserts the same `amount_out_min = 2500e18` BNT value
- [x] Full workspace test suite passes