### PR TITLE
perf(sim): recover bytecode cache + V2 reserves cache wiring

### DIFF
--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -199,6 +199,12 @@ pub struct AetherEngine {
     /// When `Some`, `run_detection_cycle` uses `RpcForkedState` instead of
     /// the empty `ForkedState`.
     rpc_provider: Option<DynProvider<Ethereum>>,
+    /// Optional persistent bytecode cache. When opened (via the
+    /// `AETHER_BYTECODE_CACHE_PATH` env var) `prewarm_state` consults it
+    /// before issuing `eth_getCode` and writes back any freshly fetched
+    /// bytecode so subsequent block cycles serve cache hits. `None`
+    /// preserves the historical RPC-every-time behaviour.
+    bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
     /// Prometheus metrics for engine operations.
     metrics: Arc<EngineMetrics>,
     /// Persistent trade ledger. NoopLedger by default; PgLedger when
@@ -424,6 +430,25 @@ impl AetherEngine {
             Some(provider.erased())
         });
 
+        // Open the persistent bytecode cache when configured. Failure to open
+        // never blocks engine startup — every cache operation degrades to
+        // `None` and falls through to the existing RPC path.
+        let bytecode_cache = std::env::var("AETHER_BYTECODE_CACHE_PATH")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .and_then(|path| {
+                match aether_simulator::bytecode_cache::BytecodeCache::open(&path) {
+                    Ok(c) => {
+                        info!(path = %path, "bytecode cache opened");
+                        Some(Arc::new(c))
+                    }
+                    Err(e) => {
+                        warn!(path = %path, error = %e, "bytecode cache open failed; running without cache");
+                        None
+                    }
+                }
+            });
+
         // Start with a reasonable initial graph size (can grow dynamically).
         let initial_graph = PriceGraph::new(100);
         let snapshot_manager = Arc::new(SnapshotManager::new(initial_graph.clone()));
@@ -442,6 +467,7 @@ impl AetherEngine {
             pool_registry: Arc::new(ArcSwap::from_pointee(HashMap::new())),
             pool_states: new_pool_state_cache(),
             rpc_provider,
+            bytecode_cache,
             metrics,
             ledger,
         }
@@ -1997,8 +2023,14 @@ impl AetherEngine {
             v2_addrs.sort_unstable();
             v2_addrs.dedup();
 
-            let state =
-                prewarm_state(provider, block_info.number, &code_addrs, &v2_addrs).await;
+            let state = prewarm_state(
+                provider,
+                block_info.number,
+                &code_addrs,
+                &v2_addrs,
+                self.bytecode_cache.as_deref(),
+            )
+            .await;
             Some(Arc::new(state))
         } else {
             None
@@ -2276,6 +2308,15 @@ impl AetherEngine {
     /// to build `RpcForkedState` per validation attempt.
     pub fn rpc_provider(&self) -> Option<DynProvider<Ethereum>> {
         self.rpc_provider.clone()
+    }
+
+    /// Borrow the persistent bytecode cache handle. `None` when the cache is
+    /// disabled (no `AETHER_BYTECODE_CACHE_PATH`). Cheap to `Arc::clone` for
+    /// downstream consumers (mempool `SimContext`).
+    pub fn bytecode_cache(
+        &self,
+    ) -> Option<&Arc<aether_simulator::bytecode_cache::BytecodeCache>> {
+        self.bytecode_cache.as_ref()
     }
 }
 

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -205,6 +205,12 @@ pub struct AetherEngine {
     /// bytecode so subsequent block cycles serve cache hits. `None`
     /// preserves the historical RPC-every-time behaviour.
     bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
+    /// In-memory cache of UniswapV2 / SushiSwap pool reserves populated by
+    /// the WS `Sync` event handler. `prewarm_state` consults it before
+    /// issuing `eth_getStorageAt` for slot 8 of each pool. Always present
+    /// (lock-free `DashMap`-backed) but only effective once Sync events
+    /// have populated entries for the monitored pools.
+    v2_reserves_cache: aether_simulator::v2_reserves_cache::V2ReservesCache,
     /// Prometheus metrics for engine operations.
     metrics: Arc<EngineMetrics>,
     /// Persistent trade ledger. NoopLedger by default; PgLedger when
@@ -468,6 +474,7 @@ impl AetherEngine {
             pool_states: new_pool_state_cache(),
             rpc_provider,
             bytecode_cache,
+            v2_reserves_cache: aether_simulator::v2_reserves_cache::V2ReservesCache::new(),
             metrics,
             ledger,
         }
@@ -1449,6 +1456,17 @@ impl AetherEngine {
             } => {
                 debug!(%pool, ?protocol, "Pool reserve update");
 
+                // Capture the live reserves into the WS-fed cache so the
+                // next pre-warm cycle can serve slot 8 locally instead of
+                // round-tripping `eth_getStorageAt`. Only V2-family pools
+                // pack reserves at slot 8 in the format this cache emits;
+                // V3 / Curve / Balancer have richer state representations
+                // and stay on the existing RPC path.
+                if matches!(protocol, ProtocolType::UniswapV2 | ProtocolType::SushiSwap) {
+                    let block = self.current_block.load().number;
+                    self.v2_reserves_cache.record(pool, reserve0, reserve1, block);
+                }
+
                 // Look up pool metadata to get graph vertex indices.
                 let meta = self.pool_registry.load().get(&pool).cloned();
 
@@ -2029,6 +2047,7 @@ impl AetherEngine {
                 &code_addrs,
                 &v2_addrs,
                 self.bytecode_cache.as_deref(),
+                Some(&self.v2_reserves_cache),
             )
             .await;
             Some(Arc::new(state))
@@ -2317,6 +2336,13 @@ impl AetherEngine {
         &self,
     ) -> Option<&Arc<aether_simulator::bytecode_cache::BytecodeCache>> {
         self.bytecode_cache.as_ref()
+    }
+
+    /// Clone the V2 reserves cache populated by the WS `Sync` event handler.
+    /// The cache is internally `Arc`-backed so the clone is cheap; consumers
+    /// share a single underlying store with the engine writer side.
+    pub fn v2_reserves_cache(&self) -> aether_simulator::v2_reserves_cache::V2ReservesCache {
+        self.v2_reserves_cache.clone()
     }
 }
 

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -214,6 +214,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // address-keyed `eth_getCode` hits skip the RPC round-trip.
             sim_ctx_inner =
                 sim_ctx_inner.with_bytecode_cache(engine.bytecode_cache().cloned());
+            // Plumb the engine's WS-fed V2 reserves cache so the mempool
+            // prewarm path can synthesise slot 8 for warm pools instead of
+            // round-tripping `eth_getStorageAt`.
+            sim_ctx_inner =
+                sim_ctx_inner.with_v2_reserves_cache(Some(engine.v2_reserves_cache()));
             let sim_ctx = Arc::new(sim_ctx_inner);
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -209,6 +209,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "MEMPOOL_POST_STATE_REPLAY enabled — V3 tick-crossing swaps will escalate to revm fork-replay"
                 );
             }
+            // Plumb the engine's bytecode cache (when configured via
+            // `AETHER_BYTECODE_CACHE_PATH`) into the mempool prewarm path so
+            // address-keyed `eth_getCode` hits skip the RPC round-trip.
+            sim_ctx_inner =
+                sim_ctx_inner.with_bytecode_cache(engine.bytecode_cache().cloned());
             let sim_ctx = Arc::new(sim_ctx_inner);
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -185,6 +185,13 @@ pub struct SimContext {
     /// Optional persistent bytecode cache. Threaded into `prewarm_state` so
     /// addresses already on disk skip the `eth_getCode` round-trip.
     pub bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
+    /// WS-fed V2 reserves cache. Threaded into `prewarm_state` so pools
+    /// whose latest `Sync` event arrived within
+    /// `aether_simulator::fork::V2_RESERVES_MAX_LAG_BLOCKS` of the target
+    /// block synthesise slot 8 locally instead of round-tripping
+    /// `eth_getStorageAt`. `None` retains the pre-existing RPC-every-time
+    /// behaviour.
+    pub v2_reserves_cache: Option<aether_simulator::v2_reserves_cache::V2ReservesCache>,
 }
 
 impl SimContext {
@@ -212,6 +219,7 @@ impl SimContext {
             post_state_replay_enabled: false,
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
             bytecode_cache: None,
+            v2_reserves_cache: None,
         }
     }
 
@@ -224,6 +232,17 @@ impl SimContext {
         cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
     ) -> Self {
         self.bytecode_cache = cache;
+        self
+    }
+
+    /// Attach the engine's WS-fed V2 reserves cache. When set, the mempool
+    /// pre-warm path consults the cache for slot 8 of every UniV2 / Sushi
+    /// pool before issuing `eth_getStorageAt`.
+    pub fn with_v2_reserves_cache(
+        mut self,
+        cache: Option<aether_simulator::v2_reserves_cache::V2ReservesCache>,
+    ) -> Self {
+        self.v2_reserves_cache = cache;
         self
     }
 
@@ -457,6 +476,7 @@ async fn run_prewarm_refresh(
         &code_addrs,
         &v2_addrs,
         sim_ctx.bytecode_cache.as_deref(),
+        sim_ctx.v2_reserves_cache.as_ref(),
     )
     .await;
 

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -182,6 +182,9 @@ pub struct SimContext {
     /// bytecode on every attempt. `None` until the first refresh lands.
     pub mempool_prewarm:
         Arc<ArcSwap<Option<Arc<aether_simulator::fork::PrewarmedState>>>>,
+    /// Optional persistent bytecode cache. Threaded into `prewarm_state` so
+    /// addresses already on disk skip the `eth_getCode` round-trip.
+    pub bytecode_cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
 }
 
 impl SimContext {
@@ -208,7 +211,20 @@ impl SimContext {
             pair_index_cache: Mutex::new(None),
             post_state_replay_enabled: false,
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
+            bytecode_cache: None,
         }
+    }
+
+    /// Attach a persistent bytecode cache. Future `prewarm_state` calls that
+    /// receive this `SimContext` will consult the cache before issuing
+    /// `eth_getCode` and persist any freshly fetched bytecode back. Passing
+    /// `None` is equivalent to the historical RPC-every-time behaviour.
+    pub fn with_bytecode_cache(
+        mut self,
+        cache: Option<Arc<aether_simulator::bytecode_cache::BytecodeCache>>,
+    ) -> Self {
+        self.bytecode_cache = cache;
+        self
     }
 
     /// Flip the revm post-state replay fallback on. Callers should also
@@ -435,9 +451,14 @@ async fn run_prewarm_refresh(
     let pool_count = registry_guard.len();
     drop(registry_guard);
 
-    let fresh =
-        aether_simulator::fork::prewarm_state(provider, block_number, &code_addrs, &v2_addrs)
-            .await;
+    let fresh = aether_simulator::fork::prewarm_state(
+        provider,
+        block_number,
+        &code_addrs,
+        &v2_addrs,
+        sim_ctx.bytecode_cache.as_deref(),
+    )
+    .await;
 
     sim_ctx
         .mempool_prewarm

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -22,6 +22,7 @@ dashmap = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[bench]]
 name = "simulation"

--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -7,7 +7,15 @@ use futures::StreamExt;
 use revm::bytecode::Bytecode;
 
 use crate::bytecode_cache::BytecodeCache;
+use crate::v2_reserves_cache::V2ReservesCache;
 use revm::database::CacheDB;
+
+/// How many blocks of WS lag the pre-warm reads-from-cache path tolerates
+/// before falling back to RPC. `Sync` events arrive within ~50 ms of a
+/// block landing on the WS subscription; one block of slack (~12 s) is
+/// more than enough headroom under normal latency while still rejecting
+/// clearly stale snapshots after a reconnect or reorg.
+pub const V2_RESERVES_MAX_LAG_BLOCKS: u64 = 1;
 use revm::database_interface::EmptyDB;
 use revm::state::AccountInfo;
 use revm_database::{AlloyDB, BlockId, WrapDatabaseAsync};
@@ -90,12 +98,18 @@ fn resolve_prewarm_max_concurrent() -> usize {
 /// cache short-circuit the `eth_getCode` call entirely; freshly fetched
 /// bytecode is persisted back so subsequent block cycles serve from the
 /// cache. Pass `None` to retain the historical RPC-every-time behaviour.
+///
+/// **`v2_reserves_cache`**: when supplied, V2 pool addresses whose latest
+/// `Sync` event landed within [`V2_RESERVES_MAX_LAG_BLOCKS`] of
+/// `block_number` synthesise the slot-8 storage value locally and skip the
+/// `eth_getStorageAt` round-trip. Stale pools fall back to RPC.
 pub async fn prewarm_state(
     provider: &DynProvider<Ethereum>,
     block_number: u64,
     code_addresses: &[Address],
     v2_pool_addresses: &[Address],
     bytecode_cache: Option<&BytecodeCache>,
+    v2_reserves_cache: Option<&V2ReservesCache>,
 ) -> PrewarmedState {
     let max_concurrent = resolve_prewarm_max_concurrent();
     // Shared in-flight gate across both the code and storage streams so the
@@ -155,13 +169,34 @@ pub async fn prewarm_state(
     }))
     .buffer_unordered(max_concurrent);
 
-    // Fetch slot 8 (packed reserves: reserve0 | reserve1 | blockTimestampLast)
-    // for UniswapV2 / SushiSwap pools through the same shared gate.
+    // Slot 8 of every UniV2 pair packs `(blockTimestampLast << 224) |
+    // (reserve1 << 112) | reserve0`. Two paths feed it:
+    //
+    // 1. WS-fed `V2ReservesCache`: synthesise the slot locally for any pool
+    //    whose latest `Sync` event landed within `V2_RESERVES_MAX_LAG_BLOCKS`
+    //    of the target block. Stale or missing entries fall through.
+    // 2. Throttled RPC `eth_getStorageAt` for the remaining addresses,
+    //    sharing the in-flight semaphore with the code-fetch stream so the
+    //    combined RPC pressure is bounded by `max_concurrent`.
     const V2_RESERVES_SLOT: u64 = 8;
-    let storage_addrs = v2_pool_addresses.to_vec();
+    let mut ws_storage: Vec<(Address, U256, U256)> = Vec::new();
+    let mut storage_to_fetch: Vec<Address> = Vec::with_capacity(v2_pool_addresses.len());
+    if let Some(rcache) = v2_reserves_cache {
+        for &addr in v2_pool_addresses {
+            match rcache.get_fresh(addr, block_number, V2_RESERVES_MAX_LAG_BLOCKS) {
+                Some(snap) => {
+                    ws_storage.push((addr, U256::from(V2_RESERVES_SLOT), snap.pack_slot8()));
+                }
+                None => storage_to_fetch.push(addr),
+            }
+        }
+    } else {
+        storage_to_fetch.extend_from_slice(v2_pool_addresses);
+    }
+
     let storage_gate = gate.clone();
     let storage_provider = provider.clone();
-    let storage_stream = futures::stream::iter(storage_addrs.into_iter().map(move |addr| {
+    let storage_stream = futures::stream::iter(storage_to_fetch.into_iter().map(move |addr| {
         let p = storage_provider.clone();
         let g = storage_gate.clone();
         async move {
@@ -191,10 +226,12 @@ pub async fn prewarm_state(
 
     let cache_hits = cached.len();
     let rpc_fetched = code_results.iter().filter(|r| r.is_some()).count();
+    let ws_reserves_hits = ws_storage.len();
     let storage_warmed = storage_results.iter().filter(|r| r.is_some()).count();
     debug!(
         cache_hits,
         rpc_fetched,
+        ws_reserves_hits,
         storage_warmed,
         max_concurrent,
         "Block pre-warm complete"
@@ -205,9 +242,12 @@ pub async fn prewarm_state(
     let mut code_cache = cached;
     code_cache.extend(code_results.into_iter().flatten());
 
+    let mut storage = ws_storage;
+    storage.extend(storage_results.into_iter().flatten());
+
     PrewarmedState {
         code_cache,
-        storage: storage_results.into_iter().flatten().collect(),
+        storage,
     }
 }
 
@@ -686,7 +726,8 @@ mod tests {
             .connect_http("http://127.0.0.1:1/".parse().unwrap())
             .erased();
 
-        let state = prewarm_state(&provider, 1, &[addr_a, addr_b], &[], Some(&cache)).await;
+        let state =
+            prewarm_state(&provider, 1, &[addr_a, addr_b], &[], Some(&cache), None).await;
 
         assert_eq!(
             state.code_cache.len(),
@@ -709,8 +750,76 @@ mod tests {
         let provider = ProviderBuilder::new()
             .connect_http("http://127.0.0.1:1/".parse().unwrap())
             .erased();
-        let state = prewarm_state(&provider, 1, &[], &[], None).await;
+        let state = prewarm_state(&provider, 1, &[], &[], None, None).await;
         assert!(state.code_cache.is_empty());
         assert!(state.storage.is_empty());
+    }
+
+    /// Verifies the WS-fed V2 reserves cache short-circuits the storage
+    /// fetch path. A fully populated reserves cache must let `prewarm_state`
+    /// return slot-8 entries for every V2 pool address without ever
+    /// touching the RPC endpoint (which here is unreachable).
+    #[tokio::test]
+    async fn prewarm_state_skips_rpc_on_full_v2_reserves_hit() {
+        use crate::v2_reserves_cache::V2ReservesCache;
+        use alloy::providers::ProviderBuilder;
+
+        let rcache = V2ReservesCache::new();
+        let p1 = address!("1111111111111111111111111111111111111111");
+        let p2 = address!("2222222222222222222222222222222222222222");
+        let r0_p1 = U256::from(1_000u64);
+        let r1_p1 = U256::from(2_000u64);
+        let r0_p2 = U256::from(5_000u64);
+        let r1_p2 = U256::from(6_000u64);
+        rcache.record(p1, r0_p1, r1_p1, 100);
+        rcache.record(p2, r0_p2, r1_p2, 100);
+
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+
+        // Target the same block the cache recorded — well inside the lag
+        // window — so both pools must surface via the WS cache.
+        let state = prewarm_state(&provider, 100, &[], &[p1, p2], None, Some(&rcache)).await;
+
+        assert_eq!(
+            state.storage.len(),
+            2,
+            "both pools must surface slot-8 entries via the WS cache"
+        );
+        let by_addr: std::collections::HashMap<_, _> =
+            state.storage.iter().map(|(a, _, v)| (*a, *v)).collect();
+        // Decode the packed slot-8 layout to confirm reserve0 and reserve1
+        // round-trip intact for at least one pool.
+        let packed_p1 = by_addr.get(&p1).copied().expect("p1 entry");
+        let mask112 = (U256::from(1u64) << 112) - U256::from(1u64);
+        assert_eq!(packed_p1 & mask112, r0_p1);
+        assert_eq!((packed_p1 >> 112) & mask112, r1_p1);
+    }
+
+    /// Stale reserve snapshots (older than the lag window) must NOT short-
+    /// circuit the RPC call. The cache hit is rejected and the address
+    /// falls through to the normal RPC path; with an unreachable provider
+    /// that path errors and the address is simply absent from the result.
+    #[tokio::test]
+    async fn prewarm_state_falls_through_when_v2_cache_is_stale() {
+        use crate::v2_reserves_cache::V2ReservesCache;
+        use alloy::providers::ProviderBuilder;
+
+        let rcache = V2ReservesCache::new();
+        let p1 = address!("3333333333333333333333333333333333333333");
+        rcache.record(p1, U256::from(1u64), U256::from(2u64), 10);
+
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+
+        // Target block 100, cache entry at block 10 — well outside the
+        // 1-block lag window. RPC is unreachable so the result is empty.
+        let state = prewarm_state(&provider, 100, &[], &[p1], None, Some(&rcache)).await;
+        assert!(
+            state.storage.is_empty(),
+            "stale cache entries must not surface in pre-warm output"
+        );
     }
 }

--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -5,6 +5,8 @@ use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::providers::{DynProvider, Provider};
 use futures::StreamExt;
 use revm::bytecode::Bytecode;
+
+use crate::bytecode_cache::BytecodeCache;
 use revm::database::CacheDB;
 use revm::database_interface::EmptyDB;
 use revm::state::AccountInfo;
@@ -83,11 +85,17 @@ fn resolve_prewarm_max_concurrent() -> usize {
 /// **`v2_pool_addresses`**: UniswapV2 / SushiSwap pools whose packed-reserve
 /// slot (slot 8) is pre-fetched. This is the single most impactful storage
 /// slot to warm — `getReserves()` reads it on every V2 swap path.
+///
+/// **`bytecode_cache`**: when supplied, addresses already resident in the
+/// cache short-circuit the `eth_getCode` call entirely; freshly fetched
+/// bytecode is persisted back so subsequent block cycles serve from the
+/// cache. Pass `None` to retain the historical RPC-every-time behaviour.
 pub async fn prewarm_state(
     provider: &DynProvider<Ethereum>,
     block_number: u64,
     code_addresses: &[Address],
     v2_pool_addresses: &[Address],
+    bytecode_cache: Option<&BytecodeCache>,
 ) -> PrewarmedState {
     let max_concurrent = resolve_prewarm_max_concurrent();
     // Shared in-flight gate across both the code and storage streams so the
@@ -95,16 +103,33 @@ pub async fn prewarm_state(
     let gate = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
     let block_id = BlockId::from(block_number);
 
-    // Fetch contract code via a bounded-concurrency stream. Each future
-    // acquires a semaphore permit before issuing the request and releases it
-    // on completion, keeping at most `max_concurrent` in flight across both
-    // streams combined.
-    let code_addrs = code_addresses.to_vec();
+    // Partition addresses into cache hits (served locally) and misses (must
+    // RPC). Hits bypass the entire RPC fan-out so they don't even contribute
+    // to the in-flight burst that drives free-tier 429s.
+    let mut cached: Vec<(B256, Bytecode)> = Vec::new();
+    let mut to_fetch: Vec<Address> = Vec::with_capacity(code_addresses.len());
+    if let Some(cache) = bytecode_cache {
+        for &addr in code_addresses {
+            match cache.get(addr) {
+                Some(hit) => cached.push(hit),
+                None => to_fetch.push(addr),
+            }
+        }
+    } else {
+        to_fetch.extend_from_slice(code_addresses);
+    }
+
+    // Fetch contract code for every cache-miss via a bounded-concurrency
+    // stream. Each future acquires a semaphore permit before issuing the
+    // request and releases it on completion, keeping at most `max_concurrent`
+    // in flight across both code and storage streams combined.
     let code_gate = gate.clone();
     let code_provider = provider.clone();
-    let code_stream = futures::stream::iter(code_addrs.into_iter().map(move |addr| {
+    let code_cache_handle = bytecode_cache.cloned();
+    let code_stream = futures::stream::iter(to_fetch.into_iter().map(move |addr| {
         let p = code_provider.clone();
         let g = code_gate.clone();
+        let cache = code_cache_handle.clone();
         async move {
             let _permit = g.acquire().await.ok()?;
             match p.get_code_at(addr).block_id(block_id).await {
@@ -113,6 +138,11 @@ pub async fn prewarm_state(
                     let bytecode = Bytecode::new_raw(
                         revm::primitives::Bytes::copy_from_slice(&code),
                     );
+                    if let Some(c) = cache.as_ref() {
+                        if let Err(e) = c.put(addr, code_hash, &code) {
+                            warn!(%addr, error = %e, "pre-warm: bytecode cache persist failed");
+                        }
+                    }
                     Some((code_hash, bytecode))
                 }
                 Ok(_) => None, // empty bytecode (EOA)
@@ -159,15 +189,24 @@ pub async fn prewarm_state(
         storage_stream.collect::<Vec<_>>(),
     );
 
+    let cache_hits = cached.len();
+    let rpc_fetched = code_results.iter().filter(|r| r.is_some()).count();
+    let storage_warmed = storage_results.iter().filter(|r| r.is_some()).count();
     debug!(
-        code_warmed = code_results.iter().filter(|r| r.is_some()).count(),
-        storage_warmed = storage_results.iter().filter(|r| r.is_some()).count(),
+        cache_hits,
+        rpc_fetched,
+        storage_warmed,
         max_concurrent,
         "Block pre-warm complete"
     );
 
+    // Merge cached + freshly fetched entries. Order doesn't matter because
+    // injection is keyed by code hash on the consumer side.
+    let mut code_cache = cached;
+    code_cache.extend(code_results.into_iter().flatten());
+
     PrewarmedState {
-        code_cache: code_results.into_iter().flatten().collect(),
+        code_cache,
         storage: storage_results.into_iter().flatten().collect(),
     }
 }
@@ -611,5 +650,67 @@ mod tests {
             CAP
         );
         assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+    }
+
+    // ── prewarm + bytecode cache wiring ────────────────────────────
+
+    /// When every requested address is already resident in the bytecode
+    /// cache, `prewarm_state` must surface those entries without issuing a
+    /// single RPC. We exercise this by handing the function a provider
+    /// pointed at an unreachable port: any cache miss would trip the
+    /// connection refusal and produce a `warn!` log, but with a fully warm
+    /// cache the RPC code path is never entered and the returned state
+    /// reflects exactly what was pre-populated.
+    #[tokio::test]
+    async fn prewarm_state_skips_rpc_on_full_cache_hit() {
+        use crate::bytecode_cache::BytecodeCache;
+        use alloy::providers::ProviderBuilder;
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let cache = BytecodeCache::open(tmp.path()).unwrap();
+
+        // Two addresses, each pre-populated with a distinct bytecode.
+        let addr_a = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let code_a = vec![0x60u8, 0x80, 0x60, 0x40, 0x52];
+        let hash_a = alloy::primitives::keccak256(&code_a);
+        cache.put(addr_a, hash_a, &code_a).unwrap();
+
+        let addr_b = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let code_b = vec![0x60u8, 0x00, 0x60, 0x00, 0xf3];
+        let hash_b = alloy::primitives::keccak256(&code_b);
+        cache.put(addr_b, hash_b, &code_b).unwrap();
+
+        // Localhost on a port we'll never bind to — guarantees any RPC
+        // attempt fails fast (and surfaces a `warn!`) instead of hanging.
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+
+        let state = prewarm_state(&provider, 1, &[addr_a, addr_b], &[], Some(&cache)).await;
+
+        assert_eq!(
+            state.code_cache.len(),
+            2,
+            "both addresses must come back via the cache, not RPC"
+        );
+        let returned_hashes: std::collections::HashSet<_> =
+            state.code_cache.iter().map(|(h, _)| *h).collect();
+        assert!(returned_hashes.contains(&hash_a));
+        assert!(returned_hashes.contains(&hash_b));
+    }
+
+    /// Without a cache, the function must behave exactly as before. Pointing
+    /// at an unreachable RPC and supplying no addresses gives us a stable
+    /// "all paths empty" baseline that verifies the new signature did not
+    /// break the historical `None`-cache code path.
+    #[tokio::test]
+    async fn prewarm_state_without_cache_returns_empty_for_empty_input() {
+        use alloy::providers::ProviderBuilder;
+        let provider = ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1/".parse().unwrap())
+            .erased();
+        let state = prewarm_state(&provider, 1, &[], &[], None).await;
+        assert!(state.code_cache.is_empty());
+        assert!(state.storage.is_empty());
     }
 }

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -3,6 +3,7 @@ pub mod calldata;
 pub mod fork;
 pub mod mempool_backrun;
 pub mod post_state_replay;
+pub mod v2_reserves_cache;
 
 use alloy::primitives::{Address, U256};
 use aether_common::types::SimulationResult;

--- a/crates/simulator/src/v2_reserves_cache.rs
+++ b/crates/simulator/src/v2_reserves_cache.rs
@@ -1,0 +1,240 @@
+//! In-memory cache of the latest packed reserves slot for UniswapV2 /
+//! SushiSwap pools, fed by the WebSocket `Sync` event stream.
+//!
+//! UniV2's `getReserves()` reads a single packed slot at storage index 8:
+//!
+//! ```text
+//! slot8 = (blockTimestampLast << 224) | (reserve1 << 112) | reserve0
+//! ```
+//!
+//! The detector already subscribes to every monitored pool's `Sync` event
+//! and decodes the new reserve pair on every block. Today we throw that
+//! data away after the price-graph edge update and pay a fresh
+//! `eth_getStorageAt` round-trip per pool on every pre-warm cycle to refetch
+//! information that just arrived for free over the WS.
+//!
+//! `V2ReservesCache` captures the latest decoded reserves and exposes them
+//! as a synthesised slot-8 value for the pre-warm path. The `blockTimestampLast`
+//! field is *not* part of a Sync event, so we leave it zero — UniV2 swap
+//! math does not depend on it (only `_update()` writes the field, and that
+//! happens *after* the swap quantities are computed). Any consumer that
+//! does need a live timestamp must still fall through to RPC.
+//!
+//! All operations are O(1) lock-free via `DashMap`. The cache is cheap to
+//! clone (it's `Arc`-backed) so the engine writer side and the pre-warm
+//! reader side share a single shared instance.
+
+use std::sync::Arc;
+
+use alloy::primitives::{Address, U256};
+use dashmap::DashMap;
+
+/// Bit shift for `reserve1` inside UniV2's packed slot 8.
+const RESERVE1_SHIFT: u32 = 112;
+
+/// 112-bit mask used when packing `reserve0` / `reserve1` into slot 8.
+fn uint112_mask() -> U256 {
+    (U256::from(1u64) << 112) - U256::from(1u64)
+}
+
+/// Latest reserve pair captured for a single pool. `block_number` is the
+/// chain head at which the underlying Sync event was emitted; the pre-warm
+/// path can use it to reject stale entries during reorgs.
+#[derive(Clone, Copy, Debug)]
+pub struct ReserveSnapshot {
+    pub reserve0: U256,
+    pub reserve1: U256,
+    pub block_number: u64,
+}
+
+impl ReserveSnapshot {
+    /// Encode the snapshot as a UniV2 packed slot-8 value.
+    /// `blockTimestampLast` is forced to 0 — see module docs.
+    pub fn pack_slot8(&self) -> U256 {
+        let mask = uint112_mask();
+        let r0 = self.reserve0 & mask;
+        let r1 = self.reserve1 & mask;
+        r0 | (r1 << RESERVE1_SHIFT)
+    }
+}
+
+/// Lock-free cache of the latest per-pool reserve snapshot.
+#[derive(Clone, Default)]
+pub struct V2ReservesCache {
+    inner: Arc<DashMap<Address, ReserveSnapshot>>,
+}
+
+impl V2ReservesCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of distinct pools currently cached. Useful for diagnostics.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Record the latest reserves for `pool` at `block_number`. Newer
+    /// `block_number` always wins; older updates are dropped so a delayed
+    /// out-of-order event cannot poison the cache with stale state.
+    pub fn record(&self, pool: Address, reserve0: U256, reserve1: U256, block_number: u64) {
+        self.inner
+            .entry(pool)
+            .and_modify(|existing| {
+                if block_number >= existing.block_number {
+                    existing.reserve0 = reserve0;
+                    existing.reserve1 = reserve1;
+                    existing.block_number = block_number;
+                }
+            })
+            .or_insert(ReserveSnapshot {
+                reserve0,
+                reserve1,
+                block_number,
+            });
+    }
+
+    /// Look up the latest snapshot for `pool` if one has been captured.
+    pub fn get(&self, pool: Address) -> Option<ReserveSnapshot> {
+        self.inner.get(&pool).map(|v| *v.value())
+    }
+
+    /// Look up the latest snapshot for `pool` only if it is fresh enough for
+    /// `target_block` — i.e. emitted no earlier than `target_block.saturating_sub(max_lag)`.
+    /// Stale entries return `None` so the caller falls through to RPC.
+    pub fn get_fresh(
+        &self,
+        pool: Address,
+        target_block: u64,
+        max_lag: u64,
+    ) -> Option<ReserveSnapshot> {
+        let snap = self.get(pool)?;
+        let oldest_acceptable = target_block.saturating_sub(max_lag);
+        if snap.block_number >= oldest_acceptable {
+            Some(snap)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn record_then_get_roundtrip() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        cache.record(pool, U256::from(100u64), U256::from(200u64), 42);
+        let s = cache.get(pool).expect("hit");
+        assert_eq!(s.reserve0, U256::from(100u64));
+        assert_eq!(s.reserve1, U256::from(200u64));
+        assert_eq!(s.block_number, 42);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn get_returns_none_when_unseen() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        assert!(cache.get(pool).is_none());
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn newer_block_overwrites_older() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("cccccccccccccccccccccccccccccccccccccccc");
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 100);
+        cache.record(pool, U256::from(3u64), U256::from(4u64), 101);
+        let s = cache.get(pool).unwrap();
+        assert_eq!(s.reserve0, U256::from(3u64));
+        assert_eq!(s.reserve1, U256::from(4u64));
+        assert_eq!(s.block_number, 101);
+    }
+
+    #[test]
+    fn out_of_order_older_event_is_dropped() {
+        // Sync events occasionally arrive out of order during a reorg or a
+        // mid-stream WS reconnect. An older `block_number` must not replace
+        // the freshest snapshot or the cache would poison the pre-warm path
+        // with stale state.
+        let cache = V2ReservesCache::new();
+        let pool = address!("dddddddddddddddddddddddddddddddddddddddd");
+        cache.record(pool, U256::from(3u64), U256::from(4u64), 101);
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 100); // older
+        let s = cache.get(pool).unwrap();
+        assert_eq!(s.reserve0, U256::from(3u64));
+        assert_eq!(s.block_number, 101);
+    }
+
+    #[test]
+    fn pack_slot8_layout_matches_uniswap_v2() {
+        // The synthesised slot8 layout must place reserve0 in bits 0..111,
+        // reserve1 in bits 112..223, and leave the high 32 bits (where
+        // `blockTimestampLast` would live) untouched. Use small, distinct
+        // values that fit comfortably inside 112 bits.
+        let snap = ReserveSnapshot {
+            reserve0: U256::from(0xAABBCCu64),
+            reserve1: U256::from(0xDDEEFFu64),
+            block_number: 1,
+        };
+        let packed = snap.pack_slot8();
+        let mask112 = uint112_mask();
+        let r0_back = packed & mask112;
+        let r1_back = (packed >> RESERVE1_SHIFT) & mask112;
+        assert_eq!(r0_back, U256::from(0xAABBCCu64));
+        assert_eq!(r1_back, U256::from(0xDDEEFFu64));
+        // High 32 bits = blockTimestampLast region must be zero.
+        let ts_region = packed >> 224;
+        assert_eq!(ts_region, U256::ZERO, "timestamp region must stay zero");
+    }
+
+    #[test]
+    fn pack_slot8_truncates_to_uint112() {
+        // Real on-chain values are already uint112, but defensively the
+        // packer must mask anything wider so a malformed input never
+        // contaminates the reserve1 / timestamp bands.
+        let mask112 = uint112_mask();
+        let oversized = (U256::from(1u64) << 130) | U256::from(7u64);
+        let snap = ReserveSnapshot {
+            reserve0: oversized,
+            reserve1: oversized,
+            block_number: 1,
+        };
+        let packed = snap.pack_slot8();
+        let r0_back = packed & mask112;
+        let r1_back = (packed >> RESERVE1_SHIFT) & mask112;
+        // The bit-130 value is dropped because it falls outside the 112-bit
+        // window; only the low 7 survives.
+        assert_eq!(r0_back, U256::from(7u64));
+        assert_eq!(r1_back, U256::from(7u64));
+        // No overflow into the timestamp band.
+        let ts_region = packed >> 224;
+        assert_eq!(ts_region, U256::ZERO);
+    }
+
+    #[test]
+    fn get_fresh_accepts_within_lag_window() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 100);
+        // Target block 102, lag 3 -> oldest acceptable = 99; cached at 100 -> hit.
+        assert!(cache.get_fresh(pool, 102, 3).is_some());
+    }
+
+    #[test]
+    fn get_fresh_rejects_stale_snapshot() {
+        let cache = V2ReservesCache::new();
+        let pool = address!("ffffffffffffffffffffffffffffffffffffffff");
+        cache.record(pool, U256::from(1u64), U256::from(2u64), 50);
+        // Target block 100, lag 3 -> oldest acceptable = 97; cached at 50 -> miss.
+        assert!(cache.get_fresh(pool, 100, 3).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Stacked-PR squash-merge fallout: #175 and #176 were marked merged on GitHub because their parent branches (`feat/bytecode-disk-cache`, `feat/bytecode-cache-wire`) were deleted after squash-merge of #174, but their actual deltas vs `develop` never landed. This PR recovers both.

What was missing from `develop`:
- `prewarm_state` had no `bytecode_cache` / `v2_reserves_cache` parameters → `BytecodeCache` module compiled but unused.
- `crates/simulator/src/v2_reserves_cache.rs` absent entirely.
- `Engine` did not open the disk cache, expose a `bytecode_cache()` / `v2_reserves_cache()` getter, or record `Sync` events into the WS cache.
- `SimContext` lacked the `bytecode_cache` / `v2_reserves_cache` fields and `with_*` builders; `main.rs` never plumbed them.

## Files Changed

| File | Change |
|---|---|
| `crates/simulator/src/fork.rs` | `prewarm_state` partitions code addresses by bytecode-cache hit and V2 pool addresses by WS-fed reserve freshness; both miss paths go through the existing `#173` throttled stream so the in-flight cap is preserved. |
| `crates/simulator/src/v2_reserves_cache.rs` | New module: WS-fed UniV2/Sushi reserves cache with block-tagged freshness, `pack_slot8` synthesizer, out-of-order drop. |
| `crates/simulator/src/lib.rs` | Export `v2_reserves_cache`. |
| `crates/simulator/Cargo.toml` | dev-deps: `tempfile`, `tokio` macros for the new tests. |
| `crates/grpc-server/src/engine.rs` | Open `BytecodeCache` from `AETHER_BYTECODE_CACHE_PATH`; record V2 `Sync` reserves into `V2ReservesCache` from `handle_pool_update`; expose both via getters. |
| `crates/grpc-server/src/mempool_pipeline.rs` | `SimContext.bytecode_cache` + `SimContext.v2_reserves_cache` fields + `with_*` builders; mempool prewarm refresher passes them into `prewarm_state`. |
| `crates/grpc-server/src/main.rs` | Wire both caches from `Engine` into the mempool `SimContext`. |

## Acceptance Criteria

- [x] `prewarm_state` signature matches the one used by `Engine` and `run_prewarm_refresh`.
- [x] `Sync` events recorded into `V2ReservesCache` for UniV2 + SushiSwap protocols only.
- [x] Freshness gate (`V2_RESERVES_MAX_LAG_BLOCKS = 1`) rejects stale snapshots → falls back to RPC.
- [x] Bytecode cache hits short-circuit `eth_getCode`; misses are persisted back.
- [x] No cache → identical RPC-every-time behaviour (back-compat).
- [x] `cargo clippy --all-targets -- -D warnings` clean on touched crates.
- [x] `cargo test --workspace --lib` — 510 passed.
- [x] `go test ./...` — green.
- [x] `cargo build --workspace --release` — green.

## Test plan

- [x] Unit: `prewarm_state_skips_rpc_on_full_cache_hit` — full bytecode-cache hit, RPC endpoint unreachable, both addresses returned.
- [x] Unit: 8 `v2_reserves_cache` tests covering pack/unpack, freshness window, out-of-order drop, newer-overwrites-older.
- [x] Unit: 7 `bytecode_cache` tests covering roundtrip, idempotency, hash overwrite, disk persistence across reopen.
- [ ] Shadow-mode smoke once merged: confirm `aether_prewarm_*` counters show cache hits climbing across consecutive blocks and `eth_getCode` rate drops.
