### PR TITLE
docs(readme): refresh for mempool backrun, decoder coverage, cache tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Production-grade, cross-DEX arbitrage engine for Ethereum Mainnet.**
 
-Sub-millisecond opportunity detection across Uniswap V2/V3, SushiSwap, Curve, Balancer, Bancor, and 1inch — with Flashbots-native bundle execution, on-chain simulation via `revm`, and extensible pool registry.
+Sub-millisecond opportunity detection across Uniswap V2/V3, SushiSwap, Curve, Balancer, Bancor, 1inch v6, and the Uniswap Universal Router — with Flashbots-native bundle execution, on-chain simulation via `revm`, mempool-backrun support, and an extensible pool registry.
 
 ---
 
@@ -13,28 +13,46 @@ Sub-millisecond opportunity detection across Uniswap V2/V3, SushiSwap, Curve, Ba
 | Data Ingestion & ABI Parsing | **Rust** | `tokio`, `alloy`, WebSocket |
 | Pool State Management | **Rust** | `DashMap`, arena allocators |
 | Arbitrage Detection | **Rust** | Bellman-Ford (SPFA), SIMD math |
-| EVM Simulation | **Rust** | `revm` (fork mode) |
+| EVM Simulation | **Rust** | `revm` (fork mode), `AlloyDB` |
+| Mempool Tracking | **Rust** | Alchemy `alchemy_pendingTransactions`, calldata decoders |
+| Caches | **Rust** | `redb` (bytecode disk cache), `DashMap` (WS-fed V2 reserves) |
 | Bundle Construction & Submission | **Go** | `go-ethereum`, `flashbotsrpc` |
 | Risk Management & Circuit Breakers | **Go** | Stateful controllers, `sync/atomic` |
 | Monitoring & API | **Go** | Prometheus, gRPC, `net/http` |
-| On-Chain Executor | **Solidity** | Aave V3 Flash Loans, OpenZeppelin |
+| On-Chain Executor | **Solidity** | Aave V3 Flash Loans, OpenZeppelin `Ownable2Step` |
 | Inter-Service Communication | Both | gRPC + Protobuf over Unix Domain Sockets |
-| Infrastructure | — | Prometheus, Grafana, Loki |
+| Persistence | — | PostgreSQL (trade ledger + mempool predictions) |
+| Observability | — | Prometheus, Grafana, Loki, OpenTelemetry (OTLP → Tempo) |
+| Alerting | — | Slack |
 
 ---
 
 ## Architecture
 
-The system is organized into **7 distinct layers** with clear ownership boundaries:
+The system is organized into distinct layers with clear ownership boundaries. Two execution paths share the same downstream: the block-driven detector and the mempool-backrun pipeline.
 
 ```mermaid
 graph TB
     ETH["Eth Nodes (WS/IPC)"]
+    ALCH["Alchemy WS<br/>pendingTransactions"]
 
     subgraph RUST["Rust Core — Latency-Critical"]
         direction LR
         IG["Ingestion"] --> PR["Pool Registry"] --> SM["State + Price Graph"]
         SM --> DT["Detector<br/>Bellman-Ford"] --> SIM["Simulator<br/>revm"]
+
+        MP["Mempool<br/>Decoder"] --> PP["Post-State<br/>Predictor"] --> MV["Backrun<br/>Validator"]
+
+        subgraph CACHE["Cache Tier"]
+            BC["Bytecode<br/>(redb on disk)"]
+            VR["V2 Reserves<br/>(WS-fed)"]
+            PS["Pool States<br/>(V3/Curve/Balancer/Bancor)"]
+        end
+
+        BC -.->|prewarm hit| SIM
+        VR -.->|prewarm hit| SIM
+        PS -.->|analytical| PP
+        MV -.->|revm fork| SIM
     end
 
     subgraph GO["Go Execution Layer — Coordination"]
@@ -42,6 +60,7 @@ graph TB
         EX["Bundle Builder"] --> SUB["Multi-Builder Submitter"]
         RM["Risk Manager"] -.->|preflight| EX
         MN["Monitor"] -.->|metrics| RM
+        REC["Reconciler"] -.->|predicted vs realized| MN
     end
 
     BUILDERS["Flashbots · Titan · Beaver · rsync"]
@@ -52,14 +71,21 @@ graph TB
         AE --> DEXES["DEX Pools"]
     end
 
+    LEDGER[("PostgreSQL<br/>Ledger")]
+
     ETH --> IG
+    ALCH --> MP
     SIM -->|gRPC / UDS <1μs| EX
+    MV -->|gRPC / UDS <1μs| EX
     SUB -->|eth_sendBundle| BUILDERS
     BUILDERS --> AE
+    EX -.->|persist| LEDGER
+    MV -.->|persist| LEDGER
 
     style RUST fill:#1a1520,stroke:#9580ff,stroke-width:2px,color:#fff
     style GO fill:#151a20,stroke:#5ce6c7,stroke-width:2px,color:#fff
     style CHAIN fill:#1a1815,stroke:#f5a623,stroke-width:2px,color:#fff
+    style CACHE fill:#0f1a18,stroke:#5ce6c7,stroke-width:1px,color:#fff
 ```
 
 ### Hot Path (target <15ms end-to-end)
@@ -71,12 +97,12 @@ sequenceDiagram
     participant Go as Go Executor
     participant B as Block Builders
 
-    Node->>Rust: WS log (Swap/Sync)
+    Node->>Rust: WS log (Swap/Sync) or pending tx
     Note over Rust: decode + state update<br/><1ms
     Note over Rust: Bellman-Ford SPFA<br/><3ms
-    Note over Rust: revm fork + execute<br/><5ms
+    Note over Rust: revm fork + execute<br/><5ms<br/>(cache-warm prewarm)
     Rust->>Go: ValidatedArb (gRPC/UDS <1μs)
-    Note over Go: build + sign bundle<br/><2ms
+    Note over Go: risk gates + build + sign<br/><2ms
     par fan-out
         Go->>B: eth_sendBundle (Flashbots)
     and
@@ -92,50 +118,70 @@ sequenceDiagram
 
 ```
 aether/
-├── Cargo.toml                    # Rust workspace root
-├── go.mod                        # Go module root
+├── Cargo.toml                       # Rust workspace root
+├── go.mod                           # Go module root
 ├── proto/
-│   └── aether.proto              # Shared Protobuf schema (gRPC contract)
+│   └── aether.proto                 # Shared Protobuf schema (gRPC contract)
 │
-├── crates/                       # ── Rust Crates ──
-│   ├── ingestion/                # Data ingestion & node pool
-│   ├── pools/                    # DEX pool implementations (6 protocols)
-│   ├── state/                    # State management & price graph
-│   ├── detector/                 # Arbitrage detection engine (Bellman-Ford)
-│   ├── simulator/                # EVM simulation (revm)
-│   ├── grpc-server/              # tonic gRPC server (Rust binary entry point)
-│   └── common/                   # Shared types, utils, errors
+├── crates/                          # ── Rust Crates ──
+│   ├── ingestion/                   # WS event + Alchemy mempool subscription
+│   ├── pools/                       # DEX pool implementations + router decoders
+│   ├── state/                       # Price graph, MVCC snapshots
+│   ├── detector/                    # Bellman-Ford (SPFA) cycle detection
+│   ├── simulator/                   # revm fork sim + caches + mempool backrun validator
+│   ├── grpc-server/                 # tonic gRPC server (Rust binary entry point)
+│   ├── common/                      # Shared types, utils, errors, ledger schema
+│   └── integration-tests/           # Mainnet-fork + multi-block end-to-end tests
 │
-├── cmd/                          # ── Go Services ──
-│   ├── executor/                 # Bundle construction & multi-builder submission
-│   ├── risk/                     # Risk management & circuit breakers
-│   └── monitor/                  # Prometheus metrics, dashboard, alerting
+├── cmd/                             # ── Go Services ──
+│   ├── executor/                    # Bundle construction & multi-builder submission
+│   ├── risk/                        # Risk management & circuit breakers
+│   ├── monitor/                     # Prometheus metrics, dashboard, Slack alerter
+│   ├── pooldiscovery/               # Pool discovery + qualification tool
+│   └── reconciler/                  # Mempool prediction outcome reconciler
 │
-├── contracts/                    # ── Solidity ──
-│   ├── src/AetherExecutor.sol    # Flashloan receiver + multi-DEX swap router
-│   ├── test/AetherExecutor.t.sol
+├── contracts/                       # ── Solidity ──
+│   ├── src/AetherExecutor.sol       # Flashloan receiver + multi-DEX swap router
+│   ├── test/                        # AetherExecutor + Deploy + fork tests (Foundry)
 │   └── foundry.toml
 │
-├── config/                       # Runtime configuration
-│   ├── pools.toml                # Pool registry (hot-reloadable)
-│   ├── risk.yaml                 # Risk parameters & circuit breaker thresholds
-│   ├── nodes.yaml                # Ethereum node provider endpoints
-│   └── builders.yaml             # Block builder API endpoints
+├── config/                          # Runtime configuration
+│   ├── pools.toml                   # Pool registry (hot-reloadable)
+│   ├── pools_staging.toml           # Reduced registry for staging
+│   ├── pools_historical_replay.toml # Snapshot used by replay tooling
+│   ├── risk.yaml                    # Risk parameters & circuit breaker thresholds
+│   ├── nodes.yaml                   # Ethereum node provider endpoints
+│   ├── builders.yaml                # Block builder API endpoints
+│   └── executor.yaml                # Bundle build + tip parameters
 │
 ├── deploy/
-│   ├── systemd/                  # aether-rust.service, aether-go.service
-│   ├── ansible/                  # Server provisioning playbooks
-│   └── docker/                   # Docker Compose, Dockerfiles, Prometheus config
+│   ├── systemd/                     # aether-rust.service, aether-go.service
+│   ├── ansible/                     # Server provisioning playbooks
+│   └── docker/                      # Docker Compose, Dockerfiles, Prometheus config
 │
-├── scripts/
-│   ├── backtest.py               # Historical opportunity analysis
-│   ├── gas_profiler.py           # Gas usage profiling
-│   └── deploy.sh                 # Build, test, deploy automation
+├── scripts/                         # ── Tooling ──
+│   ├── deploy.sh                    # Build, test, deploy automation
+│   ├── canary.py                    # Pre-prod canary check
+│   ├── staging_test.sh              # Staging end-to-end smoke
+│   ├── db_migrate.sh                # Postgres schema migrations
+│   ├── historical_replay_e2e.sh     # Replay a past block against current pipeline
+│   ├── mempool_capture.sh           # Capture raw pending-tx stream
+│   ├── mempool_smoke.sh             # Mempool path smoke test
+│   ├── mempool_backrun_shadow.sh    # Shadow-mode mempool backrun orchestrator
+│   ├── replay_with_monitoring.sh    # Replay + Prom/Grafana sidecar
+│   ├── test_integration.sh          # Run integration-tests crate
+│   ├── backtest.py                  # Historical opportunity analysis
+│   └── gas_profiler.py              # Gas usage profiling
 │
 └── docs/
-    ├── architecture.md           # Detailed architecture documentation
-    ├── runbook.md                # Operational procedures
-    └── incident-response.md      # Incident response playbook
+    ├── architecture.md              # Detailed architecture documentation
+    ├── runbook.md                   # Operational procedures
+    ├── incident-response.md         # SEV1–SEV4 incident playbooks
+    ├── demo/                        # Shadow-demo run reports + next-steps doc
+    ├── research/                    # Tx ordering, builder matrix, strategy analysis
+    ├── runbook/                     # Mempool rollout + observability runbooks
+    ├── issues/                      # Staged issue bodies for upcoming workstreams
+    └── perf/                        # Performance tuning notes
 ```
 
 ---
@@ -146,7 +192,8 @@ aether/
 - **Go** 1.26.1
 - **Foundry** ([forge, cast, anvil](https://getfoundry.sh/))
 - **Protobuf compiler** (`protoc`)
-- **Docker & Docker Compose** (for local infrastructure)
+- **Docker & Docker Compose** (local infrastructure)
+- **PostgreSQL** 15+ (trade ledger; optional in dev)
 
 ---
 
@@ -196,7 +243,10 @@ go test ./...
 # Solidity tests
 cd contracts && forge test
 
-# All tests
+# Integration tests (Rust crate, hits mainnet fork)
+./scripts/test_integration.sh
+
+# All-in-one
 ./scripts/deploy.sh test
 ```
 
@@ -204,14 +254,38 @@ cd contracts && forge test
 
 ## Configuration
 
-All configuration lives in the `config/` directory:
+All configuration lives in `config/`:
 
 | File | Purpose | Hot-Reload |
 |---|---|---|
 | `config/pools.toml` | Pool registry — monitored DEX pools | Yes (via `ControlService.ReloadConfig()`) |
-| `config/risk.yaml` | Risk parameters & circuit breaker thresholds | No (requires Go restart) |
-| `config/nodes.yaml` | Ethereum node provider endpoints (WS/IPC) | No |
+| `config/risk.yaml` | Risk parameters & circuit breaker thresholds | No (Go restart) |
+| `config/nodes.yaml` | Ethereum node provider endpoints (WS/IPC/HTTP) | No |
 | `config/builders.yaml` | Block builder API endpoints & auth | No |
+| `config/executor.yaml` | Bundle build + tip share parameters | No |
+
+### Key environment variables
+
+| Variable | Purpose |
+|---|---|
+| `ETH_RPC_URL` | Primary RPC endpoint (WS preferred; HTTP auto-derived for fork sim) |
+| `AETHER_POOLS_CONFIG` | Override path to `config/pools.toml` |
+| `AETHER_NODES_CONFIG` | Optional multi-node pool config |
+| `DATABASE_URL` | Trade ledger DSN (omit → `NoopLedger`) |
+| `MEMPOOL_TRACKING=1` | Enable Alchemy mempool subscription + decode pipeline |
+| `MEMPOOL_WS_URL` | Override mempool WS endpoint (defaults to `ETH_RPC_URL`) |
+| `MEMPOOL_LEDGER_DSN` | Separate DSN for `mempool_predictions` table |
+| `MEMPOOL_POST_STATE_REPLAY=1` | Enable revm fork-replay fallback for V3 tick-crossing swaps |
+| `MEMPOOL_BACKRUN_SHADOW=1` | Run backrun validator without submitting bundles |
+| `AETHER_EXECUTOR_ADDRESS` | Address used by the backrun validator |
+| `AETHER_EXECUTOR_BYTECODE_PATH` | Inject `AetherExecutor` bytecode into revm fork |
+| `AETHER_BYTECODE_CACHE_PATH` | Enable persistent `redb` bytecode cache |
+| `AETHER_PREWARM_MAX_CONCURRENT` | Cap on in-flight prewarm RPCs (default 8) |
+| `AETHER_GIT_SHA` | Stamped onto every persisted mempool prediction |
+| `LOG_FORMAT=json` | JSON log formatter |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Send OTel spans to Tempo |
+
+See [`docs/runbook.md`](docs/runbook.md) for the full table.
 
 ---
 
@@ -219,19 +293,17 @@ All configuration lives in the `config/` directory:
 
 ### Local Development (Docker Compose)
 
-Start the full stack locally with infrastructure services:
-
 ```bash
 ./scripts/deploy.sh docker up
 ```
 
-This starts: `aether-rust`, `aether-go`, Prometheus.
+Starts: `aether-rust`, `aether-go`, Prometheus, Grafana, Loki.
 
 ### Manual Start
 
 ```bash
 # 1. Start infrastructure
-docker compose -f deploy/docker/docker-compose.yml up -d prometheus
+docker compose -f deploy/docker/docker-compose.yml up -d prometheus grafana loki
 
 # 2. Start Rust core (gRPC server)
 cargo run --release --bin aether-grpc-server
@@ -243,20 +315,46 @@ go run ./cmd/executor
 ### Production Deployment
 
 ```bash
-# Deploy to staging
 ./scripts/deploy.sh deploy staging
-
-# Deploy to production
 ./scripts/deploy.sh deploy production
-
-# Check status
 ./scripts/deploy.sh status production
-
-# Rollback if needed
 ./scripts/deploy.sh rollback production
 ```
 
 See [`docs/runbook.md`](docs/runbook.md) for detailed operational procedures.
+
+---
+
+## Mempool Backrun
+
+Aether supports two execution paths sharing the same `AetherExecutor` contract and `ValidatedArb` channel:
+
+1. **Block-driven** — every `newHeads` event triggers Bellman-Ford on the price graph, simulates winners in revm, and ships bundles.
+2. **Mempool backrun** — pending swaps on Uniswap V2/V3/Universal Router, SushiSwap, Curve, Balancer, Bancor and 1inch v6 are decoded from Alchemy's `alchemy_pendingTransactions` stream; the post-state predictor computes the pool state the victim's swap would create; the detector scans for a backrun cycle; the revm validator forks at the latest block and re-simulates with the victim transaction prepended.
+
+The mempool path is opt-in (`MEMPOOL_TRACKING=1`) and rolls out in three stages:
+
+| Stage | Toggle | Behaviour |
+|---|---|---|
+| **Shadow** | `MEMPOOL_BACKRUN_SHADOW=1` | Validate, persist predictions, **never** submit |
+| **Canary** | shadow off, low-cap risk gates | Submit a small fraction of candidates |
+| **Live** | full risk gates | Submit on every validated backrun |
+
+See [`docs/runbook/mempool-backrun-rollout.md`](docs/runbook/mempool-backrun-rollout.md) and [`docs/runbook/mempool-observability.md`](docs/runbook/mempool-observability.md).
+
+---
+
+## Cache Layers (RPC Reduction)
+
+Three caches eliminate the bulk of per-simulation RPC traffic, making the free-tier RPC budget viable:
+
+| Cache | Source | What it kills |
+|---|---|---|
+| **Pre-warm throttle** | `tokio::Semaphore` | Burst-induced 429s by bounding in-flight pre-warm RPCs (default 8) |
+| **Bytecode disk cache** | `redb` on disk | Repeat `eth_getCode` for immutable contract bytecode (≈95% of pre-warm RPC volume after warmup) |
+| **V2 reserves WS cache** | `Sync` event stream | Repeat `eth_getStorageAt` on slot 8 for warm V2/Sushi pools |
+
+All caches degrade gracefully — a miss or open failure transparently falls back to the existing RPC path. See `docs/architecture.md` for the layout.
 
 ---
 
@@ -266,12 +364,12 @@ See [`docs/runbook.md`](docs/runbook.md) for detailed operational procedures.
 |---|---|
 | Event decode + state update | <1ms |
 | Bellman-Ford detection | <3ms |
-| EVM simulation (revm) | <5ms |
+| EVM simulation (revm, cache-warm) | <5ms |
 | gRPC Rust → Go | <1ms |
 | Bundle build + sign | <2ms |
 | **Total end-to-end** | **<15ms** |
 | Events processed per block | 10,000+ |
-| Pools monitored | 5,000+ |
+| Pools monitored | 5,000+ (current registry: see `config/pools.toml`) |
 | Simulations per second | 200+ |
 | Rust core memory | <2 GB RSS |
 | Go executor memory | <512 MB RSS |
@@ -290,6 +388,7 @@ The system enforces automatic circuit breakers:
 | ETH balance <0.1 ETH | **HALT** |
 | Node latency >500ms | **DEGRADE** |
 | Bundle miss rate >80% in 1h | **ALERT** |
+| Decode error rate sustained >10/min | **ALERT** (ABI drift / malformed flood) |
 
 System state machine:
 
@@ -311,13 +410,18 @@ stateDiagram-v2
 
 Prometheus metrics are exposed on port 9090 (`/metrics`). Key metrics:
 
-- `aether_opportunities_detected_total` — Arbitrage opportunities found
-- `aether_bundles_included_total` — Bundles included on-chain
+- `aether_opportunities_detected_total` — Arbitrage opportunities found (block-driven)
+- `aether_mempool_pending_arb_candidates_total` — Mempool candidates produced by decode + predictor
+- `aether_bundles_included_total` — Bundles included on-chain (labelled by source)
 - `aether_detection_latency_ms` — Detection pipeline latency
 - `aether_end_to_end_latency_ms` — Full pipeline latency
+- `aether_mempool_first_seen_latency_ms` — Time between pending-tx arrival and our decode
 - `aether_gas_price_gwei` — Current gas price
 - `aether_daily_pnl_eth` — Daily profit & loss
 - `aether_eth_balance` — Searcher wallet balance
+- `aether_decode_errors_total` — Calldata decode failures (ABI drift / malformed)
+
+Alerts are dispatched via **Slack** only (see `cmd/monitor/alerter.go`).
 
 See [`docs/architecture.md`](docs/architecture.md) for the full metrics table.
 
@@ -331,7 +435,8 @@ See [`docs/architecture.md`](docs/architecture.md) for the full metrics table.
 4. Add swap routing in `contracts/src/AetherExecutor.sol` `_executeSwap()`
 5. Add gas estimate in `crates/detector/src/gas.rs`
 6. Add pool config entry in `config/pools.toml`
-7. No changes needed to detection or execution logic
+7. (Optional) add a calldata decoder in `crates/pools/src/router_decoder.rs` for mempool tracking
+8. No changes needed to detection or execution logic
 
 ---
 
@@ -339,7 +444,13 @@ See [`docs/architecture.md`](docs/architecture.md) for the full metrics table.
 
 - [`docs/architecture.md`](docs/architecture.md) — System architecture deep dive
 - [`docs/runbook.md`](docs/runbook.md) — Operational procedures and service management
-- [`docs/incident-response.md`](docs/incident-response.md) — Incident response playbook (SEV1-SEV4)
+- [`docs/incident-response.md`](docs/incident-response.md) — SEV1–SEV4 incident playbooks
+- [`docs/runbook/mempool-backrun-rollout.md`](docs/runbook/mempool-backrun-rollout.md) — Shadow → canary → live rollout
+- [`docs/runbook/mempool-observability.md`](docs/runbook/mempool-observability.md) — Ledger queries + Grafana panels for mempool path
+- [`docs/research/builder-matrix.md`](docs/research/builder-matrix.md) — Builder integration matrix
+- [`docs/research/tx-ordering-strategy.md`](docs/research/tx-ordering-strategy.md) — Backrun ordering analysis
+- [`docs/research/strategy-class-analysis.md`](docs/research/strategy-class-analysis.md) — Strategy class taxonomy
+- [`docs/demo/`](docs/demo/) — Shadow-demo run reports + next-steps planning
 
 ---
 
@@ -349,6 +460,8 @@ See [`docs/architecture.md`](docs/architecture.md) for the full metrics table.
 - Searcher EOA (hot wallet) holds minimal ETH (~0.5 ETH for gas)
 - Profits swept to cold wallet every 100 blocks
 - Private keys loaded from HSM/KMS at startup, never stored on disk
+- `AetherExecutor` uses OpenZeppelin `Ownable2Step` — owner rotation requires explicit acceptance from the incoming key
+- `setPaused(true)` halts `executeArb` without touching ownership (use for SEV2/SEV3 with safe owner key)
 - All outbound connections pinned to known IP ranges
 - Network hardened: iptables, WireGuard VPN, mTLS for gRPC
 


### PR DESCRIPTION
## Summary

- README had drifted ~6 weeks behind develop (last touched in the April mermaid-diagrams commit). Sweep covers every workstream that landed (or is in flight) since.
- DEX list extended to 1inch v6 and the Uniswap Universal Router.
- Repository structure gains `crates/integration-tests`, `cmd/pooldiscovery`, `cmd/reconciler`, `config/executor.yaml`, staging / replay pool configs, and the new scripts (`canary.py`, `mempool_*`, `historical_replay_e2e.sh`, `staging_test.sh`, `db_migrate.sh`, `test_integration.sh`).
- Architecture mermaid adds the mempool decoder + post-state predictor + revm backrun validator, the cache tier (bytecode disk cache, V2 reserves WS cache, per-protocol pool-state cache), and the Postgres ledger / reconciler.
- New **Mempool Backrun** section documents the shadow / canary / live rollout and links the runbook subdocs.
- New **Cache Layers** section sketches the RPC-reduction stack.
- **Environment Variables** table covers the mempool, cache, sim, ledger, and OTel knobs.
- Monitoring section drops PagerDuty / Telegram / Discord — alerts are Slack-only via `cmd/monitor/alerter.go`.
- Documentation links pick up `docs/runbook/`, `docs/research/`, `docs/demo/`.
- Security section calls out Ownable2Step ownership rotation and the `setPaused` circuit breaker.
- Pure documentation change. No code paths touched.

## Files Changed

| File | Change |
|---|---|
| `README.md` | +176 / −63 — full sweep covering mempool, caches, decoder coverage, docs links, Slack alerting, Ownable2Step |

## Acceptance Criteria

- [x] DEX list reflects 1inch v6 and Universal Router
- [x] All current crates / binaries / config files / scripts present in the repo are listed
- [x] Mermaid architecture diagram renders cleanly (verified locally)
- [x] No references to PagerDuty / Telegram / Discord — Slack only
- [x] Ownable2Step + `setPaused` documented in the Security section
- [x] `docs/runbook/`, `docs/research/`, `docs/demo/` linked from the Documentation section
- [x] Env vars table covers mempool, cache, sim, ledger, OTel
- [x] No PR or issue references embedded in the prose
- [x] No AI / Claude / Anthropic mentions

## Test plan

- [x] Markdown renders cleanly in GitHub preview
- [x] All relative links point at files that exist on `develop`
- [x] All repository-structure paths exist (`ls` cross-check)
- [ ] Follow-up PRs in this sweep will update `docs/architecture.md`, `docs/runbook.md`, and `docs/incident-response.md` to match

## Sequencing note

The `AETHER_BYTECODE_CACHE_PATH` and `AETHER_PREWARM_MAX_CONCURRENT` env vars and the Cache Layers section describe the in-flight RPC-reduction PRs (#173–#176). Suggested merge order: land the cache PRs first, then this docs PR — by the time it merges every env var it documents is functional.