### PR TITLE
perf(sim): WS-fed V2 reserves cache, skip getStorageAt for warm pools

### DIFF
--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -205,6 +205,12 @@ pub struct AetherEngine {
     /// bytecode so subsequent block cycles serve cache hits. `None`
     /// preserves the historical RPC-every-time behaviour.
     bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
+    /// In-memory cache of UniswapV2 / SushiSwap pool reserves populated by
+    /// the WS `Sync` event handler. `prewarm_state` consults it before
+    /// issuing `eth_getStorageAt` for slot 8 of each pool. Always present
+    /// (lock-free `DashMap`-backed) but only effective once Sync events
+    /// have populated entries for the monitored pools.
+    v2_reserves_cache: aether_simulator::v2_reserves_cache::V2ReservesCache,
     /// Prometheus metrics for engine operations.
     metrics: Arc<EngineMetrics>,
     /// Persistent trade ledger. NoopLedger by default; PgLedger when
@@ -468,6 +474,7 @@ impl AetherEngine {
             pool_states: new_pool_state_cache(),
             rpc_provider,
             bytecode_cache,
+            v2_reserves_cache: aether_simulator::v2_reserves_cache::V2ReservesCache::new(),
             metrics,
             ledger,
         }
@@ -1449,6 +1456,17 @@ impl AetherEngine {
             } => {
                 debug!(%pool, ?protocol, "Pool reserve update");
 
+                // Capture the live reserves into the WS-fed cache so the
+                // next pre-warm cycle can serve slot 8 locally instead of
+                // round-tripping `eth_getStorageAt`. Only V2-family pools
+                // pack reserves at slot 8 in the format this cache emits;
+                // V3 / Curve / Balancer have richer state representations
+                // and stay on the existing RPC path.
+                if matches!(protocol, ProtocolType::UniswapV2 | ProtocolType::SushiSwap) {
+                    let block = self.current_block.load().number;
+                    self.v2_reserves_cache.record(pool, reserve0, reserve1, block);
+                }
+
                 // Look up pool metadata to get graph vertex indices.
                 let meta = self.pool_registry.load().get(&pool).cloned();
 
@@ -2029,6 +2047,7 @@ impl AetherEngine {
                 &code_addrs,
                 &v2_addrs,
                 self.bytecode_cache.as_deref(),
+                Some(&self.v2_reserves_cache),
             )
             .await;
             Some(Arc::new(state))
@@ -2317,6 +2336,13 @@ impl AetherEngine {
         &self,
     ) -> Option<&Arc<aether_simulator::bytecode_cache::BytecodeCache>> {
         self.bytecode_cache.as_ref()
+    }
+
+    /// Clone the V2 reserves cache populated by the WS `Sync` event handler.
+    /// The cache is internally `Arc`-backed so the clone is cheap; consumers
+    /// share a single underlying store with the engine writer side.
+    pub fn v2_reserves_cache(&self) -> aether_simulator::v2_reserves_cache::V2ReservesCache {
+        self.v2_reserves_cache.clone()
     }
 }
 

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -214,6 +214,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // address-keyed `eth_getCode` hits skip the RPC round-trip.
             sim_ctx_inner =
                 sim_ctx_inner.with_bytecode_cache(engine.bytecode_cache().cloned());
+            // Plumb the engine's WS-fed V2 reserves cache so the mempool
+            // prewarm path can synthesise slot 8 for warm pools instead of
+            // round-tripping `eth_getStorageAt`.
+            sim_ctx_inner =
+                sim_ctx_inner.with_v2_reserves_cache(Some(engine.v2_reserves_cache()));
             let sim_ctx = Arc::new(sim_ctx_inner);
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -185,6 +185,13 @@ pub struct SimContext {
     /// Optional persistent bytecode cache. Threaded into `prewarm_state` so
     /// addresses already on disk skip the `eth_getCode` round-trip.
     pub bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
+    /// WS-fed V2 reserves cache. Threaded into `prewarm_state` so pools
+    /// whose latest `Sync` event arrived within
+    /// `aether_simulator::fork::V2_RESERVES_MAX_LAG_BLOCKS` of the target
+    /// block synthesise slot 8 locally instead of round-tripping
+    /// `eth_getStorageAt`. `None` retains the pre-existing RPC-every-time
+    /// behaviour.
+    pub v2_reserves_cache: Option<aether_simulator::v2_reserves_cache::V2ReservesCache>,
 }
 
 impl SimContext {
@@ -212,6 +219,7 @@ impl SimContext {
             post_state_replay_enabled: false,
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
             bytecode_cache: None,
+            v2_reserves_cache: None,
         }
     }
 
@@ -224,6 +232,17 @@ impl SimContext {
         cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
     ) -> Self {
         self.bytecode_cache = cache;
+        self
+    }
+
+    /// Attach the engine's WS-fed V2 reserves cache. When set, the mempool
+    /// pre-warm path consults the cache for slot 8 of every UniV2 / Sushi
+    /// pool before issuing `eth_getStorageAt`.
+    pub fn with_v2_reserves_cache(
+        mut self,
+        cache: Option<aether_simulator::v2_reserves_cache::V2ReservesCache>,
+    ) -> Self {
+        self.v2_reserves_cache = cache;
         self
     }
 
@@ -457,6 +476,7 @@ async fn run_prewarm_refresh(
         &code_addrs,
         &v2_addrs,
         sim_ctx.bytecode_cache.as_deref(),
+        sim_ctx.v2_reserves_cache.as_ref(),
     )
     .await;
 

--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -5,7 +5,15 @@ use futures::future::join_all;
 use revm::bytecode::Bytecode;
 
 use crate::bytecode_cache::BytecodeCache;
+use crate::v2_reserves_cache::V2ReservesCache;
 use revm::database::CacheDB;
+
+/// How many blocks of WS lag the pre-warm reads-from-cache path tolerates
+/// before falling back to RPC. `Sync` events arrive within ~50 ms of a
+/// block landing on the WS subscription; one block of slack (~12 s) is
+/// more than enough headroom under normal latency while still rejecting
+/// clearly stale snapshots after a reconnect or reorg.
+pub const V2_RESERVES_MAX_LAG_BLOCKS: u64 = 1;
 use revm::database_interface::EmptyDB;
 use revm::state::AccountInfo;
 use revm_database::{AlloyDB, BlockId, WrapDatabaseAsync};
@@ -66,12 +74,18 @@ impl PrewarmedState {
 /// cache short-circuit the `eth_getCode` call entirely; freshly fetched
 /// bytecode is persisted back so subsequent block cycles serve from the
 /// cache. Pass `None` to retain the historical RPC-every-time behaviour.
+///
+/// **`v2_reserves_cache`**: when supplied, V2 pool addresses whose latest
+/// `Sync` event landed within [`V2_RESERVES_MAX_LAG_BLOCKS`] of
+/// `block_number` synthesise the slot-8 storage value locally and skip the
+/// `eth_getStorageAt` round-trip. Stale pools fall back to RPC.
 pub async fn prewarm_state(
     provider: &DynProvider<Ethereum>,
     block_number: u64,
     code_addresses: &[Address],
     v2_pool_addresses: &[Address],
     bytecode_cache: Option<&BytecodeCache>,
+    v2_reserves_cache: Option<&V2ReservesCache>,
 ) -> PrewarmedState {
     let block_id = BlockId::from(block_number);
 
@@ -120,10 +134,29 @@ pub async fn prewarm_state(
         }
     });
 
-    // Fetch slot 8 (packed reserves: reserve0 | reserve1 | blockTimestampLast)
-    // for UniswapV2 / SushiSwap pools in parallel.
+    // Slot 8 of every UniV2 pair packs `(blockTimestampLast << 224) |
+    // (reserve1 << 112) | reserve0`. Two paths feed it:
+    //
+    // 1. WS-fed `V2ReservesCache`: synthesise the slot locally for any pool
+    //    whose latest `Sync` event landed within `V2_RESERVES_MAX_LAG_BLOCKS`
+    //    of the target block. Stale or missing entries fall through.
+    // 2. RPC `eth_getStorageAt` for the remaining addresses.
     const V2_RESERVES_SLOT: u64 = 8;
-    let storage_futs = v2_pool_addresses.iter().map(|&addr| {
+    let mut ws_storage: Vec<(Address, U256, U256)> = Vec::new();
+    let mut storage_to_fetch: Vec<Address> = Vec::with_capacity(v2_pool_addresses.len());
+    if let Some(rcache) = v2_reserves_cache {
+        for &addr in v2_pool_addresses {
+            match rcache.get_fresh(addr, block_number, V2_RESERVES_MAX_LAG_BLOCKS) {
+                Some(snap) => {
+                    ws_storage.push((addr, U256::from(V2_RESERVES_SLOT), snap.pack_slot8()));
+                }
+                None => storage_to_fetch.push(addr),
+            }
+        }
+    } else {
+        storage_to_fetch.extend_from_slice(v2_pool_addresses);
+    }
+    let storage_futs = storage_to_fetch.into_iter().map(|addr| {
         let p = provider.clone();
         async move {
             match p
@@ -148,10 +181,12 @@ pub async fn prewarm_state(
 
     let cache_hits = cached.len();
     let rpc_fetched = code_results.iter().filter(|r| r.is_some()).count();
+    let ws_reserves_hits = ws_storage.len();
     let storage_warmed = storage_results.iter().filter(|r| r.is_some()).count();
     debug!(
         cache_hits,
         rpc_fetched,
+        ws_reserves_hits,
         storage_warmed,
         "Block pre-warm complete"
     );
@@ -161,9 +196,12 @@ pub async fn prewarm_state(
     let mut code_cache = cached;
     code_cache.extend(code_results.into_iter().flatten());
 
+    let mut storage = ws_storage;
+    storage.extend(storage_results.into_iter().flatten());
+
     PrewarmedState {
         code_cache,
-        storage: storage_results.into_iter().flatten().collect(),
+        storage,
     }
 }
 
@@ -552,7 +590,8 @@ mod tests {
             .connect_http("http://127.0.0.1:1/".parse().unwrap())
             .erased();
 
-        let state = prewarm_state(&provider, 1, &[addr_a, addr_b], &[], Some(&cache)).await;
+        let state =
+            prewarm_state(&provider, 1, &[addr_a, addr_b], &[], Some(&cache), None).await;
 
         assert_eq!(
             state.code_cache.len(),
@@ -575,8 +614,76 @@ mod tests {
         let provider = ProviderBuilder::new()
             .connect_http("http://127.0.0.1:1/".parse().unwrap())
             .erased();
-        let state = prewarm_state(&provider, 1, &[], &[], None).await;
+        let state = prewarm_state(&provider, 1, &[], &[], None, None).await;
         assert!(state.code_cache.is_empty());
         assert!(state.storage.is_empty());
+    }
+
+    /// Verifies the WS-fed V2 reserves cache short-circuits the storage
+    /// fetch path. A fully populated reserves cache must let `prewarm_state`
+    /// return slot-8 entries for every V2 pool address without ever
+    /// touching the RPC endpoint (which here is unreachable).
+    #[tokio::test]
+    async fn prewarm_state_skips_rpc_on_full_v2_reserves_hit() {
+        use crate::v2_reserves_cache::V2ReservesCache;
+        use alloy::providers::ProviderBuilder;
+
+        let rcache = V2ReservesCache::new();
+        let p1 = address!("1111111111111111111111111111111111111111");
+        let p2 = address!("2222222222222222222222222222222222222222");
+        let r0_p1 = U256::from(1_000u64);
+        let r1_p1 = U256::from(2_000u64);
+        let r0_p2 = U256::from(5_000u64);
+        let r1_p2 = U256::from(6_000u64);
+        rcache.record(p1, r0_p1, r1_p1, 100);
+        rcache.record(p2, r0_p2, r1_p2, 100);
+
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+
+        // Target the same block the cache recorded — well inside the lag
+        // window — so both pools must surface via the WS cache.
+        let state = prewarm_state(&provider, 100, &[], &[p1, p2], None, Some(&rcache)).await;
+
+        assert_eq!(
+            state.storage.len(),
+            2,
+            "both pools must surface slot-8 entries via the WS cache"
+        );
+        let by_addr: std::collections::HashMap<_, _> =
+            state.storage.iter().map(|(a, _, v)| (*a, *v)).collect();
+        // Decode the packed slot-8 layout to confirm reserve0 and reserve1
+        // round-trip intact for at least one pool.
+        let packed_p1 = by_addr.get(&p1).copied().expect("p1 entry");
+        let mask112 = (U256::from(1u64) << 112) - U256::from(1u64);
+        assert_eq!(packed_p1 & mask112, r0_p1);
+        assert_eq!((packed_p1 >> 112) & mask112, r1_p1);
+    }
+
+    /// Stale reserve snapshots (older than the lag window) must NOT short-
+    /// circuit the RPC call. The cache hit is rejected and the address
+    /// falls through to the normal RPC path; with an unreachable provider
+    /// that path errors and the address is simply absent from the result.
+    #[tokio::test]
+    async fn prewarm_state_falls_through_when_v2_cache_is_stale() {
+        use crate::v2_reserves_cache::V2ReservesCache;
+        use alloy::providers::ProviderBuilder;
+
+        let rcache = V2ReservesCache::new();
+        let p1 = address!("3333333333333333333333333333333333333333");
+        rcache.record(p1, U256::from(1u64), U256::from(2u64), 10);
+
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+
+        // Target block 100, cache entry at block 10 — well outside the
+        // 1-block lag window. RPC is unreachable so the result is empty.
+        let state = prewarm_state(&provider, 100, &[], &[p1], None, Some(&rcache)).await;
+        assert!(
+            state.storage.is_empty(),
+            "stale cache entries must not surface in pre-warm output"
+        );
     }
 }

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -3,6 +3,7 @@ pub mod calldata;
 pub mod fork;
 pub mod mempool_backrun;
 pub mod post_state_replay;
+pub mod v2_reserves_cache;
 
 use alloy::primitives::{Address, U256};
 use aether_common::types::SimulationResult;

--- a/crates/simulator/src/v2_reserves_cache.rs
+++ b/crates/simulator/src/v2_reserves_cache.rs
@@ -1,0 +1,240 @@
+//! In-memory cache of the latest packed reserves slot for UniswapV2 /
+//! SushiSwap pools, fed by the WebSocket `Sync` event stream.
+//!
+//! UniV2's `getReserves()` reads a single packed slot at storage index 8:
+//!
+//! ```text
+//! slot8 = (blockTimestampLast << 224) | (reserve1 << 112) | reserve0
+//! ```
+//!
+//! The detector already subscribes to every monitored pool's `Sync` event
+//! and decodes the new reserve pair on every block. Today we throw that
+//! data away after the price-graph edge update and pay a fresh
+//! `eth_getStorageAt` round-trip per pool on every pre-warm cycle to refetch
+//! information that just arrived for free over the WS.
+//!
+//! `V2ReservesCache` captures the latest decoded reserves and exposes them
+//! as a synthesised slot-8 value for the pre-warm path. The `blockTimestampLast`
+//! field is *not* part of a Sync event, so we leave it zero — UniV2 swap
+//! math does not depend on it (only `_update()` writes the field, and that
+//! happens *after* the swap quantities are computed). Any consumer that
+//! does need a live timestamp must still fall through to RPC.
+//!
+//! All operations are O(1) lock-free via `DashMap`. The cache is cheap to
+//! clone (it's `Arc`-backed) so the engine writer side and the pre-warm
+//! reader side share a single shared instance.
+
+use std::sync::Arc;
+
+use alloy::primitives::{Address, U256};
+use dashmap::DashMap;
+
+/// Bit shift for `reserve1` inside UniV2's packed slot 8.
+const RESERVE1_SHIFT: u32 = 112;
+
+/// 112-bit mask used when packing `reserve0` / `reserve1` into slot 8.
+fn uint112_mask() -> U256 {
+    (U256::from(1u64) << 112) - U256::from(1u64)
+}
+
+/// Latest reserve pair captured for a single pool. `block_number` is the
+/// chain head at which the underlying Sync event was emitted; the pre-warm
+/// path can use it to reject stale entries during reorgs.
+#[derive(Clone, Copy, Debug)]
+pub struct ReserveSnapshot {
+    pub reserve0: U256,
+    pub reserve1: U256,
+    pub block_number: u64,
+}
+
+impl ReserveSnapshot {
+    /// Encode the snapshot as a UniV2 packed slot-8 value.
+    /// `blockTimestampLast` is forced to 0 — see module docs.
+    pub fn pack_slot8(&self) -> U256 {
+        let mask = uint112_mask();
+        let r0 = self.reserve0 & mask;
+        let r1 = self.reserve1 & mask;
+        r0 | (r1 << RESERVE1_SHIFT)
+    }
+}
+
+/// Lock-free cache of the latest per-pool reserve snapshot.
+#[derive(Clone, Default)]
+pub struct V2ReservesCache {
+    inner: Arc<DashMap<Address, ReserveSnapshot>>,
+}
+
+impl V2ReservesCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of distinct pools currently cached. Useful for diagnostics.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Record the latest reserves for `pool` at `block_number`. Newer
+    /// `block_number` always wins; older updates are dropped so a delayed
+    /// out-of-order event cannot poison the cache with stale state.
+    pub fn record(&self, pool: Address, reserve0: U256, reserve1: U256, block_number: u64) {
+        self.inner
+            .entry(pool)
+            .and_modify(|existing| {
+                if block_number >= existing.block_number {
+                    existing.reserve0 = reserve0;
+                    existing.reserve1 = reserve1;
+                    existing.block_number = block_number;
+                }
+            })
+            .or_insert(ReserveSnapshot {
+                reserve0,
+                reserve1,
+                block_number,
+            });
+    }
+
+    /// Look up the latest snapshot for `pool` if one has been captured.
+    pub fn get(&self, pool: Address) -> Option<ReserveSnapshot> {
+        self.inner.get(&pool).map(|v| *v.value())
+    }
+
+    /// Look up the latest snapshot for `pool` only if it is fresh enough for
+    /// `target_block` — i.e. emitted no earlier than `target_block.saturating_sub(max_lag)`.
+    /// Stale entries return `None` so the caller falls through to RPC.
+    pub fn get_fresh(
+        &self,
+        pool: Address,
+        target_block: u64,
+        max_lag: u64,
+    ) -> Option<ReserveSnapshot> {
+        let snap = self.get(pool)?;
+        let oldest_acceptable = target_block.saturating_sub(max_lag);
+        if snap.block_number >= oldest_acceptable {
+            Some(snap)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn record_then_get_roundtrip() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        cache.record(pool, U256::from(100u64), U256::from(200u64), 42);
+        let s = cache.get(pool).expect("hit");
+        assert_eq!(s.reserve0, U256::from(100u64));
+        assert_eq!(s.reserve1, U256::from(200u64));
+        assert_eq!(s.block_number, 42);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn get_returns_none_when_unseen() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        assert!(cache.get(pool).is_none());
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn newer_block_overwrites_older() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("cccccccccccccccccccccccccccccccccccccccc");
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 100);
+        cache.record(pool, U256::from(3u64), U256::from(4u64), 101);
+        let s = cache.get(pool).unwrap();
+        assert_eq!(s.reserve0, U256::from(3u64));
+        assert_eq!(s.reserve1, U256::from(4u64));
+        assert_eq!(s.block_number, 101);
+    }
+
+    #[test]
+    fn out_of_order_older_event_is_dropped() {
+        // Sync events occasionally arrive out of order during a reorg or a
+        // mid-stream WS reconnect. An older `block_number` must not replace
+        // the freshest snapshot or the cache would poison the pre-warm path
+        // with stale state.
+        let cache = V2ReservesCache::new();
+        let pool = address!("dddddddddddddddddddddddddddddddddddddddd");
+        cache.record(pool, U256::from(3u64), U256::from(4u64), 101);
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 100); // older
+        let s = cache.get(pool).unwrap();
+        assert_eq!(s.reserve0, U256::from(3u64));
+        assert_eq!(s.block_number, 101);
+    }
+
+    #[test]
+    fn pack_slot8_layout_matches_uniswap_v2() {
+        // The synthesised slot8 layout must place reserve0 in bits 0..111,
+        // reserve1 in bits 112..223, and leave the high 32 bits (where
+        // `blockTimestampLast` would live) untouched. Use small, distinct
+        // values that fit comfortably inside 112 bits.
+        let snap = ReserveSnapshot {
+            reserve0: U256::from(0xAABBCCu64),
+            reserve1: U256::from(0xDDEEFFu64),
+            block_number: 1,
+        };
+        let packed = snap.pack_slot8();
+        let mask112 = uint112_mask();
+        let r0_back = packed & mask112;
+        let r1_back = (packed >> RESERVE1_SHIFT) & mask112;
+        assert_eq!(r0_back, U256::from(0xAABBCCu64));
+        assert_eq!(r1_back, U256::from(0xDDEEFFu64));
+        // High 32 bits = blockTimestampLast region must be zero.
+        let ts_region = packed >> 224;
+        assert_eq!(ts_region, U256::ZERO, "timestamp region must stay zero");
+    }
+
+    #[test]
+    fn pack_slot8_truncates_to_uint112() {
+        // Real on-chain values are already uint112, but defensively the
+        // packer must mask anything wider so a malformed input never
+        // contaminates the reserve1 / timestamp bands.
+        let mask112 = uint112_mask();
+        let oversized = (U256::from(1u64) << 130) | U256::from(7u64);
+        let snap = ReserveSnapshot {
+            reserve0: oversized,
+            reserve1: oversized,
+            block_number: 1,
+        };
+        let packed = snap.pack_slot8();
+        let r0_back = packed & mask112;
+        let r1_back = (packed >> RESERVE1_SHIFT) & mask112;
+        // The bit-130 value is dropped because it falls outside the 112-bit
+        // window; only the low 7 survives.
+        assert_eq!(r0_back, U256::from(7u64));
+        assert_eq!(r1_back, U256::from(7u64));
+        // No overflow into the timestamp band.
+        let ts_region = packed >> 224;
+        assert_eq!(ts_region, U256::ZERO);
+    }
+
+    #[test]
+    fn get_fresh_accepts_within_lag_window() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 100);
+        // Target block 102, lag 3 -> oldest acceptable = 99; cached at 100 -> hit.
+        assert!(cache.get_fresh(pool, 102, 3).is_some());
+    }
+
+    #[test]
+    fn get_fresh_rejects_stale_snapshot() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("ffffffffffffffffffffffffffffffffffffffff");
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 50);
+        // Target block 100, lag 3 -> oldest acceptable = 97; cached at 50 -> miss.
+        assert!(cache.get_fresh(pool, 100, 3).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- **Stacks on #175.** Extends the `prewarm_state` signature again with `Option<&V2ReservesCache>` and threads it through the engine + mempool pipeline.
- **Problem.** Engine already subscribes to every monitored pool's `Sync` event and decodes the reserve pair on every block. Today the decoded values feed the price-graph edge and are then discarded; every pre-warm cycle issues a fresh `eth_getStorageAt` against slot 8 of the same pool to refetch numbers that just arrived for free over the WebSocket.
- **Fix.** Introduce `V2ReservesCache`: a lock-free `DashMap` of latest `(reserve0, reserve1, block_number)` per pool, fed by `handle_pool_update` whenever a UniV2 / Sushi `ReserveUpdate` lands. `prewarm_state` partitions V2 addresses into hits (synthesise packed slot-8 locally) and misses (RPC). Stale entries older than `V2_RESERVES_MAX_LAG_BLOCKS` (1 block) fall back to RPC.
- **Slot 8 layout.** `reserve0 | (reserve1 << 112)`. `blockTimestampLast` is deliberately left at zero — Sync events don't carry it and UniV2 swap math doesn't consult it during quote derivation (only `_update()` writes the field after the swap completes).
- **Latency rule check.** WS-fed (~10-50 ms in memory) beats `eth_getStorageAt` (50-200 ms). Aligns with `IPC > WS > HTTP`.
- **G3** sub-task of the Path B RPC-reduction workstream: G1 (#173) → G2-module (#174) → G2-wire (#175) → **G3 (this)** → G4.

## Files Changed

| File | Change |
|---|---|
| `crates/simulator/src/v2_reserves_cache.rs` | New module — `V2ReservesCache` + `ReserveSnapshot` + slot-8 packing + 8 unit tests |
| `crates/simulator/src/lib.rs` | Re-export the module |
| `crates/simulator/src/fork.rs` | Extend `prewarm_state` with `Option<&V2ReservesCache>` param; partition v2 addresses into WS hits vs. RPC; 2 new unit tests |
| `crates/grpc-server/src/engine.rs` | Add `v2_reserves_cache` field; write on `handle_pool_update` for V2/Sushi; getter; pass to `prewarm_state` call site |
| `crates/grpc-server/src/mempool_pipeline.rs` | Add `v2_reserves_cache` field on `SimContext` + `with_v2_reserves_cache` builder; pass to `spawn_mempool_prewarm_refresher` |
| `crates/grpc-server/src/main.rs` | Plumb `engine.v2_reserves_cache()` into the mempool `SimContext` |

## Acceptance Criteria

- [x] `V2ReservesCache::record` updates the latest snapshot per pool; older block numbers cannot overwrite newer ones (reorg / WS reconnect safety)
- [x] `get_fresh(addr, block, max_lag)` rejects stale snapshots so the caller falls through to RPC
- [x] Slot-8 layout matches UniV2: `reserve0` in bits 0-111, `reserve1` in bits 112-223, timestamp band zero
- [x] Oversized inputs are masked to uint112 — no overflow into the reserve1 / timestamp bands
- [x] `prewarm_state` partitions V2 pools into WS cache hits vs RPC misses
- [x] Fully populated cache + unreachable RPC = all hits surface (no RPC issued)
- [x] Stale entries + unreachable RPC = empty result (cache did NOT short-circuit the missing entries)
- [x] Engine's `handle_pool_update` writes to the cache on V2/Sushi `ReserveUpdate` only
- [x] V3 / Curve / Balancer protocols are untouched — they retain the existing RPC path
- [x] `cargo test -p aether-simulator --lib v2_reserves_cache` → 8/8 pass
- [x] `cargo test -p aether-simulator --lib fork::` → 15/15 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (one unrelated pre-existing bancor-overflow failure addressed by #172)

## Test plan

- [x] `record_then_get_roundtrip`, `newer_block_overwrites_older`, `out_of_order_older_event_is_dropped`
- [x] `pack_slot8_layout_matches_uniswap_v2`, `pack_slot8_truncates_to_uint112`
- [x] `get_fresh_accepts_within_lag_window`, `get_fresh_rejects_stale_snapshot`
- [x] `prewarm_state_skips_rpc_on_full_v2_reserves_hit`
- [x] `prewarm_state_falls_through_when_v2_cache_is_stale`
- [ ] Shadow demo run — expect `eth_getStorageAt` rate against V2 pools to drop to near-zero after the first Sync events arrive

## Stacking note

Base is `feat/bytecode-cache-wire` (#175). Auto-rebases onto develop once #175 lands.