### PR TITLE
perf(sim): write fresh V2 reserves back into cache after RPC fetch

### DIFF
--- a/crates/simulator/src/fork.rs
+++ b/crates/simulator/src/fork.rs
@@ -233,9 +233,15 @@ pub async fn prewarm_state(
 
     let storage_gate = gate.clone();
     let storage_provider = provider.clone();
+    // Clone the cache handle into the closure so the storage stream can
+    // write fresh fetch results back. Cheap — `V2ReservesCache` is
+    // `Arc<DashMap>` under the hood. `None` keeps the original
+    // RPC-every-time behaviour for callers that opt out.
+    let storage_cache_handle = v2_reserves_cache.cloned();
     let storage_stream = futures::stream::iter(storage_to_fetch.into_iter().map(move |addr| {
         let p = storage_provider.clone();
         let g = storage_gate.clone();
+        let cache = storage_cache_handle.clone();
         async move {
             let _permit = g.acquire().await.ok()?;
             match p
@@ -244,6 +250,16 @@ pub async fn prewarm_state(
                 .await
             {
                 Ok(value) if value != U256::ZERO => {
+                    // Write back into the WS-fed cache so the next
+                    // pre-warm cycle for this pool hits locally. The
+                    // recorded `block_number` is the target block of this
+                    // fetch — same value the freshness gate will compare
+                    // against on the next cycle, so a fetch at block N
+                    // makes the pool fresh for block N+1.
+                    if let Some(c) = cache.as_ref() {
+                        let (r0, r1) = crate::v2_reserves_cache::unpack_slot8(value);
+                        c.record(addr, r0, r1, block_number);
+                    }
                     Some((addr, U256::from(V2_RESERVES_SLOT), value))
                 }
                 Ok(_) => None,

--- a/crates/simulator/src/v2_reserves_cache.rs
+++ b/crates/simulator/src/v2_reserves_cache.rs
@@ -37,6 +37,19 @@ fn uint112_mask() -> U256 {
     (U256::from(1u64) << 112) - U256::from(1u64)
 }
 
+/// Inverse of [`ReserveSnapshot::pack_slot8`]: decode a raw UniV2 slot-8
+/// value into the `(reserve0, reserve1)` pair, discarding the high 32 bits
+/// (`blockTimestampLast`) which the cache always stores as zero.
+///
+/// Used by the pre-warm path to write fresh RPC `eth_getStorageAt` results
+/// back into the cache so subsequent cycles serve them locally.
+pub fn unpack_slot8(slot: U256) -> (U256, U256) {
+    let mask = uint112_mask();
+    let r0 = slot & mask;
+    let r1 = (slot >> RESERVE1_SHIFT) & mask;
+    (r0, r1)
+}
+
 /// Latest reserve pair captured for a single pool. `block_number` is the
 /// chain head at which the underlying Sync event was emitted; the pre-warm
 /// path can use it to reject stale entries during reorgs.
@@ -265,6 +278,39 @@ mod tests {
         cache.record(pool, U256::from(1u64), U256::from(2u64), 50);
         // Target block 100, lag 3 -> oldest acceptable = 97; cached at 50 -> miss.
         assert!(cache.get_fresh(pool, 100, 3).is_none());
+    }
+
+    /// `unpack_slot8` must be the exact inverse of `pack_slot8` so RPC
+    /// results written back via the prewarm fetch path round-trip to the
+    /// same `(reserve0, reserve1)` the cache would have emitted itself.
+    /// The high 32 bits (timestamp) are dropped — the cache never stores
+    /// them and consumers don't depend on them.
+    #[test]
+    fn pack_unpack_slot8_roundtrip() {
+        let snap = ReserveSnapshot {
+            reserve0: U256::from(0x1234_5678u64),
+            reserve1: U256::from(0xAABB_CCDDu64),
+            block_number: 99,
+        };
+        let packed = snap.pack_slot8();
+        let (r0, r1) = unpack_slot8(packed);
+        assert_eq!(r0, snap.reserve0);
+        assert_eq!(r1, snap.reserve1);
+    }
+
+    /// Real RPC `eth_getStorageAt` returns slot 8 with the timestamp band
+    /// populated. The unpacker must ignore it instead of bleeding it into
+    /// `reserve1`.
+    #[test]
+    fn unpack_slot8_ignores_timestamp_band() {
+        // Build a real-shape slot: timestamp = 0xDEADBEEF, reserve1 = 7, reserve0 = 11.
+        let timestamp = U256::from(0xDEAD_BEEFu64) << 224;
+        let reserve1 = U256::from(7u64) << RESERVE1_SHIFT;
+        let reserve0 = U256::from(11u64);
+        let slot = timestamp | reserve1 | reserve0;
+        let (r0, r1) = unpack_slot8(slot);
+        assert_eq!(r0, U256::from(11u64));
+        assert_eq!(r1, U256::from(7u64));
     }
 
     /// `get_fresh_status` must split the miss path into Stale vs Missing so


### PR DESCRIPTION
## Summary

Demo telemetry surfaced a structural problem with the WS-fed V2 reserves cache: after 50+ blocks it was still serving **0% hits**, with 94% of lookups landing on pools the WS `Sync` writer had never observed.

Root cause is an overlap problem, not a timing one:

- The detector picks pools that show price discrepancies — usually **low-liquidity, low-volume** pools.
- Those pools `Sync` rarely; the WS writer never sees them.
- High-volume pools (which `Sync` every block) sit at equilibrium and rarely appear in arb cycles.

Bumping `V2_RESERVES_MAX_LAG_BLOCKS` would only have rescued the 5.6% that were stale-but-present; the 94% missing remained.

## Fix

After every successful `eth_getStorageAt` in the pre-warm storage stream, decode the packed slot via the new `unpack_slot8` helper and write `(reserve0, reserve1, target_block)` back into the cache. The next pre-warm cycle for the same pool then hits locally.

This turns every RPC fetch into a one-shot lazy populate. Steady-state miss rate collapses to *pools the detector has not yet looked at*, bounded by the registry size — independent of which pools the WS writer ever observes.

## Files Changed

| File | Change |
|---|---|
| `crates/simulator/src/v2_reserves_cache.rs` | New `unpack_slot8(U256) -> (U256, U256)` helper (inverse of `pack_slot8`). Two new tests: roundtrip + ignore-timestamp-band. |
| `crates/simulator/src/fork.rs` | Storage stream clones the `V2ReservesCache` handle and calls `record(addr, r0, r1, block_number)` on every successful RPC fetch. |

## Acceptance Criteria

- [x] Cache write-back fires on RPC success only (zero-value reads still skipped).
- [x] Recorded `block_number = target block` of the fetch — guarantees freshness on the *next* cycle.
- [x] No change when `v2_reserves_cache=None` (back-compat path preserved).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` — 514 passed (was 512, +2 new).
- [x] `cargo build --workspace --release` — green.
- [x] `go test ./...` — green.

## Test plan

- [x] Unit: `pack_unpack_slot8_roundtrip` — packs then unpacks, asserts identity on the reserve fields.
- [x] Unit: `unpack_slot8_ignores_timestamp_band` — builds a slot with non-zero high 32 bits, confirms unpacker drops them.
- [ ] Shadow run post-merge: confirm `aether_prewarm_v2_reserves_cache_hits_total` starts climbing within ~2 blocks of boot and `_missing_total` plateaus instead of monotonically growing.
