### PR TITLE
obs(grafana): cache + RPC-reduction dashboard

### DIFF
--- a/deploy/docker/grafana/dashboards/cache.json
+++ b/deploy/docker/grafana/dashboards/cache.json
@@ -1,0 +1,293 @@
+{
+  "uid": "aether-cache",
+  "title": "Aether — RPC Reduction Caches",
+  "tags": [
+    "aether",
+    "cache",
+    "rpc"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Bytecode cache hit ratio (cumulative)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "aether_prewarm_bytecode_cache_hits_total{job=~\"aether-rust|aether-host-rust\"} / (aether_prewarm_bytecode_cache_hits_total{job=~\"aether-rust|aether-host-rust\"} + aether_prewarm_bytecode_rpc_fetches_total{job=~\"aether-rust|aether-host-rust\"})",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 6 }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "V2 reserves cache hit ratio (cumulative)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "aether_prewarm_v2_reserves_cache_hits_total{job=~\"aether-rust|aether-host-rust\"} / clamp_min(aether_prewarm_v2_reserves_cache_hits_total{job=~\"aether-rust|aether-host-rust\"} + aether_prewarm_v2_reserves_cache_missing_total{job=~\"aether-rust|aether-host-rust\"} + aether_prewarm_v2_reserves_cache_stale_total{job=~\"aether-rust|aether-host-rust\"}, 1)",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 6 }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "RPC calls avoided (last 5m)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "increase(aether_prewarm_bytecode_cache_hits_total{job=~\"aether-rust|aether-host-rust\"}[5m]) + increase(aether_prewarm_v2_reserves_cache_hits_total{job=~\"aether-rust|aether-host-rust\"}[5m])",
+          "legendFormat": "avoided"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 6 }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Warm pools (mempool refresher)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "aether_mempool_prewarm_warm_pools{job=~\"aether-rust|aether-host-rust\"}",
+          "legendFormat": "pools"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 6 }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Bytecode pre-warm: cache hits vs RPC fetches (per 1m)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(aether_prewarm_bytecode_cache_hits_total{job=~\"aether-rust|aether-host-rust\"}[1m])",
+          "legendFormat": "cache hits"
+        },
+        {
+          "refId": "B",
+          "expr": "rate(aether_prewarm_bytecode_rpc_fetches_total{job=~\"aether-rust|aether-host-rust\"}[1m])",
+          "legendFormat": "RPC fetches"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "stacking": { "mode": "none" }
+          }
+        }
+      },
+      "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "V2 reserves pre-warm: hits / stale / missing (per 1m)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(aether_prewarm_v2_reserves_cache_hits_total{job=~\"aether-rust|aether-host-rust\"}[1m])",
+          "legendFormat": "WS hits"
+        },
+        {
+          "refId": "B",
+          "expr": "rate(aether_prewarm_v2_reserves_cache_stale_total{job=~\"aether-rust|aether-host-rust\"}[1m])",
+          "legendFormat": "stale (lag-rejected)"
+        },
+        {
+          "refId": "C",
+          "expr": "rate(aether_prewarm_v2_reserves_cache_missing_total{job=~\"aether-rust|aether-host-rust\"}[1m])",
+          "legendFormat": "missing (no Sync yet)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20
+          }
+        }
+      },
+      "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Mempool pre-warm refresh latency (ms)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(aether_mempool_prewarm_refresh_duration_ms_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(aether_mempool_prewarm_refresh_duration_ms_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(aether_mempool_prewarm_refresh_duration_ms_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Mempool pre-warm inject (hit / miss per 1m)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (result) (rate(aether_mempool_prewarm_inject_total{job=~\"aether-rust|aether-host-rust\"}[1m]))",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20
+          }
+        }
+      },
+      "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New Grafana dashboard `Aether — RPC Reduction Caches` (uid `aether-cache`) visualises every counter introduced by the pre-warm cache stack (#173 / #174 / #178 / #179). Without it the only way to read the cache wins was `curl /metrics | grep`.

Auto-loaded via the existing `/var/lib/grafana/dashboards` bind-mount; the 30-second provisioning poll picks it up without a Grafana restart.

## Panels (8)

| Row | Panel | Source metric |
|---|---|---|
| Top stats | Bytecode hit ratio | `hits / (hits + rpc_fetches)` |
| Top stats | V2 reserves hit ratio | `hits / (hits + stale + missing)` |
| Top stats | RPC calls avoided (5m) | `increase(bytecode_hits[5m]) + increase(v2_hits[5m])` |
| Top stats | Warm pools | `aether_mempool_prewarm_warm_pools` gauge |
| Time-series | Bytecode hits vs RPC fetches per minute | rate over both bytecode counters |
| Time-series | V2 hits / stale / missing per minute | rate over all three V2 counters |
| Time-series | Mempool refresh latency p50/p95/p99 | `histogram_quantile` over `_duration_ms_bucket` |
| Time-series | Mempool inject hit / miss per minute | `mempool_prewarm_inject_total{result=...}` |

Hit-ratio gauges are thresholded red < 50% < orange < 80% < green so a glance reveals when a cache is failing.

## Files Changed

| File | Change |
|---|---|
| `deploy/docker/grafana/dashboards/cache.json` | New — 293 lines of dashboard JSON. |

## Acceptance Criteria

- [x] JSON parses cleanly (`python3 -c 'json.load(...)'`).
- [x] Every panel targets `job=~"aether-rust|aether-host-rust"` so both compose-internal and host-side runs render.
- [x] No new dashboard provisioning config needed — existing `default.yml` picks the file up via `foldersFromFilesStructure: false`.
- [x] Existing 5 dashboards (overview / mempool / latency / builders / risk) untouched.

## Test plan

- [x] Validate JSON shape locally.
- [ ] Post-merge: refresh Grafana within 30s, open dashboard list, confirm `Aether — RPC Reduction Caches` listed and panels populate from live `/metrics` scrape.
