### PR TITLE
perf(sim): wire bytecode cache into prewarm + engine + mempool pipeline

### DIFF
--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -199,6 +199,12 @@ pub struct AetherEngine {
     /// When `Some`, `run_detection_cycle` uses `RpcForkedState` instead of
     /// the empty `ForkedState`.
     rpc_provider: Option<DynProvider<Ethereum>>,
+    /// Optional persistent bytecode cache. When opened (via the
+    /// `AETHER_BYTECODE_CACHE_PATH` env var) `prewarm_state` consults it
+    /// before issuing `eth_getCode` and writes back any freshly fetched
+    /// bytecode so subsequent block cycles serve cache hits. `None`
+    /// preserves the historical RPC-every-time behaviour.
+    bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
     /// Prometheus metrics for engine operations.
     metrics: Arc<EngineMetrics>,
     /// Persistent trade ledger. NoopLedger by default; PgLedger when
@@ -424,6 +430,25 @@ impl AetherEngine {
             Some(provider.erased())
         });
 
+        // Open the persistent bytecode cache when configured. Failure to open
+        // never blocks engine startup — every cache operation degrades to
+        // `None` and falls through to the existing RPC path.
+        let bytecode_cache = std::env::var("AETHER_BYTECODE_CACHE_PATH")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .and_then(|path| {
+                match aether_simulator::bytecode_cache::BytecodeCache::open(&path) {
+                    Ok(c) => {
+                        info!(path = %path, "bytecode cache opened");
+                        Some(Arc::new(c))
+                    }
+                    Err(e) => {
+                        warn!(path = %path, error = %e, "bytecode cache open failed; running without cache");
+                        None
+                    }
+                }
+            });
+
         // Start with a reasonable initial graph size (can grow dynamically).
         let initial_graph = PriceGraph::new(100);
         let snapshot_manager = Arc::new(SnapshotManager::new(initial_graph.clone()));
@@ -442,6 +467,7 @@ impl AetherEngine {
             pool_registry: Arc::new(ArcSwap::from_pointee(HashMap::new())),
             pool_states: new_pool_state_cache(),
             rpc_provider,
+            bytecode_cache,
             metrics,
             ledger,
         }
@@ -1997,8 +2023,14 @@ impl AetherEngine {
             v2_addrs.sort_unstable();
             v2_addrs.dedup();
 
-            let state =
-                prewarm_state(provider, block_info.number, &code_addrs, &v2_addrs).await;
+            let state = prewarm_state(
+                provider,
+                block_info.number,
+                &code_addrs,
+                &v2_addrs,
+                self.bytecode_cache.as_deref(),
+            )
+            .await;
             Some(Arc::new(state))
         } else {
             None
@@ -2276,6 +2308,15 @@ impl AetherEngine {
     /// to build `RpcForkedState` per validation attempt.
     pub fn rpc_provider(&self) -> Option<DynProvider<Ethereum>> {
         self.rpc_provider.clone()
+    }
+
+    /// Borrow the persistent bytecode cache handle. `None` when the cache is
+    /// disabled (no `AETHER_BYTECODE_CACHE_PATH`). Cheap to `Arc::clone` for
+    /// downstream consumers (mempool `SimContext`).
+    pub fn bytecode_cache(
+        &self,
+    ) -> Option<&Arc<aether_simulator::bytecode_cache::BytecodeCache>> {
+        self.bytecode_cache.as_ref()
     }
 }
 

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -209,6 +209,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "MEMPOOL_POST_STATE_REPLAY enabled — V3 tick-crossing swaps will escalate to revm fork-replay"
                 );
             }
+            // Plumb the engine's bytecode cache (when configured via
+            // `AETHER_BYTECODE_CACHE_PATH`) into the mempool prewarm path so
+            // address-keyed `eth_getCode` hits skip the RPC round-trip.
+            sim_ctx_inner =
+                sim_ctx_inner.with_bytecode_cache(engine.bytecode_cache().cloned());
             let sim_ctx = Arc::new(sim_ctx_inner);
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -182,6 +182,9 @@ pub struct SimContext {
     /// bytecode on every attempt. `None` until the first refresh lands.
     pub mempool_prewarm:
         Arc<ArcSwap<Option<Arc<aether_simulator::fork::PrewarmedState>>>>,
+    /// Optional persistent bytecode cache. Threaded into `prewarm_state` so
+    /// addresses already on disk skip the `eth_getCode` round-trip.
+    pub bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
 }
 
 impl SimContext {
@@ -208,7 +211,20 @@ impl SimContext {
             pair_index_cache: Mutex::new(None),
             post_state_replay_enabled: false,
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
+            bytecode_cache: None,
         }
+    }
+
+    /// Attach a persistent bytecode cache. Future `prewarm_state` calls that
+    /// receive this `SimContext` will consult the cache before issuing
+    /// `eth_getCode` and persist any freshly fetched bytecode back. Passing
+    /// `None` is equivalent to the historical RPC-every-time behaviour.
+    pub fn with_bytecode_cache(
+        mut self,
+        cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
+    ) -> Self {
+        self.bytecode_cache = cache;
+        self
     }
 
     /// Flip the revm post-state replay fallback on. Callers should also
@@ -435,9 +451,14 @@ async fn run_prewarm_refresh(
     let pool_count = registry_guard.len();
     drop(registry_guard);
 
-    let fresh =
-        aether_simulator::fork::prewarm_state(provider, block_number, &code_addrs, &v2_addrs)
-            .await;
+    let fresh = aether_simulator::fork::prewarm_state(
+        provider,
+        block_number,
+        &code_addrs,
+        &v2_addrs,
+        sim_ctx.bytecode_cache.as_deref(),
+    )
+    .await;
 
     sim_ctx
         .mempool_prewarm

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -22,6 +22,7 @@ dashmap = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[bench]]
 name = "simulation"

--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -3,6 +3,8 @@ use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::providers::{DynProvider, Provider};
 use futures::future::join_all;
 use revm::bytecode::Bytecode;
+
+use crate::bytecode_cache::BytecodeCache;
 use revm::database::CacheDB;
 use revm::database_interface::EmptyDB;
 use revm::state::AccountInfo;
@@ -59,19 +61,42 @@ impl PrewarmedState {
 /// **`v2_pool_addresses`**: UniswapV2 / SushiSwap pools whose packed-reserve
 /// slot (slot 8) is pre-fetched. This is the single most impactful storage
 /// slot to warm — `getReserves()` reads it on every V2 swap path.
+///
+/// **`bytecode_cache`**: when supplied, addresses already resident in the
+/// cache short-circuit the `eth_getCode` call entirely; freshly fetched
+/// bytecode is persisted back so subsequent block cycles serve from the
+/// cache. Pass `None` to retain the historical RPC-every-time behaviour.
 pub async fn prewarm_state(
     provider: &DynProvider<Ethereum>,
     block_number: u64,
     code_addresses: &[Address],
     v2_pool_addresses: &[Address],
+    bytecode_cache: Option<&BytecodeCache>,
 ) -> PrewarmedState {
     let block_id = BlockId::from(block_number);
 
-    // Fetch contract code for every address in parallel.
-    // Returns (code_hash, bytecode) pairs — we warm the bytecode cache only,
+    // Partition addresses into cache hits (served locally) and misses (must
+    // RPC). Hits bypass the entire RPC fan-out so they don't even contribute
+    // to the in-flight burst that drives free-tier 429s.
+    let mut cached: Vec<(B256, Bytecode)> = Vec::new();
+    let mut to_fetch: Vec<Address> = Vec::with_capacity(code_addresses.len());
+    if let Some(cache) = bytecode_cache {
+        for &addr in code_addresses {
+            match cache.get(addr) {
+                Some(hit) => cached.push(hit),
+                None => to_fetch.push(addr),
+            }
+        }
+    } else {
+        to_fetch.extend_from_slice(code_addresses);
+    }
+
+    // Fetch contract code for every cache-miss in parallel. Returns
+    // (code_hash, bytecode) pairs — we warm the bytecode cache only,
     // leaving account balance/nonce for lazy RPC fetch.
-    let code_futs = code_addresses.iter().map(|&addr| {
+    let code_futs = to_fetch.into_iter().map(|addr| {
         let p = provider.clone();
+        let cache = bytecode_cache.cloned();
         async move {
             match p.get_code_at(addr).block_id(block_id).await {
                 Ok(code) if !code.is_empty() => {
@@ -79,6 +104,11 @@ pub async fn prewarm_state(
                     let bytecode = Bytecode::new_raw(
                         revm::primitives::Bytes::copy_from_slice(&code),
                     );
+                    if let Some(c) = cache.as_ref() {
+                        if let Err(e) = c.put(addr, code_hash, &code) {
+                            warn!(%addr, error = %e, "pre-warm: bytecode cache persist failed");
+                        }
+                    }
                     Some((code_hash, bytecode))
                 }
                 Ok(_) => None, // empty bytecode (EOA)
@@ -116,14 +146,23 @@ pub async fn prewarm_state(
     let (code_results, storage_results) =
         tokio::join!(join_all(code_futs), join_all(storage_futs));
 
+    let cache_hits = cached.len();
+    let rpc_fetched = code_results.iter().filter(|r| r.is_some()).count();
+    let storage_warmed = storage_results.iter().filter(|r| r.is_some()).count();
     debug!(
-        code_warmed = code_results.iter().filter(|r| r.is_some()).count(),
-        storage_warmed = storage_results.iter().filter(|r| r.is_some()).count(),
+        cache_hits,
+        rpc_fetched,
+        storage_warmed,
         "Block pre-warm complete"
     );
 
+    // Merge cached + freshly fetched entries. Order doesn't matter because
+    // injection is keyed by code hash on the consumer side.
+    let mut code_cache = cached;
+    code_cache.extend(code_results.into_iter().flatten());
+
     PrewarmedState {
-        code_cache: code_results.into_iter().flatten().collect(),
+        code_cache,
         storage: storage_results.into_iter().flatten().collect(),
     }
 }
@@ -477,5 +516,67 @@ mod tests {
         assert_eq!(*db_account.storage.get(&U256::from(0)).unwrap(), U256::from(111));
         assert_eq!(*db_account.storage.get(&U256::from(1)).unwrap(), U256::from(222));
         assert_eq!(*db_account.storage.get(&U256::from(2)).unwrap(), U256::from(333));
+    }
+
+    // ── prewarm + bytecode cache wiring ────────────────────────────
+
+    /// When every requested address is already resident in the bytecode
+    /// cache, `prewarm_state` must surface those entries without issuing a
+    /// single RPC. We exercise this by handing the function a provider
+    /// pointed at an unreachable port: any cache miss would trip the
+    /// connection refusal and produce a `warn!` log, but with a fully warm
+    /// cache the RPC code path is never entered and the returned state
+    /// reflects exactly what was pre-populated.
+    #[tokio::test]
+    async fn prewarm_state_skips_rpc_on_full_cache_hit() {
+        use crate::bytecode_cache::BytecodeCache;
+        use alloy::providers::ProviderBuilder;
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let cache = BytecodeCache::open(tmp.path()).unwrap();
+
+        // Two addresses, each pre-populated with a distinct bytecode.
+        let addr_a = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let code_a = vec![0x60u8, 0x80, 0x60, 0x40, 0x52];
+        let hash_a = alloy::primitives::keccak256(&code_a);
+        cache.put(addr_a, hash_a, &code_a).unwrap();
+
+        let addr_b = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let code_b = vec![0x60u8, 0x00, 0x60, 0x00, 0xf3];
+        let hash_b = alloy::primitives::keccak256(&code_b);
+        cache.put(addr_b, hash_b, &code_b).unwrap();
+
+        // Localhost on a port we'll never bind to — guarantees any RPC
+        // attempt fails fast (and surfaces a `warn!`) instead of hanging.
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+
+        let state = prewarm_state(&provider, 1, &[addr_a, addr_b], &[], Some(&cache)).await;
+
+        assert_eq!(
+            state.code_cache.len(),
+            2,
+            "both addresses must come back via the cache, not RPC"
+        );
+        let returned_hashes: std::collections::HashSet<_> =
+            state.code_cache.iter().map(|(h, _)| *h).collect();
+        assert!(returned_hashes.contains(&hash_a));
+        assert!(returned_hashes.contains(&hash_b));
+    }
+
+    /// Without a cache, the function must behave exactly as before. Pointing
+    /// at an unreachable RPC and supplying no addresses gives us a stable
+    /// "all paths empty" baseline that verifies the new signature did not
+    /// break the historical `None`-cache code path.
+    #[tokio::test]
+    async fn prewarm_state_without_cache_returns_empty_for_empty_input() {
+        use alloy::providers::ProviderBuilder;
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+        let state = prewarm_state(&provider, 1, &[], &[], None).await;
+        assert!(state.code_cache.is_empty());
+        assert!(state.storage.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **Stacks on #174.** This PR consumes the `BytecodeCache` introduced there and threads it through to the two `prewarm_state` call sites: the block-driven `engine.rs:2001` path and the mempool-shadow `mempool_pipeline.rs:439` path.
- **Hot-path RPC delta.** Each address that is already on disk now skips the `eth_getCode` round-trip entirely. After a single warm-up cycle, expect `eth_getCode` traffic to drop from ~20 calls per validation to near zero.
- **Opt-in.** Cache is enabled only when `AETHER_BYTECODE_CACHE_PATH` is set. Empty / unset = identical behaviour to develop.
- **Failure mode preserved.** Any cache open / read / persist failure logs `warn!` and falls through to the historical RPC path. Nothing the cache does is on a hard-dependency edge.
- **G2-wire** sub-task of the Path B RPC-reduction workstream: G1 (#173) → G2-module (#174) → **G2-wire (this)** → G3 → G4.

## Files Changed

| File | Change |
|---|---|
| `crates/simulator/src/fork.rs` | Extend `prewarm_state` with `Option<&BytecodeCache>` param; partition addresses into hits vs. misses; persist freshly fetched bytecode back to cache; 2 new unit tests |
| `crates/grpc-server/src/engine.rs` | Add `bytecode_cache: Option<Arc<BytecodeCache>>` field; open from `AETHER_BYTECODE_CACHE_PATH` at startup; expose via `bytecode_cache()` getter; pass to `prewarm_state` call site |
| `crates/grpc-server/src/mempool_pipeline.rs` | Add `bytecode_cache` field on `SimContext` + `with_bytecode_cache` builder; pass to `spawn_mempool_prewarm_refresher`'s `prewarm_state` call |
| `crates/grpc-server/src/main.rs` | Plumb `engine.bytecode_cache()` into the mempool `SimContext` after `with_post_state_replay` |
| `crates/simulator/Cargo.toml` | Add `tokio` dev-dep `macros + rt-multi-thread` features for the async fork test |

## Acceptance Criteria

- [x] `prewarm_state` partitions code addresses into cache hits (locally served) and misses (RPC-fetched)
- [x] Freshly fetched bytecode is persisted back via `cache.put()` after RPC success
- [x] `AETHER_BYTECODE_CACHE_PATH` unset → cache disabled, behaviour identical to develop
- [x] Cache open failure → `warn!` + run without cache (no startup abort)
- [x] Cache persist failure → `warn!` + serve freshly-fetched value
- [x] `prewarm_state` with fully warm cache succeeds against an unreachable RPC (no RPC issued)
- [x] `cargo test -p aether-simulator --lib fork::` → 13/13 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (one unrelated pre-existing bancor-overflow failure addressed by #172)

## Test plan

- [x] `prewarm_state_skips_rpc_on_full_cache_hit` — fully warm cache + unreachable RPC = all hits returned
- [x] `prewarm_state_without_cache_returns_empty_for_empty_input` — `None` cache + empty inputs = empty output (signature regression guard)
- [ ] Shadow demo run with `AETHER_BYTECODE_CACHE_PATH=data/bytecode.redb` — expect `eth_getCode` rate to drop ~95% after the first 1-2 block cycles (validated post-merge)

## Stacking note

Base is `feat/bytecode-disk-cache` (#174). Once that merges, this PR's base flips to `develop` automatically.