### PR TITLE
feat: mempool shadow-run suite — discovery, WS keepalive, retention, config hardening, dashboard

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -33,6 +33,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -51,6 +52,21 @@ const (
 	// query. Twice the average block time so a 24-block prediction
 	// reaches the dropped state within ~12 s of its window closing.
 	staleSweepInterval = 6 * time.Second
+
+	// Retention sweep defaults. The mempool ledger (predictions + their
+	// reconciliation/profitability cascade children) grows ~per decoded
+	// swap, so over a multi-day unattended run it must be bounded.
+	// runRetentionLoop deletes rows older than the horizon on a slow
+	// cadence. Override via MEMPOOL_RETENTION_HOURS /
+	// MEMPOOL_RETENTION_INTERVAL_MINS; MEMPOOL_RETENTION_HOURS<=0 disables
+	// retention entirely (ledger grows unbounded — logged loudly at boot).
+	defaultRetentionHorizon  = 48 * time.Hour
+	minRetentionHorizon      = 1 * time.Hour
+	defaultRetentionInterval = 1 * time.Hour
+	minRetentionInterval     = 1 * time.Minute
+	// retentionPruneTimeout caps one DELETE so a wedged Postgres cannot
+	// stall the retention goroutine for a full sweep interval.
+	retentionPruneTimeout = 30 * time.Second
 
 	// receiptFetchTimeout caps how long the reconciler waits for a single
 	// `eth_getTransactionReceipt` round-trip. Sized for the p99 mainnet
@@ -117,8 +133,14 @@ func main() {
 		_ = metricsServer.Shutdown(shutdownCtx)
 	}()
 
+	retain, retentionInterval, retentionEnabled := retentionConfigFromEnv()
+
 	var wg sync.WaitGroup
-	wg.Add(2)
+	loops := 2
+	if retentionEnabled {
+		loops = 3
+	}
+	wg.Add(loops)
 	go func() {
 		defer wg.Done()
 		runHeaderLoop(rootCtx, ethClient, pgRecon, loopMetrics)
@@ -127,6 +149,14 @@ func main() {
 		defer wg.Done()
 		runStaleSweepLoop(rootCtx, ethClient, pgRecon)
 	}()
+	if retentionEnabled {
+		go func() {
+			defer wg.Done()
+			runRetentionLoop(rootCtx, pgRecon, loopMetrics, retentionInterval, retain)
+		}()
+	} else {
+		slog.Warn("mempool retention disabled (MEMPOOL_RETENTION_HOURS<=0) — ledger will grow unbounded")
+	}
 
 	<-rootCtx.Done()
 	slog.Info("shutdown signalled; waiting for loops to exit")
@@ -345,6 +375,71 @@ func runStaleSweepLoop(
 	}
 }
 
+// retentionConfigFromEnv resolves the retention horizon + sweep interval.
+// Returns enabled=false when MEMPOOL_RETENTION_HOURS<=0, which disables the
+// retention loop. Unparseable values fall back to the defaults rather than
+// disabling, so a typo never silently drops retention.
+func retentionConfigFromEnv() (retain, interval time.Duration, enabled bool) {
+	retain = defaultRetentionHorizon
+	if v := os.Getenv("MEMPOOL_RETENTION_HOURS"); v != "" {
+		if h, err := strconv.ParseFloat(v, 64); err == nil {
+			if h <= 0 {
+				return 0, 0, false
+			}
+			retain = time.Duration(h * float64(time.Hour))
+			if retain < minRetentionHorizon {
+				retain = minRetentionHorizon
+			}
+		}
+	}
+	interval = defaultRetentionInterval
+	if v := os.Getenv("MEMPOOL_RETENTION_INTERVAL_MINS"); v != "" {
+		if m, err := strconv.ParseFloat(v, 64); err == nil && m > 0 {
+			interval = time.Duration(m * float64(time.Minute))
+			if interval < minRetentionInterval {
+				interval = minRetentionInterval
+			}
+		}
+	}
+	return retain, interval, true
+}
+
+// runRetentionLoop periodically prunes the mempool ledger to a bounded
+// horizon. Mirrors runStaleSweepLoop: independent ticker, context-cancellable,
+// failures counted + logged but never fatal (a missed sweep just defers
+// deletion to the next tick).
+func runRetentionLoop(
+	ctx context.Context,
+	recon *db.PgMempoolReconciliation,
+	metrics *loopMetrics,
+	interval time.Duration,
+	retain time.Duration,
+) {
+	slog.Info("mempool retention loop started", "interval", interval, "retain", retain)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pruneCtx, cancel := context.WithTimeout(ctx, retentionPruneTimeout)
+			rows, err := recon.PruneMempoolLedger(pruneCtx, retain)
+			cancel()
+			if err != nil {
+				metrics.RetentionErrors.Inc()
+				slog.Warn("mempool retention prune failed", "err", err)
+				continue
+			}
+			if rows > 0 {
+				metrics.RetentionPrunedTotal.Add(float64(rows))
+				slog.Info("mempool retention pruned predictions (+cascade children)",
+					"rows", rows, "retain", retain)
+			}
+		}
+	}
+}
+
 func boolLabel(b bool) string {
 	if b {
 		return "true"
@@ -356,12 +451,14 @@ func boolLabel(b bool) string {
 // in-process by the header / sweep loops. The DB-layer metrics live with
 // PgMempoolReconciliation.
 type loopMetrics struct {
-	HeadersProcessed   prometheus.Counter
-	HeaderFetchErrors  prometheus.Counter
-	LookupErrors       prometheus.Counter
-	ReceiptFetchErrors prometheus.Counter
-	BlockDelta         prometheus.Histogram
-	PoolPathChecks     *prometheus.CounterVec
+	HeadersProcessed     prometheus.Counter
+	HeaderFetchErrors    prometheus.Counter
+	LookupErrors         prometheus.Counter
+	ReceiptFetchErrors   prometheus.Counter
+	BlockDelta           prometheus.Histogram
+	PoolPathChecks       *prometheus.CounterVec
+	RetentionPrunedTotal prometheus.Counter
+	RetentionErrors      prometheus.Counter
 }
 
 func newLoopMetrics(reg prometheus.Registerer) *loopMetrics {
@@ -391,10 +488,19 @@ func newLoopMetrics(reg prometheus.Registerer) *loopMetrics {
 			Name: "aether_mempool_pool_path_total",
 			Help: "Confirmed predictions whose receipt logs were checked against the predicted pool, by protocol and correctness",
 		}, []string{"protocol", "correct"}),
+		RetentionPrunedTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_retention_pruned_total",
+			Help: "Prediction rows deleted by the retention sweep (reconciliation + profitability children cascade-deleted)",
+		}),
+		RetentionErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "aether_mempool_retention_errors_total",
+			Help: "Retention sweep failures (PruneMempoolLedger errors)",
+		}),
 	}
 	reg.MustRegister(
 		m.HeadersProcessed, m.HeaderFetchErrors, m.LookupErrors,
 		m.ReceiptFetchErrors, m.BlockDelta, m.PoolPathChecks,
+		m.RetentionPrunedTotal, m.RetentionErrors,
 	)
 	return m
 }

--- a/cmd/reconciler/main_test.go
+++ b/cmd/reconciler/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetentionConfigFromEnv(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_HOURS", "")
+		t.Setenv("MEMPOOL_RETENTION_INTERVAL_MINS", "")
+		retain, interval, enabled := retentionConfigFromEnv()
+		if !enabled {
+			t.Fatal("expected retention enabled by default")
+		}
+		if retain != defaultRetentionHorizon {
+			t.Errorf("retain = %v, want %v", retain, defaultRetentionHorizon)
+		}
+		if interval != defaultRetentionInterval {
+			t.Errorf("interval = %v, want %v", interval, defaultRetentionInterval)
+		}
+	})
+
+	t.Run("zero disables", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_HOURS", "0")
+		if _, _, enabled := retentionConfigFromEnv(); enabled {
+			t.Fatal("expected retention disabled at 0")
+		}
+	})
+
+	t.Run("negative disables", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_HOURS", "-5")
+		if _, _, enabled := retentionConfigFromEnv(); enabled {
+			t.Fatal("expected retention disabled at negative")
+		}
+	})
+
+	t.Run("sub-floor horizon clamped to minimum", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_HOURS", "0.1")
+		retain, _, enabled := retentionConfigFromEnv()
+		if !enabled {
+			t.Fatal("expected enabled")
+		}
+		if retain != minRetentionHorizon {
+			t.Errorf("retain = %v, want floor %v", retain, minRetentionHorizon)
+		}
+	})
+
+	t.Run("custom horizon honored", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_HOURS", "24")
+		if retain, _, _ := retentionConfigFromEnv(); retain != 24*time.Hour {
+			t.Errorf("retain = %v, want 24h", retain)
+		}
+	})
+
+	t.Run("sub-floor interval clamped to minimum", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_INTERVAL_MINS", "0.1")
+		if _, interval, _ := retentionConfigFromEnv(); interval != minRetentionInterval {
+			t.Errorf("interval = %v, want floor %v", interval, minRetentionInterval)
+		}
+	})
+
+	t.Run("garbage falls back to default, stays enabled", func(t *testing.T) {
+		t.Setenv("MEMPOOL_RETENTION_HOURS", "not-a-number")
+		retain, _, enabled := retentionConfigFromEnv()
+		if !enabled {
+			t.Fatal("expected enabled on unparseable value")
+		}
+		if retain != defaultRetentionHorizon {
+			t.Errorf("retain = %v, want default %v", retain, defaultRetentionHorizon)
+		}
+	})
+}

--- a/crates/grpc-server/src/discovery.rs
+++ b/crates/grpc-server/src/discovery.rs
@@ -1,0 +1,480 @@
+//! Hot-token discovery orchestration (Part 1).
+//!
+//! Periodically pulls the hottest mempool-observed token pairs from the
+//! [`HotTokenTracker`], enriches each with on-chain venue facts (factory
+//! lookups + a WETH-liquidity proxy), runs the fee-on-transfer / honeypot
+//! round-trip screen in revm, applies the admission gate, and appends the
+//! qualifying pools to `pools.toml` — then triggers an in-process registry
+//! reload so the new pools take effect without a restart.
+//!
+//! The loop is **opt-in** (`AETHER_DISCOVERY=1`) and runs entirely off the
+//! decode hot path on its own bounded interval. It admits to a live registry,
+//! so it is capped (`AETHER_MAX_ADMITTED_POOLS`) and idempotent (the append
+//! dedups by address). Intended for the shadow/analytical run — it never
+//! submits anything.
+//!
+//! Scope notes for v1:
+//! - Only WETH-paired candidates are screened (the round-trip screen needs the
+//!   base token's balance slot; WETH = slot 3). Non-WETH pairs are rejected
+//!   (`no_weth_base`) rather than admitted unscreened.
+//! - The round-trip screen needs a UniV2/Sushi pair; a token with only V3
+//!   venues cannot pass the screen and is left for a follow-up.
+//! - Per-venue liquidity is a proxy: `2 × WETH_held_by_pool × AETHER_ETH_PRICE_USD`.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy::network::Ethereum;
+use alloy::primitives::aliases::U24;
+use alloy::primitives::{address, Address, U256};
+use alloy::providers::{DynProvider, Provider};
+use alloy::sol;
+use alloy::sol_types::SolCall;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+use aether_common::types::ProtocolType;
+use aether_grpc_server::hot_token::HotTokenTracker;
+use aether_grpc_server::pool_admission::{
+    self, AdmissionConfig, AdmissionOutcome, CandidateVenue,
+};
+use aether_grpc_server::EngineMetrics;
+use aether_simulator::fee_on_transfer::{self, FotConfig, RoundTripVerdict};
+use aether_simulator::fork::RpcForkedState;
+
+use crate::engine::AetherEngine;
+
+sol! {
+    function getPair(address tokenA, address tokenB) external view returns (address);
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+// Canonical mainnet factories + WETH.
+const UNIV2_FACTORY: Address = address!("5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f");
+const SUSHI_FACTORY: Address = address!("C0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac");
+const UNIV3_FACTORY: Address = address!("1F98431c8aD98523631AE4a59f267346ea31F984");
+const WETH: Address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+
+/// WETH's ERC20 `balances` mapping storage slot (used as the base in the screen).
+const WETH_BALANCE_SLOT: u64 = 3;
+/// UniswapV2 / SushiSwap pool fee in bps.
+const V2_FEE_BPS: u32 = 30;
+/// UniswapV3 fee tiers `(fee_1e-6, tick_spacing)`. `fee_bps = fee_1e-6 / 100`.
+const V3_FEE_TIERS: [(u32, i32); 3] = [(500, 10), (3000, 60), (10000, 200)];
+
+/// Tunables for the discovery loop. All overridable via env; defaults suit the
+/// shadow run.
+#[derive(Clone, Debug)]
+pub struct DiscoveryConfig {
+    /// How often to run a discovery tick.
+    pub interval: Duration,
+    /// Top-N hot candidates considered per tick.
+    pub max_candidates: usize,
+    /// Hard ceiling on total pools in `pools.toml`; admission stops at the cap.
+    pub max_admitted_pools: usize,
+    /// Wall-clock budget for one fee-on-transfer round-trip screen. Generous on
+    /// purpose — the screen is off the hot path and forks live state per call.
+    pub screen_timeout: Duration,
+    /// Round-trip recovery loss tolerance (bps) budgeting for price impact.
+    pub max_loss_bps: u32,
+    /// USD price of 1 ETH for the liquidity proxy.
+    pub eth_price_usd: f64,
+    /// Path to the hot-reloadable pool registry.
+    pub pools_path: String,
+    pub admission: AdmissionConfig,
+    pub fot: FotConfig,
+}
+
+impl DiscoveryConfig {
+    pub fn from_env(pools_path: String) -> Self {
+        Self {
+            interval: Duration::from_secs(env_u64("AETHER_DISCOVERY_INTERVAL_SECS", 60).max(1)),
+            max_candidates: env_u64("AETHER_DISCOVERY_MAX_CANDIDATES", 10).max(1) as usize,
+            max_admitted_pools: env_u64("AETHER_MAX_ADMITTED_POOLS", 500) as usize,
+            screen_timeout: Duration::from_millis(env_u64("AETHER_FOT_SCREEN_TIMEOUT_MS", 8_000).max(100)),
+            max_loss_bps: env_u64("AETHER_DISCOVERY_MAX_LOSS_BPS", 300) as u32,
+            eth_price_usd: std::env::var("AETHER_ETH_PRICE_USD")
+                .ok()
+                .and_then(|s| s.trim().parse::<f64>().ok())
+                .filter(|v| v.is_finite() && *v > 0.0)
+                .unwrap_or(3_000.0),
+            pools_path,
+            admission: AdmissionConfig::default(),
+            fot: FotConfig::default(),
+        }
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn now_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Spawn the discovery loop. Returns the task handle; the loop runs until the
+/// `shutdown` watch flips to `true`.
+pub fn spawn_discovery(
+    engine: Arc<AetherEngine>,
+    hot_tokens: Arc<HotTokenTracker>,
+    provider: DynProvider<Ethereum>,
+    metrics: Arc<EngineMetrics>,
+    cfg: DiscoveryConfig,
+    mut shutdown: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(cfg.interval);
+        // Consume the immediate first tick so the tracker can accumulate before
+        // the first real discovery pass.
+        ticker.tick().await;
+        let mut at_cap_logged = false;
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    run_discovery_tick(&engine, &hot_tokens, &provider, &metrics, &cfg, &mut at_cap_logged).await;
+                }
+                _ = shutdown.changed() => {
+                    if *shutdown.borrow() {
+                        info!("discovery loop shutting down");
+                        break;
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn run_discovery_tick(
+    engine: &Arc<AetherEngine>,
+    hot_tokens: &Arc<HotTokenTracker>,
+    provider: &DynProvider<Ethereum>,
+    metrics: &Arc<EngineMetrics>,
+    cfg: &DiscoveryConfig,
+    at_cap_logged: &mut bool,
+) {
+    let now = now_secs();
+    let candidates = hot_tokens.candidates(now, cfg.max_candidates);
+    metrics.set_hot_candidates(candidates.len() as i64);
+    if candidates.is_empty() {
+        return;
+    }
+
+    let current = count_pools(&cfg.pools_path);
+    if current >= cfg.max_admitted_pools {
+        if !*at_cap_logged {
+            warn!(
+                current,
+                cap = cfg.max_admitted_pools,
+                "discovery at admitted-pool cap; not admitting more"
+            );
+            *at_cap_logged = true;
+        }
+        metrics.inc_pools_rejected("at_cap");
+        return;
+    }
+    *at_cap_logged = false;
+
+    for hp in candidates {
+        let (token, base) = match weth_base(hp.token_a, hp.token_b) {
+            Some(tb) => tb,
+            None => {
+                metrics.inc_pools_rejected("no_weth_base");
+                continue;
+            }
+        };
+
+        let venues = enrich_venues(provider, token, base, cfg).await;
+        if venues.len() < cfg.admission.min_venues {
+            metrics.inc_pools_rejected("insufficient_venues");
+            continue;
+        }
+
+        // The round-trip screen needs a UniV2-style pair.
+        let v2 = venues
+            .iter()
+            .find(|v| matches!(v.protocol, ProtocolType::UniswapV2 | ProtocolType::SushiSwap));
+        let verdict = match v2 {
+            Some(v) => run_screen(provider, v.address, token, base, v.fee_bps, cfg).await,
+            None => RoundTripVerdict::Inconclusive {
+                reason: "no v2 venue for round-trip screen".into(),
+            },
+        };
+        metrics.inc_fot_screen(verdict.metric_label());
+        let fot = verdict.as_fot_verdict();
+
+        match pool_admission::evaluate(&venues, &fot, &cfg.admission) {
+            AdmissionOutcome::Admit(entries) => {
+                match pool_admission::append_admitted_pools(Path::new(&cfg.pools_path), &entries) {
+                    Ok(n) if n > 0 => {
+                        for _ in 0..n {
+                            metrics.inc_pools_admitted("admitted");
+                        }
+                        info!(
+                            token = %token,
+                            venues = entries.len(),
+                            appended = n,
+                            "discovery admitted pools; reloading registry"
+                        );
+                        engine.bootstrap_pools(&cfg.pools_path).await;
+                    }
+                    Ok(_) => metrics.inc_pools_rejected("already_present"),
+                    Err(e) => {
+                        warn!(error = %e, "discovery: append_admitted_pools failed");
+                        metrics.inc_pools_rejected("append_error");
+                    }
+                }
+            }
+            AdmissionOutcome::Reject { reason } => {
+                // Low-cardinality bucket derived from the gate's decision.
+                let label = if reason.contains("fee-on-transfer") {
+                    "fot_not_clean"
+                } else {
+                    "insufficient_liquidity"
+                };
+                debug!(token = %token, %reason, "discovery rejected candidate");
+                metrics.inc_pools_rejected(label);
+            }
+        }
+    }
+}
+
+/// Returns `(token, base)` with `base == WETH`, or `None` if neither side is WETH.
+fn weth_base(a: Address, b: Address) -> Option<(Address, Address)> {
+    if a == WETH {
+        Some((b, a))
+    } else if b == WETH {
+        Some((a, b))
+    } else {
+        None
+    }
+}
+
+/// Count `[[pools]]` blocks currently in the registry file.
+fn count_pools(path: &str) -> usize {
+    std::fs::read_to_string(path)
+        .map(|c| c.matches("[[pools]]").count())
+        .unwrap_or(0)
+}
+
+/// Resolve V2/Sushi/V3 venues for `token`/`base` and attach a liquidity proxy.
+async fn enrich_venues(
+    provider: &DynProvider<Ethereum>,
+    token: Address,
+    base: Address,
+    cfg: &DiscoveryConfig,
+) -> Vec<CandidateVenue> {
+    // UniV2/V3 canonical token0/token1 ordering is by address.
+    let (token0, token1) = if token < base { (token, base) } else { (base, token) };
+    let mut venues = Vec::new();
+
+    for (factory, protocol) in [
+        (UNIV2_FACTORY, ProtocolType::UniswapV2),
+        (SUSHI_FACTORY, ProtocolType::SushiSwap),
+    ] {
+        let cd = getPairCall {
+            tokenA: token,
+            tokenB: base,
+        }
+        .abi_encode();
+        if let Some(pair) = call_addr(provider, factory, cd).await {
+            if pair != Address::ZERO {
+                if let Some(liquidity_usd) = pool_weth_liquidity_usd(provider, pair, cfg).await {
+                    venues.push(CandidateVenue {
+                        protocol,
+                        address: pair,
+                        token0,
+                        token1,
+                        fee_bps: V2_FEE_BPS,
+                        tick_spacing: None,
+                        liquidity_usd,
+                    });
+                }
+            }
+        }
+    }
+
+    for (fee, tick_spacing) in V3_FEE_TIERS {
+        let cd = getPoolCall {
+            tokenA: token,
+            tokenB: base,
+            fee: U24::try_from(fee).expect("v3 fee tier fits u24"),
+        }
+        .abi_encode();
+        if let Some(pool) = call_addr(provider, UNIV3_FACTORY, cd).await {
+            if pool != Address::ZERO {
+                if let Some(liquidity_usd) = pool_weth_liquidity_usd(provider, pool, cfg).await {
+                    venues.push(CandidateVenue {
+                        protocol: ProtocolType::UniswapV3,
+                        address: pool,
+                        token0,
+                        token1,
+                        fee_bps: fee / 100,
+                        tick_spacing: Some(tick_spacing),
+                        liquidity_usd,
+                    });
+                }
+            }
+        }
+    }
+
+    venues
+}
+
+/// Liquidity proxy: `2 × (WETH held by `pool`) × eth_price_usd`.
+async fn pool_weth_liquidity_usd(
+    provider: &DynProvider<Ethereum>,
+    pool: Address,
+    cfg: &DiscoveryConfig,
+) -> Option<f64> {
+    let cd = balanceOfCall { account: pool }.abi_encode();
+    let weth_wei = call_u256(provider, WETH, cd).await?;
+    Some(2.0 * u256_to_eth_f64(weth_wei) * cfg.eth_price_usd)
+}
+
+async fn call_addr(
+    provider: &DynProvider<Ethereum>,
+    to: Address,
+    calldata: Vec<u8>,
+) -> Option<Address> {
+    let tx = alloy::rpc::types::TransactionRequest::default()
+        .to(to)
+        .input(calldata.into());
+    let out = provider.call(tx).await.ok()?;
+    if out.len() < 32 {
+        return None;
+    }
+    Some(Address::from_slice(&out[12..32]))
+}
+
+async fn call_u256(
+    provider: &DynProvider<Ethereum>,
+    to: Address,
+    calldata: Vec<u8>,
+) -> Option<U256> {
+    let tx = alloy::rpc::types::TransactionRequest::default()
+        .to(to)
+        .input(calldata.into());
+    let out = provider.call(tx).await.ok()?;
+    if out.len() < 32 {
+        return None;
+    }
+    Some(U256::from_be_slice(&out[..32]))
+}
+
+/// Convert a wei `U256` to whole ETH as `f64`. Lossy by design — only used for
+/// a coarse liquidity estimate, never for accounting.
+fn u256_to_eth_f64(v: U256) -> f64 {
+    v.to_string().parse::<f64>().unwrap_or(0.0) / 1e18
+}
+
+/// Run the fee-on-transfer round-trip screen against a fresh `latest` fork,
+/// bounded by `cfg.screen_timeout`. The screen is synchronous + CPU/IO-bound,
+/// so it runs on a blocking thread; a timeout maps to [`RoundTripVerdict::ScreenTimeout`].
+async fn run_screen(
+    provider: &DynProvider<Ethereum>,
+    pair: Address,
+    token: Address,
+    base: Address,
+    fee_bps: u32,
+    cfg: &DiscoveryConfig,
+) -> RoundTripVerdict {
+    let block_number = provider.get_block_number().await.unwrap_or(0);
+    let state = match RpcForkedState::new_at_latest(
+        provider.clone(),
+        block_number,
+        now_secs(),
+        1_000_000_000,
+    ) {
+        Some(s) => s,
+        None => {
+            return RoundTripVerdict::Inconclusive {
+                reason: "fork state unavailable (need multi-thread runtime)".into(),
+            }
+        }
+    };
+
+    let fot = cfg.fot.clone();
+    let max_loss = cfg.max_loss_bps;
+    let base_slot = U256::from(WETH_BALANCE_SLOT);
+    let budget = cfg.screen_timeout;
+    let join = tokio::task::spawn_blocking(move || {
+        fee_on_transfer::screen_token_v2_round_trip(
+            state, pair, token, base, base_slot, fee_bps, &fot, max_loss,
+        )
+    });
+    match tokio::time::timeout(budget, join).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(_join_err)) => RoundTripVerdict::Inconclusive {
+            reason: "screen task panicked".into(),
+        },
+        Err(_elapsed) => RoundTripVerdict::ScreenTimeout {
+            budget_ms: budget.as_millis() as u64,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn weth_base_orders_correctly() {
+        let other = address!("00000000000000000000000000000000000000Aa");
+        assert_eq!(weth_base(WETH, other), Some((other, WETH)));
+        assert_eq!(weth_base(other, WETH), Some((other, WETH)));
+        let nonweth = address!("00000000000000000000000000000000000000Bb");
+        assert_eq!(weth_base(other, nonweth), None);
+    }
+
+    #[test]
+    fn count_pools_counts_blocks() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            f,
+            "[[pools]]\naddress = \"0x1\"\n\n[[pools]]\naddress = \"0x2\"\n"
+        )
+        .unwrap();
+        assert_eq!(count_pools(f.path().to_str().unwrap()), 2);
+        assert_eq!(count_pools("/nonexistent/path/pools.toml"), 0);
+    }
+
+    #[test]
+    fn config_defaults_are_sane() {
+        let cfg = DiscoveryConfig::from_env("config/pools.toml".to_string());
+        assert!(cfg.interval >= Duration::from_secs(1));
+        assert!(cfg.max_candidates >= 1);
+        assert!(cfg.screen_timeout >= Duration::from_millis(100));
+        assert!(cfg.eth_price_usd > 0.0);
+    }
+
+    #[tokio::test]
+    async fn screen_timeout_maps_to_screen_timeout_verdict() {
+        // Mirrors run_screen's timeout arm: a blocking job slower than the
+        // budget yields Elapsed, which we map to ScreenTimeout.
+        let budget = Duration::from_millis(10);
+        let join =
+            tokio::task::spawn_blocking(|| std::thread::sleep(Duration::from_millis(200)));
+        let verdict = match tokio::time::timeout(budget, join).await {
+            Ok(_) => RoundTripVerdict::Inconclusive {
+                reason: "unexpected".into(),
+            },
+            Err(_) => RoundTripVerdict::ScreenTimeout {
+                budget_ms: budget.as_millis() as u64,
+            },
+        };
+        assert_eq!(verdict.metric_label(), "screen_timeout");
+        assert!(!verdict.as_fot_verdict().is_admissible());
+    }
+}

--- a/crates/grpc-server/src/hot_token.rs
+++ b/crates/grpc-server/src/hot_token.rs
@@ -1,0 +1,400 @@
+//! Mempool hot-token frequency tracker.
+//!
+//! Counts how often each *unordered* token pair appears in decoded pending-tx
+//! swaps, with exponential time-decay so the ranking reflects **recent**
+//! trading activity rather than all-time totals. It feeds two consumers:
+//!
+//!   1. **Operator visibility** — "which tokens is the mempool trading most
+//!      right now", surfaced by the periodic reporter in the mempool pipeline.
+//!   2. **The pool-admission gate** (follow-up work) — a ranked candidate list
+//!      of pairs whose pools are not yet in the registry, to be qualified
+//!      (≥2 venues, liquidity/age, fee-on-transfer screen) before admission.
+//!
+//! Design notes:
+//! - **Clock-injected.** `record` / `ranked` / `prune` take an explicit
+//!   `now_secs`, so the core ranking is fully deterministic and unit-testable
+//!   without a real clock or RPC. The pipeline supplies wall-clock seconds.
+//! - **Registry-agnostic.** The tracker never looks at the pool registry; it
+//!   only counts what the decoder emits. Cross-checking which pairs are already
+//!   registered (and the authoritative ≥2-qualified-venue check) is the
+//!   admission gate's job.
+//! - **Bounded memory.** [`HotTokenTracker::prune`] drops pairs once their
+//!   decayed score falls below a floor, so transient shitcoin churn does not
+//!   grow the table without bound.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use aether_pools::router_decoder::Protocol;
+use alloy::primitives::Address;
+
+/// Unordered token-pair key: the two token addresses sorted ascending so that
+/// `(A, B)` and `(B, A)` collapse to a single entry.
+pub type PairKey = (Address, Address);
+
+/// Canonicalise a token pair into a [`PairKey`] (addresses sorted ascending).
+#[inline]
+pub fn pair_key(a: Address, b: Address) -> PairKey {
+    if a <= b {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+/// Tuning for the tracker. Defaults target a ~5 min half-life — recent bursts
+/// dominate the ranking, while day-old noise decays toward zero.
+#[derive(Clone, Debug)]
+pub struct HotTokenConfig {
+    /// Decay half-life in seconds: a pair's score halves for every
+    /// `half_life_secs` of silence. Smaller = more reactive to fresh bursts.
+    pub half_life_secs: f64,
+    /// Drop a pair from the table once its decayed score falls below this floor
+    /// (keeps memory bounded as transient tokens go cold).
+    pub prune_below_score: f64,
+    /// Minimum distinct decoder-visible venues (protocol + optional pool) before
+    /// a pair is reported as an admission *candidate*. Coarse pre-filter only —
+    /// the authoritative "≥2 qualified venues" check belongs to the admission
+    /// gate, which queries factories/registry for the pair.
+    pub min_venues: usize,
+}
+
+impl Default for HotTokenConfig {
+    fn default() -> Self {
+        Self {
+            half_life_secs: 300.0,
+            prune_below_score: 0.05,
+            min_venues: 2,
+        }
+    }
+}
+
+/// Per-pair accumulator. `score` is only correct as of `last_update_secs`;
+/// callers must re-decay to "now" when reading (see [`decay_factor`]).
+#[derive(Clone, Debug)]
+struct PairStat {
+    score: f64,
+    last_update_secs: u64,
+    /// Raw lifetime hit count (never decays) — handy for sanity / debugging.
+    hits: u64,
+    /// Distinct decoder-visible venues: `(protocol_code, pool_address)`. V2 /
+    /// SushiSwap swaps carry no pool address in calldata (it is resolved
+    /// downstream via the registry pair-index), so they dedupe by protocol.
+    venues: Vec<(u8, Option<Address>)>,
+    first_seen_secs: u64,
+    last_seen_secs: u64,
+}
+
+/// One ranked hot pair, returned by [`HotTokenTracker::ranked`] /
+/// [`HotTokenTracker::candidates`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct HotPair {
+    pub token_a: Address,
+    pub token_b: Address,
+    /// Decayed activity score as of the queried `now_secs`.
+    pub score: f64,
+    pub hits: u64,
+    /// Count of distinct decoder-visible venues observed for this pair.
+    pub venues: usize,
+    pub first_seen_secs: u64,
+    pub last_seen_secs: u64,
+}
+
+/// Stable small-int code for a decoder protocol, used for venue de-duplication.
+fn protocol_code(p: Protocol) -> u8 {
+    match p {
+        Protocol::UniswapV2 => 1,
+        Protocol::UniswapV3 => 2,
+        Protocol::SushiSwap => 3,
+        Protocol::Curve => 4,
+        Protocol::BalancerV2 => 5,
+        Protocol::BancorV3 => 6,
+        Protocol::OneInchV6 => 7,
+    }
+}
+
+/// Multiplicative decay applied to a score after `dt_secs` of silence.
+/// `0.5 ^ (dt / half_life)` — i.e. one half-life halves the score.
+#[inline]
+fn decay_factor(dt_secs: u64, half_life_secs: f64) -> f64 {
+    if half_life_secs <= 0.0 {
+        return 1.0;
+    }
+    0.5_f64.powf(dt_secs as f64 / half_life_secs)
+}
+
+/// Thread-safe, time-decaying frequency counter over token pairs.
+///
+/// Written from the single mempool recv-loop task and read infrequently (the
+/// periodic reporter / admission gate), so a `Mutex<HashMap>` is more than
+/// adequate and avoids pulling in a concurrent map dependency.
+pub struct HotTokenTracker {
+    cfg: HotTokenConfig,
+    stats: Mutex<HashMap<PairKey, PairStat>>,
+}
+
+impl HotTokenTracker {
+    pub fn new(cfg: HotTokenConfig) -> Self {
+        Self {
+            cfg,
+            stats: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record one decoded swap observed at `now_secs`. `pool_address` is the
+    /// decoder-peeled pool when known (UniswapV3 / 1inch encode it in
+    /// calldata), `None` otherwise. Self-swaps (`token_in == token_out`) are
+    /// ignored.
+    pub fn record(
+        &self,
+        token_in: Address,
+        token_out: Address,
+        protocol: Protocol,
+        pool_address: Option<Address>,
+        now_secs: u64,
+    ) {
+        if token_in == token_out {
+            return;
+        }
+        let key = pair_key(token_in, token_out);
+        let venue = (protocol_code(protocol), pool_address);
+        let mut stats = self.stats.lock().expect("hot-token mutex poisoned");
+        let entry = stats.entry(key).or_insert_with(|| PairStat {
+            score: 0.0,
+            last_update_secs: now_secs,
+            hits: 0,
+            venues: Vec::new(),
+            first_seen_secs: now_secs,
+            last_seen_secs: now_secs,
+        });
+        // Decay the running score to `now` before adding this hit. Clamp the
+        // delta at zero so an out-of-order / regressing clock cannot inflate
+        // the score (it would otherwise raise 0.5 to a negative power).
+        let dt = now_secs.saturating_sub(entry.last_update_secs);
+        entry.score = entry.score * decay_factor(dt, self.cfg.half_life_secs) + 1.0;
+        entry.last_update_secs = entry.last_update_secs.max(now_secs);
+        entry.last_seen_secs = entry.last_seen_secs.max(now_secs);
+        entry.hits += 1;
+        if !entry.venues.contains(&venue) {
+            entry.venues.push(venue);
+        }
+    }
+
+    /// Decayed score for a single pair as of `now_secs` (0.0 if never seen).
+    pub fn score(&self, key: &PairKey, now_secs: u64) -> f64 {
+        let stats = self.stats.lock().expect("hot-token mutex poisoned");
+        stats
+            .get(key)
+            .map(|s| {
+                let dt = now_secs.saturating_sub(s.last_update_secs);
+                s.score * decay_factor(dt, self.cfg.half_life_secs)
+            })
+            .unwrap_or(0.0)
+    }
+
+    /// Number of distinct token pairs currently tracked.
+    pub fn len(&self) -> usize {
+        self.stats.lock().expect("hot-token mutex poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// All tracked pairs ranked by decayed score (descending) as of `now_secs`.
+    pub fn ranked(&self, now_secs: u64) -> Vec<HotPair> {
+        let stats = self.stats.lock().expect("hot-token mutex poisoned");
+        let mut out: Vec<HotPair> = stats
+            .iter()
+            .map(|(k, s)| {
+                let dt = now_secs.saturating_sub(s.last_update_secs);
+                HotPair {
+                    token_a: k.0,
+                    token_b: k.1,
+                    score: s.score * decay_factor(dt, self.cfg.half_life_secs),
+                    hits: s.hits,
+                    venues: s.venues.len(),
+                    first_seen_secs: s.first_seen_secs,
+                    last_seen_secs: s.last_seen_secs,
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        out
+    }
+
+    /// Top-`n` hot pairs meeting the `min_venues` pre-filter — the admission
+    /// candidate list. The caller cross-checks the registry to keep only pairs
+    /// whose pools are not already tracked.
+    pub fn candidates(&self, now_secs: u64, n: usize) -> Vec<HotPair> {
+        self.ranked(now_secs)
+            .into_iter()
+            .filter(|p| p.venues >= self.cfg.min_venues)
+            .take(n)
+            .collect()
+    }
+
+    /// Drop pairs whose decayed score has fallen below `prune_below_score`.
+    /// Returns the number of pairs removed. Call periodically to bound memory.
+    pub fn prune(&self, now_secs: u64) -> usize {
+        let mut stats = self.stats.lock().expect("hot-token mutex poisoned");
+        let before = stats.len();
+        let half_life = self.cfg.half_life_secs;
+        let floor = self.cfg.prune_below_score;
+        stats.retain(|_, s| {
+            let dt = now_secs.saturating_sub(s.last_update_secs);
+            s.score * decay_factor(dt, half_life) >= floor
+        });
+        before - stats.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(b: u8) -> Address {
+        Address::repeat_byte(b)
+    }
+
+    #[test]
+    fn pair_key_is_order_independent() {
+        let a = addr(0x11);
+        let b = addr(0x22);
+        assert_eq!(pair_key(a, b), pair_key(b, a));
+        // Sorted ascending.
+        assert_eq!(pair_key(b, a), (a, b));
+    }
+
+    #[test]
+    fn record_counts_hits_and_score() {
+        let t = HotTokenTracker::new(HotTokenConfig::default());
+        let (a, b) = (addr(1), addr(2));
+        t.record(a, b, Protocol::UniswapV2, None, 0);
+        t.record(b, a, Protocol::UniswapV2, None, 0); // reverse order, same pair
+        let ranked = t.ranked(0);
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].hits, 2);
+        // Two same-instant hits with no decay => score 2.0.
+        assert!((ranked[0].score - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn self_swap_is_ignored() {
+        let t = HotTokenTracker::new(HotTokenConfig::default());
+        let a = addr(7);
+        t.record(a, a, Protocol::UniswapV2, None, 0);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn score_halves_after_one_half_life() {
+        let cfg = HotTokenConfig {
+            half_life_secs: 100.0,
+            ..HotTokenConfig::default()
+        };
+        let t = HotTokenTracker::new(cfg);
+        let (a, b) = (addr(1), addr(2));
+        t.record(a, b, Protocol::UniswapV2, None, 0); // score = 1.0 at t=0
+        let key = pair_key(a, b);
+        // Read 100s later: one half-life => 0.5.
+        assert!((t.score(&key, 100) - 0.5).abs() < 1e-9);
+        // 200s later => 0.25.
+        assert!((t.score(&key, 200) - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn decayed_record_accumulates_correctly() {
+        let cfg = HotTokenConfig {
+            half_life_secs: 100.0,
+            ..HotTokenConfig::default()
+        };
+        let t = HotTokenTracker::new(cfg);
+        let (a, b) = (addr(1), addr(2));
+        t.record(a, b, Protocol::UniswapV2, None, 0); // 1.0 at t=0
+        t.record(a, b, Protocol::UniswapV2, None, 100); // decay 1.0->0.5, +1 => 1.5
+        let key = pair_key(a, b);
+        assert!((t.score(&key, 100) - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn venues_dedupe_by_protocol_and_pool() {
+        let t = HotTokenTracker::new(HotTokenConfig::default());
+        let (a, b) = (addr(1), addr(2));
+        // Same protocol, no pool address -> one venue however many hits.
+        t.record(a, b, Protocol::UniswapV2, None, 0);
+        t.record(a, b, Protocol::UniswapV2, None, 0);
+        assert_eq!(t.ranked(0)[0].venues, 1);
+        // A different protocol adds a venue.
+        t.record(a, b, Protocol::SushiSwap, None, 0);
+        assert_eq!(t.ranked(0)[0].venues, 2);
+        // Distinct V3 pools count separately.
+        t.record(a, b, Protocol::UniswapV3, Some(addr(0xAA)), 0);
+        t.record(a, b, Protocol::UniswapV3, Some(addr(0xBB)), 0);
+        assert_eq!(t.ranked(0)[0].venues, 4);
+    }
+
+    #[test]
+    fn ranked_orders_by_decayed_score() {
+        let t = HotTokenTracker::new(HotTokenConfig::default());
+        let (a, b, c) = (addr(1), addr(2), addr(3));
+        // pair (a,b) hit twice, (a,c) once -> (a,b) ranks first.
+        t.record(a, b, Protocol::UniswapV2, None, 0);
+        t.record(a, b, Protocol::UniswapV2, None, 0);
+        t.record(a, c, Protocol::UniswapV2, None, 0);
+        let ranked = t.ranked(0);
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(pair_key(ranked[0].token_a, ranked[0].token_b), pair_key(a, b));
+    }
+
+    #[test]
+    fn candidates_filter_by_min_venues_and_take_n() {
+        let cfg = HotTokenConfig {
+            min_venues: 2,
+            ..HotTokenConfig::default()
+        };
+        let t = HotTokenTracker::new(cfg);
+        let (a, b, c) = (addr(1), addr(2), addr(3));
+        // (a,b): 2 venues -> candidate. (a,c): 1 venue -> excluded.
+        t.record(a, b, Protocol::UniswapV2, None, 0);
+        t.record(a, b, Protocol::SushiSwap, None, 0);
+        t.record(a, c, Protocol::UniswapV2, None, 0);
+        let cands = t.candidates(0, 10);
+        assert_eq!(cands.len(), 1);
+        assert_eq!(pair_key(cands[0].token_a, cands[0].token_b), pair_key(a, b));
+        // take(n) bounds output.
+        assert_eq!(t.candidates(0, 0).len(), 0);
+    }
+
+    #[test]
+    fn prune_drops_cold_pairs() {
+        let cfg = HotTokenConfig {
+            half_life_secs: 10.0,
+            prune_below_score: 0.1,
+            ..HotTokenConfig::default()
+        };
+        let t = HotTokenTracker::new(cfg);
+        let (a, b) = (addr(1), addr(2));
+        t.record(a, b, Protocol::UniswapV2, None, 0); // score 1.0 at t=0
+        // After ~4 half-lives (40s) score ~0.0625 < 0.1 floor -> pruned.
+        let removed = t.prune(40);
+        assert_eq!(removed, 1);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn clock_regression_does_not_panic_or_inflate() {
+        let t = HotTokenTracker::new(HotTokenConfig::default());
+        let (a, b) = (addr(1), addr(2));
+        t.record(a, b, Protocol::UniswapV2, None, 1000);
+        // A later record with an earlier timestamp must not raise score above
+        // the no-decay sum (clamped dt = 0).
+        t.record(a, b, Protocol::UniswapV2, None, 500);
+        let key = pair_key(a, b);
+        assert!(t.score(&key, 1000) <= 2.0 + 1e-9);
+    }
+}

--- a/crates/grpc-server/src/lib.rs
+++ b/crates/grpc-server/src/lib.rs
@@ -8,7 +8,9 @@
 pub mod cycle_gating;
 pub mod first_seen_tracker;
 pub mod historical;
+pub mod hot_token;
 pub(crate) mod metrics;
+pub mod pool_admission;
 pub mod profitability_writer;
 pub mod provider;
 

--- a/crates/grpc-server/src/main.rs
+++ b/crates/grpc-server/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 use tonic::transport::Server;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -11,6 +11,7 @@ use tokio::net::UnixListener;
 #[cfg(unix)]
 use tokio_stream::wrappers::UnixListenerStream;
 
+mod discovery;
 mod engine;
 mod mempool_pipeline;
 mod mempool_writer;
@@ -134,11 +135,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             None
         } else {
+            // Idle-watchdog window for the pending-tx subscription. Default
+            // 60s; set 0 to disable. Guards against a silent TCP half-close
+            // stalling ingestion until the OS keepalive fires.
+            let idle_timeout_secs = std::env::var("MEMPOOL_WS_IDLE_TIMEOUT_SECS")
+                .ok()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .unwrap_or_else(|| {
+                    aether_ingestion::mempool::IDLE_TIMEOUT_DEFAULT.as_secs()
+                });
             let cfg = aether_ingestion::mempool::AlchemyMempoolConfig {
                 ws_url,
                 router_filter: aether_ingestion::mempool::default_router_addresses(),
+                idle_timeout: std::time::Duration::from_secs(idle_timeout_secs),
             };
-            let source = Arc::new(aether_ingestion::mempool::AlchemyMempool::new(cfg));
+            // Register the ingestion-layer metrics on the shared registry so
+            // the re-encode-mismatch and idle-reconnect counters surface on
+            // `/metrics`. Without this the source runs metric-blind.
+            let ingest_metrics = aether_ingestion::metrics::MempoolIngestMetrics::register(
+                metrics.registry(),
+            );
+            let source = Arc::new(aether_ingestion::mempool::AlchemyMempool::with_metrics(
+                cfg,
+                ingest_metrics,
+            ));
             let channels = Arc::clone(engine.event_channels());
             let source_shutdown = shutdown_rx.clone();
             let source_handle = tokio::spawn(async move {
@@ -220,6 +240,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             sim_ctx_inner =
                 sim_ctx_inner.with_v2_reserves_cache(Some(engine.v2_reserves_cache()));
             let sim_ctx = Arc::new(sim_ctx_inner);
+
+            // Hot-token discovery loop (Part 1). Opt-in via AETHER_DISCOVERY=1;
+            // shares the SimContext's HotTokenTracker so it sees the same
+            // mempool-observed candidates. Runs off the decode hot path; admits
+            // qualifying pools to pools.toml and reloads the registry in-process.
+            if std::env::var("AETHER_DISCOVERY")
+                .map(|v| v == "1")
+                .unwrap_or(false)
+            {
+                if let Some(provider) = engine.rpc_provider() {
+                    let disc_cfg = discovery::DiscoveryConfig::from_env(pools_config.clone());
+                    let _discovery_handle = discovery::spawn_discovery(
+                        Arc::clone(&engine),
+                        Arc::clone(&sim_ctx.hot_tokens),
+                        provider,
+                        Arc::clone(&metrics),
+                        disc_cfg,
+                        shutdown_rx.clone(),
+                    );
+                    info!("AETHER_DISCOVERY enabled — hot-token discovery loop started");
+                } else {
+                    warn!("AETHER_DISCOVERY=1 but no RPC provider (set ETH_RPC_URL); discovery disabled");
+                }
+            }
+
             let pipeline_handle = mempool_pipeline::spawn_mempool_pipeline(
                 Arc::clone(engine.event_channels()),
                 Arc::clone(&metrics),

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -56,6 +56,7 @@ use uuid::Uuid;
 use crate::service::aether_proto;
 
 use crate::engine::PoolMetadata;
+use aether_grpc_server::hot_token::{HotTokenConfig, HotTokenTracker};
 use crate::mempool_writer::{
     MempoolPredictionSink, NewMempoolPrediction, PredictedPostState, PROTOCOL_BALANCER,
     PROTOCOL_BANCOR, PROTOCOL_CURVE, PROTOCOL_ONE_INCH_V6, PROTOCOL_SUSHI, PROTOCOL_UNI_V2, PROTOCOL_UNI_V3,
@@ -192,6 +193,12 @@ pub struct SimContext {
     /// `eth_getStorageAt`. `None` retains the pre-existing RPC-every-time
     /// behaviour.
     pub v2_reserves_cache: Option<aether_simulator::v2_reserves_cache::V2ReservesCache>,
+    /// Frequency-of-trade tracker over decoded mempool swaps, powering the
+    /// hot-token discovery loop (`AETHER_DISCOVERY=1`, see `discovery.rs`).
+    /// Every decoded swap is `record`ed here; the discovery loop reads
+    /// `candidates()` as its pool-admission source. Always present — cheap
+    /// when discovery is disabled (the loop simply never spawns).
+    pub hot_tokens: Arc<HotTokenTracker>,
 }
 
 impl SimContext {
@@ -220,6 +227,7 @@ impl SimContext {
             mempool_prewarm: Arc::new(ArcSwap::from_pointee(None)),
             bytecode_cache: None,
             v2_reserves_cache: None,
+            hot_tokens: Arc::new(HotTokenTracker::new(HotTokenConfig::default())),
         }
     }
 
@@ -527,6 +535,20 @@ fn handle_event(
             for swap in swaps {
                 emit_decoded(metrics, &router_label, &swap, &event);
                 let Some(ctx) = sim_ctx else { continue };
+                // Feed the hot-token discovery tracker before the pre-sim
+                // filter drops unregistered pairs — discovery surfaces fresh,
+                // frequently-traded tokens precisely from pairs not yet in the
+                // pool registry.
+                ctx.hot_tokens.record(
+                    swap.token_in,
+                    swap.token_out,
+                    swap.protocol,
+                    swap.pool_address,
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                );
                 if !pre_sim_filter(metrics, ctx, &swap) {
                     continue;
                 }

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -19,6 +19,19 @@ pub struct EngineMetrics {
     arbs_published: IntCounter,
     blocks_processed: IntCounter,
     decode_errors: IntCounterVec,
+    /// Hot-token discovery: pools appended to pools.toml, by reason
+    /// (low-cardinality; currently just `admitted`).
+    pools_admitted_total: IntCounterVec,
+    /// Hot-token discovery: candidate pairs rejected, by low-cardinality reason
+    /// (`no_weth_base`, `insufficient_venues`, `fot_not_clean`,
+    /// `insufficient_liquidity`, `at_cap`, `already_present`, `append_error`).
+    pools_rejected_total: IntCounterVec,
+    /// Hot-token discovery: fee-on-transfer round-trip screen outcomes, by
+    /// verdict (`clean`, `fee_on_transfer`, `honeypot`, `inconclusive`,
+    /// `screen_timeout`).
+    fot_screen_total: IntCounterVec,
+    /// Hot-token discovery: hot candidate pairs seen in the most recent tick.
+    hot_candidates: IntGauge,
     /// Counter for EVM fork-replay fallbacks invoked from the analytical
     /// post-state predictors. Bumped whenever an analytical predictor
     /// returns a low-confidence result and the caller escalates to an
@@ -468,6 +481,35 @@ impl EngineMetrics {
             "Multicall3 batches that errored and forced a per-pool eth_getStorageAt fallback",
         )
         .expect("aether_prewarm_multicall_fallbacks_total counter");
+        let pools_admitted_total = IntCounterVec::new(
+            Opts::new(
+                "aether_pools_admitted_total",
+                "Hot-token discovery: pools appended to pools.toml, by reason",
+            ),
+            &["reason"],
+        )
+        .expect("aether_pools_admitted_total counter vec");
+        let pools_rejected_total = IntCounterVec::new(
+            Opts::new(
+                "aether_pools_rejected_total",
+                "Hot-token discovery: candidate pairs rejected, by reason",
+            ),
+            &["reason"],
+        )
+        .expect("aether_pools_rejected_total counter vec");
+        let fot_screen_total = IntCounterVec::new(
+            Opts::new(
+                "aether_fot_screen_total",
+                "Hot-token discovery: fee-on-transfer round-trip screen outcomes, by verdict",
+            ),
+            &["verdict"],
+        )
+        .expect("aether_fot_screen_total counter vec");
+        let hot_candidates = IntGauge::new(
+            "aether_hot_candidates",
+            "Hot-token discovery: hot candidate pairs seen in the most recent tick",
+        )
+        .expect("aether_hot_candidates gauge");
 
         registry
             .register(Box::new(detection_latency_ms.clone()))
@@ -574,6 +616,18 @@ impl EngineMetrics {
         registry
             .register(Box::new(prewarm_multicall_fallbacks_total.clone()))
             .expect("register aether_prewarm_multicall_fallbacks_total");
+        registry
+            .register(Box::new(pools_admitted_total.clone()))
+            .expect("register aether_pools_admitted_total");
+        registry
+            .register(Box::new(pools_rejected_total.clone()))
+            .expect("register aether_pools_rejected_total");
+        registry
+            .register(Box::new(fot_screen_total.clone()))
+            .expect("register aether_fot_screen_total");
+        registry
+            .register(Box::new(hot_candidates.clone()))
+            .expect("register aether_hot_candidates");
 
         // Pre-touch every label so dashboards see zero rows from boot.
         for ev in &[
@@ -603,6 +657,30 @@ impl EngineMetrics {
                 .with_label_values(&[outcome])
                 .reset();
         }
+
+        // Pre-touch hot-token discovery label sets so dashboards render zero
+        // rows from boot rather than "No data".
+        for v in [
+            "clean",
+            "fee_on_transfer",
+            "honeypot",
+            "inconclusive",
+            "screen_timeout",
+        ] {
+            fot_screen_total.with_label_values(&[v]);
+        }
+        for r in [
+            "no_weth_base",
+            "insufficient_venues",
+            "fot_not_clean",
+            "insufficient_liquidity",
+            "at_cap",
+            "already_present",
+            "append_error",
+        ] {
+            pools_rejected_total.with_label_values(&[r]);
+        }
+        pools_admitted_total.with_label_values(&["admitted"]);
 
         Self {
             registry,
@@ -641,6 +719,10 @@ impl EngineMetrics {
             prewarm_multicall_batches_total,
             prewarm_multicall_v2_slots_total,
             prewarm_multicall_fallbacks_total,
+            pools_admitted_total,
+            pools_rejected_total,
+            fot_screen_total,
+            hot_candidates,
         }
     }
 
@@ -787,6 +869,28 @@ impl EngineMetrics {
     /// stable and enumerable for dashboards / alerts.
     pub fn inc_decode_errors(&self, reason: &str) {
         self.decode_errors.with_label_values(&[reason]).inc();
+    }
+
+    /// Bump `aether_pools_admitted_total{reason}` (hot-token discovery).
+    pub fn inc_pools_admitted(&self, reason: &str) {
+        self.pools_admitted_total.with_label_values(&[reason]).inc();
+    }
+
+    /// Bump `aether_pools_rejected_total{reason}` (hot-token discovery). Reason
+    /// must be from the pre-touched low-cardinality set.
+    pub fn inc_pools_rejected(&self, reason: &str) {
+        self.pools_rejected_total.with_label_values(&[reason]).inc();
+    }
+
+    /// Bump `aether_fot_screen_total{verdict}` (hot-token discovery). Verdict
+    /// comes from `RoundTripVerdict::metric_label()`.
+    pub fn inc_fot_screen(&self, verdict: &str) {
+        self.fot_screen_total.with_label_values(&[verdict]).inc();
+    }
+
+    /// Set `aether_hot_candidates` to the latest discovery tick's count.
+    pub fn set_hot_candidates(&self, n: i64) {
+        self.hot_candidates.set(n);
     }
 
     /// Bump `aether_sim_evm_fallback_total{reason="..."}` for an EVM

--- a/crates/grpc-server/src/pool_admission.rs
+++ b/crates/grpc-server/src/pool_admission.rs
@@ -1,0 +1,405 @@
+//! Pool-admission gate for hot-token candidates.
+//!
+//! Turns a frequently-traded candidate pair (surfaced by [`crate::hot_token`])
+//! into registered, arbitrageable pools — but only after it clears a safety
+//! gate. The admission flow:
+//!
+//! ```text
+//! hot_tokens.candidates()                         (C1 — ranked new pairs)
+//!   └─► enrich: factory getPair/getPool + reserves (integration layer)
+//!         └─► fee-on-transfer / honeypot screen     (C2 — fee_on_transfer)
+//!               └─► evaluate(venues, fot, cfg)       (this module — pure)
+//!                     └─► append_admitted_pools()    (this module — writes TOML)
+//!                           └─► ControlService.ReloadConfig / bootstrap_pools
+//! ```
+//!
+//! `ReloadConfig` re-reads the whole `pools.toml` and re-registers every entry
+//! (idempotent), so admission is simply: **append new `[[pools]]` blocks, then
+//! reload**. This module owns the two pieces that are pure and unit-testable —
+//! the admit/reject *decision* and the dedup-aware TOML *writer*. The
+//! enrichment (factory lookups, reserves, the buy→sell round-trip) and the
+//! reload trigger are the surrounding integration layer.
+//!
+//! Safety stance: the gate **fails closed**. A token is admitted only when the
+//! fee-on-transfer screen is `Clean` AND at least `min_venues` venues clear the
+//! liquidity floor. Anything else is rejected with a reason.
+
+use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+use aether_common::types::ProtocolType;
+use aether_simulator::fee_on_transfer::FotVerdict;
+use alloy::primitives::Address;
+
+/// Thresholds governing admission.
+#[derive(Clone, Debug)]
+pub struct AdmissionConfig {
+    /// Minimum distinct venues (above the liquidity floor) a pair must trade on
+    /// before any of its pools are admitted. Atomic arbitrage needs a price gap
+    /// between ≥2 venues, so this is 2 by default.
+    pub min_venues: usize,
+    /// Per-venue USD liquidity floor.
+    pub min_liquidity_usd: f64,
+    /// Reject unless the fee-on-transfer screen returned `Clean`.
+    pub require_fot_clean: bool,
+    /// Tier assigned to admitted pools (`"warm"` keeps new tokens off the
+    /// every-block hot path until they prove out).
+    pub tier: String,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self {
+            min_venues: 2,
+            min_liquidity_usd: 25_000.0,
+            require_fot_clean: true,
+            tier: "warm".to_string(),
+        }
+    }
+}
+
+/// A discovered venue for a candidate pair, enriched with on-chain facts by the
+/// integration layer (factory lookup + reserves). Input to [`evaluate`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct CandidateVenue {
+    pub protocol: ProtocolType,
+    pub address: Address,
+    pub token0: Address,
+    pub token1: Address,
+    pub fee_bps: u32,
+    pub tick_spacing: Option<i32>,
+    pub liquidity_usd: f64,
+}
+
+impl CandidateVenue {
+    fn to_entry(&self, tier: &str) -> PoolEntryToml {
+        PoolEntryToml {
+            protocol: self.protocol,
+            address: self.address,
+            token0: self.token0,
+            token1: self.token1,
+            fee_bps: self.fee_bps,
+            tick_spacing: self.tick_spacing,
+            tier: tier.to_string(),
+        }
+    }
+}
+
+/// A fully-resolved pool ready to be written as a `[[pools]]` block.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PoolEntryToml {
+    pub protocol: ProtocolType,
+    pub address: Address,
+    pub token0: Address,
+    pub token1: Address,
+    pub fee_bps: u32,
+    pub tick_spacing: Option<i32>,
+    pub tier: String,
+}
+
+/// Result of the admission decision.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AdmissionOutcome {
+    /// Admit these pool entries (one per qualifying venue).
+    Admit(Vec<PoolEntryToml>),
+    /// Reject the candidate, with a human-readable reason.
+    Reject { reason: String },
+}
+
+/// The `protocol` string `pools.toml` / `bootstrap_pools` expects.
+pub fn protocol_toml_str(p: ProtocolType) -> &'static str {
+    match p {
+        ProtocolType::UniswapV2 => "uniswap_v2",
+        ProtocolType::UniswapV3 => "uniswap_v3",
+        ProtocolType::SushiSwap => "sushiswap",
+        ProtocolType::Curve => "curve",
+        ProtocolType::BalancerV2 => "balancer_v2",
+        ProtocolType::BancorV3 => "bancor_v3",
+    }
+}
+
+/// Decide whether a candidate's venues should be admitted. Pure — all on-chain
+/// facts are already baked into `venues` and `fot`.
+pub fn evaluate(
+    venues: &[CandidateVenue],
+    fot: &FotVerdict,
+    cfg: &AdmissionConfig,
+) -> AdmissionOutcome {
+    if cfg.require_fot_clean && !fot.is_admissible() {
+        return AdmissionOutcome::Reject {
+            reason: format!("fee-on-transfer screen not clean: {fot:?}"),
+        };
+    }
+    let qualified: Vec<&CandidateVenue> = venues
+        .iter()
+        .filter(|v| v.liquidity_usd >= cfg.min_liquidity_usd)
+        .collect();
+    if qualified.len() < cfg.min_venues {
+        return AdmissionOutcome::Reject {
+            reason: format!(
+                "{} venue(s) above ${:.0} liquidity; need {}",
+                qualified.len(),
+                cfg.min_liquidity_usd,
+                cfg.min_venues
+            ),
+        };
+    }
+    let entries = qualified.iter().map(|v| v.to_entry(&cfg.tier)).collect();
+    AdmissionOutcome::Admit(entries)
+}
+
+/// Render one pool as a `pools.toml` `[[pools]]` block (trailing newline). The
+/// field order and `protocol` strings match what `bootstrap_pools` parses.
+pub fn format_pool_entry(e: &PoolEntryToml) -> String {
+    let mut s = String::new();
+    s.push_str("[[pools]]\n");
+    s.push_str(&format!("protocol = \"{}\"\n", protocol_toml_str(e.protocol)));
+    s.push_str(&format!("address = \"{}\"\n", e.address.to_checksum(None)));
+    s.push_str(&format!("token0 = \"{}\"\n", e.token0.to_checksum(None)));
+    s.push_str(&format!("token1 = \"{}\"\n", e.token1.to_checksum(None)));
+    s.push_str(&format!("fee_bps = {}\n", e.fee_bps));
+    s.push_str(&format!("tier = \"{}\"\n", e.tier));
+    if let Some(ts) = e.tick_spacing {
+        s.push_str(&format!("tick_spacing = {ts}\n"));
+    }
+    s
+}
+
+/// Lower-cased set of pool `address = "..."` values already present in the file
+/// (empty if the file is missing/unreadable). Used to keep admission idempotent.
+fn read_existing_addresses(path: &Path) -> HashSet<String> {
+    let mut set = HashSet::new();
+    if let Ok(contents) = std::fs::read_to_string(path) {
+        for line in contents.lines() {
+            let t = line.trim();
+            if let Some(rest) = t.strip_prefix("address") {
+                if let Some(open) = rest.find('"') {
+                    if let Some(len) = rest[open + 1..].find('"') {
+                        set.insert(rest[open + 1..open + 1 + len].to_lowercase());
+                    }
+                }
+            }
+        }
+    }
+    set
+}
+
+/// Append admitted pool entries to `pools.toml`, skipping any address already
+/// present in the file or earlier in `entries` (so admission is idempotent and
+/// re-running the gate never duplicates a pool). Returns how many were written.
+///
+/// Caller must trigger a config reload afterwards (`ControlService.ReloadConfig`
+/// / `AetherEngine::bootstrap_pools`) for the appended pools to take effect.
+pub fn append_admitted_pools(path: &Path, entries: &[PoolEntryToml]) -> std::io::Result<usize> {
+    let mut seen = read_existing_addresses(path);
+    let mut blocks = String::new();
+    let mut appended = 0usize;
+    for e in entries {
+        let key = e.address.to_checksum(None).to_lowercase();
+        if !seen.insert(key) {
+            continue; // already in the file or earlier in this batch
+        }
+        blocks.push('\n');
+        blocks.push_str(&format_pool_entry(e));
+        appended += 1;
+    }
+    if appended > 0 {
+        let mut f = OpenOptions::new().create(true).append(true).open(path)?;
+        writeln!(
+            f,
+            "\n# ---------------------------------------------------------------------------"
+        )?;
+        writeln!(f, "# Auto-discovered pools (hot-token admission gate)")?;
+        writeln!(
+            f,
+            "# ---------------------------------------------------------------------------"
+        )?;
+        f.write_all(blocks.as_bytes())?;
+    }
+    Ok(appended)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(b: u8) -> Address {
+        Address::repeat_byte(b)
+    }
+
+    fn venue(protocol: ProtocolType, a: u8, liq: f64) -> CandidateVenue {
+        CandidateVenue {
+            protocol,
+            address: addr(a),
+            token0: addr(0xAA),
+            token1: addr(0xBB),
+            fee_bps: 30,
+            tick_spacing: None,
+            liquidity_usd: liq,
+        }
+    }
+
+    fn cfg() -> AdmissionConfig {
+        AdmissionConfig {
+            min_venues: 2,
+            min_liquidity_usd: 25_000.0,
+            require_fot_clean: true,
+            tier: "warm".into(),
+        }
+    }
+
+    #[test]
+    fn rejects_when_fot_not_clean() {
+        let venues = vec![
+            venue(ProtocolType::UniswapV2, 1, 100_000.0),
+            venue(ProtocolType::SushiSwap, 2, 100_000.0),
+        ];
+        let out = evaluate(&venues, &FotVerdict::FeeOnTransfer { tax_bps: 500 }, &cfg());
+        assert!(matches!(out, AdmissionOutcome::Reject { .. }));
+    }
+
+    #[test]
+    fn rejects_when_too_few_qualified_venues() {
+        // Two venues but only one clears the liquidity floor.
+        let venues = vec![
+            venue(ProtocolType::UniswapV2, 1, 100_000.0),
+            venue(ProtocolType::SushiSwap, 2, 1_000.0),
+        ];
+        let out = evaluate(&venues, &FotVerdict::Clean { observed_tax_bps: 0 }, &cfg());
+        assert!(matches!(out, AdmissionOutcome::Reject { .. }));
+    }
+
+    #[test]
+    fn admits_two_qualified_clean_venues() {
+        let venues = vec![
+            venue(ProtocolType::UniswapV2, 1, 100_000.0),
+            venue(ProtocolType::SushiSwap, 2, 50_000.0),
+        ];
+        let out = evaluate(&venues, &FotVerdict::Clean { observed_tax_bps: 0 }, &cfg());
+        match out {
+            AdmissionOutcome::Admit(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].tier, "warm");
+            }
+            other => panic!("expected admit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn format_v2_entry_matches_schema() {
+        let e = PoolEntryToml {
+            protocol: ProtocolType::UniswapV2,
+            address: addr(0x11),
+            token0: addr(0xAA),
+            token1: addr(0xBB),
+            fee_bps: 30,
+            tick_spacing: None,
+            tier: "warm".into(),
+        };
+        let toml = format_pool_entry(&e);
+        assert!(toml.contains("protocol = \"uniswap_v2\""));
+        assert!(toml.contains("fee_bps = 30"));
+        assert!(toml.contains("tier = \"warm\""));
+        assert!(!toml.contains("tick_spacing"));
+        // Round-trips through the same parser bootstrap_pools uses.
+        #[derive(serde::Deserialize)]
+        struct P {
+            pools: Vec<Entry>,
+        }
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct Entry {
+            protocol: String,
+            address: String,
+            token0: String,
+            token1: String,
+            fee_bps: u32,
+        }
+        let parsed: P = toml::from_str(&toml).expect("admitted entry must parse");
+        assert_eq!(parsed.pools.len(), 1);
+        assert_eq!(parsed.pools[0].protocol, "uniswap_v2");
+        assert_eq!(parsed.pools[0].fee_bps, 30);
+    }
+
+    #[test]
+    fn format_v3_entry_includes_tick_spacing() {
+        let e = PoolEntryToml {
+            protocol: ProtocolType::UniswapV3,
+            address: addr(0x11),
+            token0: addr(0xAA),
+            token1: addr(0xBB),
+            fee_bps: 5,
+            tick_spacing: Some(10),
+            tier: "warm".into(),
+        };
+        let toml = format_pool_entry(&e);
+        assert!(toml.contains("protocol = \"uniswap_v3\""));
+        assert!(toml.contains("tick_spacing = 10"));
+    }
+
+    #[test]
+    fn append_dedups_against_file_and_batch() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // Seed the file with one existing pool (lower-cased address on disk).
+        let existing = addr(0x11);
+        std::fs::write(
+            tmp.path(),
+            format!(
+                "[[pools]]\nprotocol = \"uniswap_v2\"\naddress = \"{}\"\ntoken0 = \"{}\"\ntoken1 = \"{}\"\nfee_bps = 30\ntier = \"hot\"\n",
+                existing.to_checksum(None).to_lowercase(),
+                addr(0xAA).to_checksum(None),
+                addr(0xBB).to_checksum(None),
+            ),
+        )
+        .unwrap();
+
+        let entries = vec![
+            // Already present (different case) -> skipped.
+            PoolEntryToml {
+                protocol: ProtocolType::UniswapV2,
+                address: existing,
+                token0: addr(0xAA),
+                token1: addr(0xBB),
+                fee_bps: 30,
+                tick_spacing: None,
+                tier: "warm".into(),
+            },
+            // New -> appended.
+            PoolEntryToml {
+                protocol: ProtocolType::SushiSwap,
+                address: addr(0x22),
+                token0: addr(0xAA),
+                token1: addr(0xBB),
+                fee_bps: 30,
+                tick_spacing: None,
+                tier: "warm".into(),
+            },
+            // Duplicate of the new one within the same batch -> skipped.
+            PoolEntryToml {
+                protocol: ProtocolType::SushiSwap,
+                address: addr(0x22),
+                token0: addr(0xAA),
+                token1: addr(0xBB),
+                fee_bps: 30,
+                tick_spacing: None,
+                tier: "warm".into(),
+            },
+        ];
+
+        let n = append_admitted_pools(tmp.path(), &entries).unwrap();
+        assert_eq!(n, 1, "only the one genuinely-new pool should be appended");
+
+        // Second run with the same input appends nothing (idempotent).
+        let n2 = append_admitted_pools(tmp.path(), &entries).unwrap();
+        assert_eq!(n2, 0);
+
+        let final_contents = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(
+            final_contents.matches("[[pools]]").count(),
+            2,
+            "file should hold exactly the original + one admitted pool"
+        );
+    }
+}

--- a/crates/ingestion/src/mempool.rs
+++ b/crates/ingestion/src/mempool.rs
@@ -41,6 +41,15 @@ use crate::subscription::{EventChannels, PendingTxEvent};
 /// Default reconnect backoff after a transport error.
 const RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
 
+/// Default idle-watchdog window. If no pending tx is delivered within this
+/// span the connection is assumed dead and dropped so the reconnect loop
+/// re-establishes it. Without this a silent TCP half-close (the peer vanishes
+/// without a FIN/RST) leaves `stream.next()` parked indefinitely — up to the
+/// OS keepalive (~2 h on Linux defaults) — so the subscription silently stops
+/// delivering events while every health signal still looks "connected".
+/// Override via `MEMPOOL_WS_IDLE_TIMEOUT_SECS`; set 0 to disable.
+pub const IDLE_TIMEOUT_DEFAULT: Duration = Duration::from_secs(60);
+
 /// Returns `true` when `MEMPOOL_TRACKING` is set to a truthy value.
 ///
 /// Accepted truthy values: `1`, `true`, `yes`, `on` (case-insensitive). Any
@@ -71,6 +80,11 @@ pub struct AlchemyMempoolConfig {
     /// Empty means "no filter" — emit every pending tx Alchemy sees, which
     /// is firehose-grade and not recommended for production wiring.
     pub router_filter: Vec<Address>,
+    /// Idle-watchdog window. If no pending tx is delivered within this span the
+    /// connection is treated as dead (silent half-close) and dropped so the
+    /// reconnect loop re-establishes it. [`Duration::ZERO`] disables the
+    /// watchdog. Defaults to [`IDLE_TIMEOUT_DEFAULT`].
+    pub idle_timeout: Duration,
 }
 
 impl AlchemyMempoolConfig {
@@ -162,7 +176,11 @@ impl AlchemyMempool {
             .await?;
         let mut stream = sub.into_stream();
 
+        let idle_timeout = self.config.idle_timeout;
         loop {
+            // Recreated each iteration, so every delivered event resets the
+            // idle window. The `if` guard disables the arm entirely (and skips
+            // arming the timer) when the watchdog is configured off.
             tokio::select! {
                 next = stream.next() => {
                     match next {
@@ -175,6 +193,18 @@ impl AlchemyMempool {
                             return Err("stream closed".into());
                         }
                     }
+                }
+                _ = tokio::time::sleep(idle_timeout), if !idle_timeout.is_zero() => {
+                    if let Some(metrics) = &self.metrics {
+                        metrics.inc_idle_reconnect();
+                    }
+                    warn!(
+                        target: "aether::mempool",
+                        idle_secs = idle_timeout.as_secs(),
+                        "no pending tx within idle window; assuming silent half-close, \
+                         dropping connection to force reconnect"
+                    );
+                    return Err("idle timeout".into());
                 }
                 changed = shutdown.changed() => {
                     if changed.is_err() || *shutdown.borrow() {
@@ -395,6 +425,7 @@ mod tests {
         let cfg = AlchemyMempoolConfig {
             ws_url: "wss://example".into(),
             router_filter: vec![],
+            idle_timeout: IDLE_TIMEOUT_DEFAULT,
         };
         let v = cfg.subscribe_params();
         assert_eq!(v, json!(["alchemy_pendingTransactions"]));
@@ -406,6 +437,7 @@ mod tests {
         let cfg = AlchemyMempoolConfig {
             ws_url: "wss://example".into(),
             router_filter: vec![address!("7a250d5630B4cF539739dF2C5dAcb4c659F2488D")],
+            idle_timeout: IDLE_TIMEOUT_DEFAULT,
         };
         let v = cfg.subscribe_params();
         let expected = json!([

--- a/crates/ingestion/src/metrics.rs
+++ b/crates/ingestion/src/metrics.rs
@@ -18,6 +18,7 @@ use prometheus::{IntCounter, Registry};
 /// Metric families owned by the mempool ingestion layer.
 pub struct MempoolIngestMetrics {
     raw_reencode_mismatch_total: IntCounter,
+    idle_reconnect_total: IntCounter,
 }
 
 impl MempoolIngestMetrics {
@@ -33,12 +34,23 @@ impl MempoolIngestMetrics {
         )
         .expect("aether_mempool_raw_reencode_mismatch_total counter");
 
+        let idle_reconnect_total = IntCounter::new(
+            "aether_mempool_idle_reconnect_total",
+            "Times the pending-tx subscription was dropped and reconnected because \
+             no event arrived within the idle-watchdog window (silent TCP half-close)",
+        )
+        .expect("aether_mempool_idle_reconnect_total counter");
+
         registry
             .register(Box::new(raw_reencode_mismatch_total.clone()))
             .expect("register aether_mempool_raw_reencode_mismatch_total");
+        registry
+            .register(Box::new(idle_reconnect_total.clone()))
+            .expect("register aether_mempool_idle_reconnect_total");
 
         Arc::new(Self {
             raw_reencode_mismatch_total,
+            idle_reconnect_total,
         })
     }
 
@@ -55,6 +67,17 @@ impl MempoolIngestMetrics {
     pub fn raw_reencode_mismatch_count(&self) -> u64 {
         self.raw_reencode_mismatch_total.get()
     }
+
+    /// Bump `aether_mempool_idle_reconnect_total`. Called when the idle
+    /// watchdog fires and the subscription is dropped to force a reconnect.
+    pub fn inc_idle_reconnect(&self) {
+        self.idle_reconnect_total.inc();
+    }
+
+    /// Read the current value of `aether_mempool_idle_reconnect_total`.
+    pub fn idle_reconnect_count(&self) -> u64 {
+        self.idle_reconnect_total.get()
+    }
 }
 
 #[cfg(test)]
@@ -70,6 +93,10 @@ mod tests {
         m.inc_raw_reencode_mismatch();
         assert_eq!(m.raw_reencode_mismatch_count(), 2);
 
+        assert_eq!(m.idle_reconnect_count(), 0);
+        m.inc_idle_reconnect();
+        assert_eq!(m.idle_reconnect_count(), 1);
+
         let names: Vec<_> = registry
             .gather()
             .iter()
@@ -80,6 +107,12 @@ mod tests {
                 .iter()
                 .any(|n| n == "aether_mempool_raw_reencode_mismatch_total"),
             "missing metric family aether_mempool_raw_reencode_mismatch_total"
+        );
+        assert!(
+            names
+                .iter()
+                .any(|n| n == "aether_mempool_idle_reconnect_total"),
+            "missing metric family aether_mempool_idle_reconnect_total"
         );
     }
 }

--- a/crates/simulator/src/fee_on_transfer.rs
+++ b/crates/simulator/src/fee_on_transfer.rs
@@ -1,0 +1,1014 @@
+//! Fee-on-transfer / honeypot screen for candidate pool tokens.
+//!
+//! Why this exists: the constant-product (and other) AMM math the engine uses
+//! assumes `amount_out` arrives in full. **Fee-on-transfer ("tax") tokens break
+//! that assumption** — the recipient receives less than the swap math predicts,
+//! so the simulator says "profit" and the on-chain execution reverts (or worse,
+//! lands at a loss). A burst of those reverts also trips the consecutive-revert
+//! circuit breaker. So before any auto-discovered memecoin pool is admitted to
+//! the registry, its token must pass this screen.
+//!
+//! Approach (this component): in a forked EVM, override a fresh test holder's
+//! balance of the token, then `transfer()` a realistic amount **into the pool
+//! address** and check conservation. Transferring *to the pair* is exactly what
+//! a swap's input leg does, so pair-gated transfer taxes trigger here. The
+//! verdict is one of [`FotVerdict`]:
+//! - `Clean`            — pool received the full amount (within tolerance).
+//! - `FeeOnTransfer`    — pool received less; reports the tax in bps.
+//! - `Honeypot`         — the transfer reverted / halted (transfer-restricted).
+//! - `Inconclusive`     — could not locate the token's balance storage slot.
+//!
+//! Scope note: this screens the **buy/input leg**. A sell-side honeypot (where
+//! `transfer` works but the *swap out* reverts) needs the full buy→sell pool
+//! round-trip, which is the planned refinement — see the admission gate (C3).
+//!
+//! The pure helpers ([`erc20_balance_key`], [`expected_amount_out`],
+//! [`discover_balance_slot`], [`classify_transfer`]) carry no revm/RPC
+//! dependency and are unit-tested directly; the revm executor
+//! ([`screen_token_transfer`]) wires them to a forked state and is exercised by
+//! an RPC-gated integration test.
+
+use crate::fork::{RpcDB, RpcForkedState};
+use alloy::primitives::{address, keccak256, Address, U256};
+use revm::context::result::ExecutionResult;
+use revm::context::{BlockEnv, TxEnv};
+use revm::database::DatabaseRef;
+use revm::handler::{ExecuteEvm, MainBuilder};
+use revm::primitives::hardfork::SpecId;
+use revm::primitives::{Bytes, TxKind};
+use revm::state::AccountInfo;
+use revm::Context;
+use tracing::debug;
+
+/// `transfer(address,uint256)` selector.
+const TRANSFER_SELECTOR: [u8; 4] = [0xa9, 0x05, 0x9c, 0xbb];
+
+/// Fixed, otherwise-unused test holder EOA used as the transfer sender. Its
+/// token balance is overridden in the fork before the probe runs.
+const TEST_HOLDER: Address = address!("000000000000000000000000000000000000d39D");
+
+/// Tuning for the screen.
+#[derive(Clone, Debug)]
+pub struct FotConfig {
+    /// Tax (in bps) at or below which a token is still treated as `Clean` —
+    /// absorbs integer-rounding noise. Any deviation above this is reported as
+    /// `FeeOnTransfer`. The admission gate decides the admit/reject policy on
+    /// the reported number.
+    pub max_tax_bps: u32,
+    /// Transfer size for the probe, as a fraction of the pool's token balance
+    /// (in bps). Small enough to be realistic, large enough that a percentage
+    /// tax is measurable above rounding. Default 10 bps = 0.1% of reserve.
+    pub test_fraction_bps: u32,
+    /// How many storage slots to brute-force when locating the token's
+    /// `mapping(address => uint256)` balances slot.
+    pub max_slot_probe: u64,
+    /// Gas limit for the probe transfer.
+    pub gas_limit: u64,
+}
+
+impl Default for FotConfig {
+    fn default() -> Self {
+        Self {
+            max_tax_bps: 10,
+            test_fraction_bps: 10,
+            max_slot_probe: 40,
+            gas_limit: 1_000_000,
+        }
+    }
+}
+
+/// Outcome of screening one token.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FotVerdict {
+    /// Conservation held (received >= sent, or tax within tolerance).
+    Clean { observed_tax_bps: u32 },
+    /// The pool received measurably less than was sent.
+    FeeOnTransfer { tax_bps: u32 },
+    /// The transfer reverted or halted — transfer-restricted / honeypot-like.
+    Honeypot { reason: String },
+    /// Could not run a conclusive probe (e.g. balance slot not found).
+    Inconclusive { reason: String },
+}
+
+impl FotVerdict {
+    /// Only `Clean` tokens are safe to feed the constant-product AMM math.
+    pub fn is_admissible(&self) -> bool {
+        matches!(self, FotVerdict::Clean { .. })
+    }
+}
+
+/// Storage key for `balances[holder]` of a Solidity
+/// `mapping(address => uint256)` declared at `mapping_slot`:
+/// `keccak256(pad32(holder) ++ pad32(mapping_slot))`. Mirrors the derivation
+/// used by [`crate::EvmSimulator`]'s ERC20-profit accounting.
+pub fn erc20_balance_key(holder: Address, mapping_slot: U256) -> U256 {
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(holder.as_slice());
+    buf[32..64].copy_from_slice(&mapping_slot.to_be_bytes::<32>());
+    U256::from_be_slice(keccak256(buf).as_slice())
+}
+
+/// UniswapV2-style constant-product output for `amount_in`, where `fee_bps` is
+/// the pool fee in basis points (e.g. 30 = 0.30%). Returns 0 on degenerate
+/// input. Provided for the future buy→sell round-trip; not used by the
+/// single-transfer screen.
+pub fn expected_amount_out(
+    amount_in: U256,
+    reserve_in: U256,
+    reserve_out: U256,
+    fee_bps: u32,
+) -> U256 {
+    if amount_in.is_zero() || reserve_in.is_zero() || reserve_out.is_zero() || fee_bps >= 10_000 {
+        return U256::ZERO;
+    }
+    let fee_factor = U256::from(10_000u32 - fee_bps);
+    let amount_in_with_fee = amount_in * fee_factor;
+    let numerator = amount_in_with_fee * reserve_out;
+    let denominator = reserve_in * U256::from(10_000u64) + amount_in_with_fee;
+    numerator / denominator
+}
+
+/// Tax in basis points implied by receiving `actual` when `expected` was sent.
+/// 0 when there is no shortfall.
+fn tax_bps(expected: U256, actual: U256) -> u32 {
+    if expected.is_zero() || actual >= expected {
+        return 0;
+    }
+    let diff = expected - actual;
+    let bps = diff.saturating_mul(U256::from(10_000u64)) / expected;
+    u32::try_from(bps).unwrap_or(10_000)
+}
+
+/// Classify a single transfer: `sent` left the holder, `received` arrived at the
+/// recipient. A shortfall above `max_tax_bps` is a fee-on-transfer token.
+pub fn classify_transfer(sent: U256, received: U256, max_tax_bps: u32) -> FotVerdict {
+    let tax = tax_bps(sent, received);
+    if tax <= max_tax_bps {
+        FotVerdict::Clean {
+            observed_tax_bps: tax,
+        }
+    } else {
+        FotVerdict::FeeOnTransfer { tax_bps: tax }
+    }
+}
+
+/// Brute-force the balances-mapping storage slot for a token by finding the
+/// slot whose `balances[holder]` storage equals a *known* balance. `read_storage`
+/// returns the token's storage value at a given key (i.e. a closure over
+/// `db.storage_ref(token, key)`). Returns `None` if `known_balance` is zero or
+/// no slot in `0..max_slots` matches.
+pub fn discover_balance_slot<F>(
+    read_storage: F,
+    holder: Address,
+    known_balance: U256,
+    max_slots: u64,
+) -> Option<U256>
+where
+    F: Fn(U256) -> U256,
+{
+    if known_balance.is_zero() {
+        return None;
+    }
+    (0..max_slots).map(U256::from).find(|slot| {
+        read_storage(erc20_balance_key(holder, *slot)) == known_balance
+    })
+}
+
+/// Screen `token` (paired in `pool`, which currently holds `pool_token_balance`
+/// of it) for fee-on-transfer / transfer-restriction behaviour against `state`.
+///
+/// `pool_token_balance` is the pool's on-chain balance of `token` (the V2
+/// reserve, or the vault/pool balance) — supplied by the caller from the live
+/// registry/state and used both to locate the balances slot and to size the
+/// probe transfer. Consumes `state` (each probe needs a fresh fork).
+pub fn screen_token_transfer(
+    mut state: RpcForkedState,
+    token: Address,
+    pool: Address,
+    pool_token_balance: U256,
+    cfg: &FotConfig,
+) -> FotVerdict {
+    // 1. Locate the balances mapping slot using the pool as a known holder.
+    let slot = {
+        let read = |key: U256| state.db.storage_ref(token, key).unwrap_or_default();
+        match discover_balance_slot(read, pool, pool_token_balance, cfg.max_slot_probe) {
+            Some(s) => s,
+            None => {
+                return FotVerdict::Inconclusive {
+                    reason: "balance storage slot not found".into(),
+                }
+            }
+        }
+    };
+
+    // 2. Size the probe transfer and override the test holder's balance.
+    let x = (pool_token_balance.saturating_mul(U256::from(cfg.test_fraction_bps))
+        / U256::from(10_000u64))
+    .max(U256::from(1u64));
+    let holder_key = erc20_balance_key(TEST_HOLDER, slot);
+    let _ = state.db.insert_account_storage(token, holder_key, x);
+
+    // Pre-transfer pool balance (read before the fork state is consumed).
+    let pool_key = erc20_balance_key(pool, slot);
+    let pre_pool = state.db.storage_ref(token, pool_key).unwrap_or_default();
+
+    // 3. Build `transfer(pool, x)` calldata.
+    let mut data = Vec::with_capacity(68);
+    data.extend_from_slice(&TRANSFER_SELECTOR);
+    let mut to_word = [0u8; 32];
+    to_word[12..32].copy_from_slice(pool.as_slice());
+    data.extend_from_slice(&to_word);
+    data.extend_from_slice(&x.to_be_bytes::<32>());
+
+    // 4. Execute the transfer in the fork.
+    let RpcForkedState {
+        db,
+        block_number,
+        block_timestamp,
+        base_fee,
+        chain_id,
+    } = state;
+    let block = BlockEnv {
+        number: U256::from(block_number),
+        timestamp: U256::from(block_timestamp),
+        basefee: base_fee,
+        ..Default::default()
+    };
+    let tx = TxEnv::builder()
+        .caller(TEST_HOLDER)
+        .kind(TxKind::Call(token))
+        .data(Bytes::copy_from_slice(&data))
+        .value(U256::ZERO)
+        .gas_limit(cfg.gas_limit)
+        .gas_price(base_fee as u128)
+        .nonce(0)
+        .chain_id(Some(chain_id))
+        .build_fill();
+    let ctx = Context::<BlockEnv, TxEnv, _, RpcDB, revm::context::Journal<RpcDB>, ()>::new(
+        db,
+        SpecId::CANCUN,
+    )
+    .with_block(block)
+    .modify_cfg_chained(|c| {
+        c.chain_id = chain_id;
+        c.disable_nonce_check = true;
+        c.disable_balance_check = true;
+        c.disable_base_fee = true;
+    });
+    let mut evm = ctx.build_mainnet();
+
+    match evm.transact(tx) {
+        Ok(rs) => match rs.result {
+            ExecutionResult::Success { .. } => {
+                let post_pool = rs
+                    .state
+                    .get(&token)
+                    .and_then(|acc| acc.storage.get(&pool_key))
+                    .map(|s| s.present_value)
+                    .unwrap_or(pre_pool);
+                let received = post_pool.saturating_sub(pre_pool);
+                let verdict = classify_transfer(x, received, cfg.max_tax_bps);
+                debug!(%token, %pool, sent = %x, %received, ?verdict, "fot screen complete");
+                verdict
+            }
+            ExecutionResult::Revert { output, .. } => FotVerdict::Honeypot {
+                reason: format!("transfer reverted: 0x{}", alloy::hex::encode(&output)),
+            },
+            ExecutionResult::Halt { reason, .. } => FotVerdict::Honeypot {
+                reason: format!("transfer halted: {reason:?}"),
+            },
+        },
+        Err(e) => FotVerdict::Inconclusive {
+            reason: format!("evm transact error: {e}"),
+        },
+    }
+}
+
+// ===========================================================================
+// Buy→sell round-trip primitives (sell-side honeypot / tax detection)
+// ===========================================================================
+
+/// `swap(uint256,uint256,address,bytes)` selector on a UniswapV2 pair.
+const V2_SWAP_SELECTOR: [u8; 4] = [0x02, 0x2c, 0x0d, 0x9f];
+
+/// Storage slot holding a UniswapV2 pair's packed reserves
+/// (`reserve0 | reserve1 << 112 | blockTimestampLast << 224`).
+pub const V2_RESERVES_SLOT: u64 = 8;
+
+/// Unpack a UniswapV2 `slot 8` value into `(reserve0, reserve1)` (each uint112).
+pub fn unpack_v2_reserves(slot_value: U256) -> (U256, U256) {
+    let mask = (U256::from(1u64) << 112) - U256::from(1u64);
+    let reserve0 = slot_value & mask;
+    let reserve1 = (slot_value >> 112) & mask;
+    (reserve0, reserve1)
+}
+
+/// ABI-encode `pair.swap(amount0Out, amount1Out, to, "")` (empty `data`, so no
+/// flash-swap callback). Layout: selector ++ amount0Out ++ amount1Out ++ to ++
+/// data-offset(0x80) ++ data-len(0).
+pub fn encode_v2_swap(amount0_out: U256, amount1_out: U256, to: Address) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + 5 * 32);
+    data.extend_from_slice(&V2_SWAP_SELECTOR);
+    data.extend_from_slice(&amount0_out.to_be_bytes::<32>());
+    data.extend_from_slice(&amount1_out.to_be_bytes::<32>());
+    let mut to_word = [0u8; 32];
+    to_word[12..32].copy_from_slice(to.as_slice());
+    data.extend_from_slice(&to_word);
+    data.extend_from_slice(&U256::from(0x80u64).to_be_bytes::<32>()); // bytes offset
+    data.extend_from_slice(&U256::ZERO.to_be_bytes::<32>()); // bytes length 0
+    data
+}
+
+/// Outcome of a buy→sell round-trip screen.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RoundTripVerdict {
+    /// Round-trip recovered the base asset within `max_loss_bps` of the
+    /// fee-only expectation — safe to trade.
+    Clean { recovery_bps: u32 },
+    /// The token is sellable but the round-trip lost materially more than the
+    /// pool fee implies — a transfer/swap tax. `loss_bps` is beyond fee.
+    FeeOnTransfer { loss_bps: u32 },
+    /// The sell leg failed or returned nothing — sell-side honeypot.
+    Honeypot { reason: String },
+    /// Could not run a conclusive round-trip.
+    Inconclusive { reason: String },
+    /// The screen exceeded its wall-clock budget (the discovery loop runs the
+    /// screen under a `tokio::time::timeout`). Distinct from `Inconclusive` so
+    /// dashboards can alert on screen-budget exhaustion without false-positives
+    /// from balance-slot misses.
+    ScreenTimeout { budget_ms: u64 },
+}
+
+impl RoundTripVerdict {
+    pub fn is_admissible(&self) -> bool {
+        matches!(self, RoundTripVerdict::Clean { .. })
+    }
+
+    /// Stable, low-cardinality label for metrics. The label set is the enum
+    /// discriminator only — never embed reason strings (which can include
+    /// token addresses) so the Prometheus cardinality stays bounded.
+    pub fn metric_label(&self) -> &'static str {
+        match self {
+            RoundTripVerdict::Clean { .. } => "clean",
+            RoundTripVerdict::FeeOnTransfer { .. } => "fee_on_transfer",
+            RoundTripVerdict::Honeypot { .. } => "honeypot",
+            RoundTripVerdict::Inconclusive { .. } => "inconclusive",
+            RoundTripVerdict::ScreenTimeout { .. } => "screen_timeout",
+        }
+    }
+
+    /// Bridge to [`FotVerdict`] for the admission gate ([`crate::fee_on_transfer`]
+    /// round-trip screen produces a `RoundTripVerdict`, but `pool_admission::evaluate`
+    /// consumes a `FotVerdict`). Only `Clean` is admissible on both sides; timeouts
+    /// map to `Inconclusive` so the gate rejects rather than admits on a budget miss.
+    pub fn as_fot_verdict(&self) -> FotVerdict {
+        match self {
+            RoundTripVerdict::Clean { .. } => FotVerdict::Clean {
+                observed_tax_bps: 0,
+            },
+            RoundTripVerdict::FeeOnTransfer { loss_bps } => {
+                FotVerdict::FeeOnTransfer { tax_bps: *loss_bps }
+            }
+            RoundTripVerdict::Honeypot { reason } => FotVerdict::Honeypot {
+                reason: reason.clone(),
+            },
+            RoundTripVerdict::Inconclusive { reason } => FotVerdict::Inconclusive {
+                reason: reason.clone(),
+            },
+            RoundTripVerdict::ScreenTimeout { budget_ms } => FotVerdict::Inconclusive {
+                reason: format!("screen timed out after {budget_ms}ms"),
+            },
+        }
+    }
+}
+
+/// Classify a round-trip from its measured economics. `base_in` was spent
+/// buying; `base_out` was recovered selling everything back; `fee_bps` is the
+/// pool fee. A tax-free round-trip through one pool recovers ≈ `(1-fee)²` of
+/// `base_in` (minus small, size-dependent price impact), so anything losing
+/// more than that beyond `max_loss_bps` is taxed.
+///
+/// `max_loss_bps` must budget for the round-trip price impact at the probe
+/// size (impact does not fully cancel), so it is deliberately loose; the gate
+/// can tighten it.
+pub fn classify_round_trip(
+    base_in: U256,
+    base_out: U256,
+    fee_bps: u32,
+    sell_succeeded: bool,
+    max_loss_bps: u32,
+) -> RoundTripVerdict {
+    if !sell_succeeded {
+        return RoundTripVerdict::Honeypot {
+            reason: "sell leg reverted".into(),
+        };
+    }
+    if base_out.is_zero() {
+        return RoundTripVerdict::Honeypot {
+            reason: "sell recovered zero base".into(),
+        };
+    }
+    if base_in.is_zero() {
+        return RoundTripVerdict::Inconclusive {
+            reason: "zero base_in".into(),
+        };
+    }
+    // Actual recovery in bps of base_in.
+    let actual_bps = u32::try_from(
+        base_out.saturating_mul(U256::from(10_000u64)) / base_in,
+    )
+    .unwrap_or(u32::MAX);
+    // Fee-only expectation: (1-fee)² expressed in bps = fee_factor² / 10000.
+    let ff = (10_000u64).saturating_sub(fee_bps as u64);
+    let expected_bps = u32::try_from(ff * ff / 10_000).unwrap_or(10_000);
+    let loss_bps = expected_bps.saturating_sub(actual_bps);
+    if loss_bps <= max_loss_bps {
+        RoundTripVerdict::Clean {
+            recovery_bps: actual_bps,
+        }
+    } else {
+        RoundTripVerdict::FeeOnTransfer { loss_bps }
+    }
+}
+
+/// Run one `Call` against `db`, commit its state diffs back into `db` on
+/// success, and return `(success, revert/halt reason, db)`. The committed `db`
+/// is threaded into the next call so a multi-step sequence shares state (the
+/// same technique [`crate::EvmSimulator::deploy_and_simulate_with_erc20_profit`]
+/// uses).
+#[allow(clippy::too_many_arguments)]
+fn v2_transact(
+    db: RpcDB,
+    block: &BlockEnv,
+    chain_id: u64,
+    base_fee: u64,
+    caller: Address,
+    to: Address,
+    data: Vec<u8>,
+    nonce: u64,
+    gas_limit: u64,
+) -> (bool, Option<String>, RpcDB) {
+    let tx = TxEnv::builder()
+        .caller(caller)
+        .kind(TxKind::Call(to))
+        .data(Bytes::copy_from_slice(&data))
+        .value(U256::ZERO)
+        .gas_limit(gas_limit)
+        .gas_price(base_fee as u128)
+        .nonce(nonce)
+        .chain_id(Some(chain_id))
+        .build_fill();
+    let ctx = Context::<BlockEnv, TxEnv, _, RpcDB, revm::context::Journal<RpcDB>, ()>::new(
+        db,
+        SpecId::CANCUN,
+    )
+    .with_block(block.clone())
+    .modify_cfg_chained(|c| {
+        c.chain_id = chain_id;
+        c.disable_nonce_check = true;
+        c.disable_balance_check = true;
+        c.disable_base_fee = true;
+    });
+    let mut evm = ctx.build_mainnet();
+    match evm.transact(tx) {
+        Ok(rs) => {
+            let success = matches!(rs.result, ExecutionResult::Success { .. });
+            let reason = match &rs.result {
+                ExecutionResult::Revert { output, .. } => {
+                    Some(format!("revert 0x{}", alloy::hex::encode(output)))
+                }
+                ExecutionResult::Halt { reason, .. } => Some(format!("halt {reason:?}")),
+                _ => None,
+            };
+            let mut db = evm.ctx.journaled_state.database;
+            if success {
+                for (a, account) in rs.state.iter() {
+                    if account.is_selfdestructed() {
+                        continue;
+                    }
+                    let info = &account.info;
+                    db.insert_account_info(
+                        *a,
+                        AccountInfo {
+                            balance: info.balance,
+                            nonce: info.nonce,
+                            code_hash: info.code_hash,
+                            code: info.code.clone(),
+                            ..Default::default()
+                        },
+                    );
+                    for (slot, sv) in account.storage.iter() {
+                        let _ = db.insert_account_storage(*a, *slot, sv.present_value);
+                    }
+                }
+            }
+            (success, reason, db)
+        }
+        Err(e) => {
+            let db = evm.ctx.journaled_state.database;
+            (false, Some(format!("evm error: {e}")), db)
+        }
+    }
+}
+
+#[inline]
+fn read_balance(db: &RpcDB, token: Address, holder: Address, slot: U256) -> U256 {
+    db.storage_ref(token, erc20_balance_key(holder, slot))
+        .unwrap_or_default()
+}
+
+/// Full buy→sell round-trip screen for a token paired with `base` (e.g. WETH)
+/// in a **UniswapV2-style** `pair`. Buys `token` with `base` (base funded by
+/// balance override — base is assumed tax-free), then sells the received tokens
+/// back via a *real* `transfer` into the pair followed by `swap` — so a
+/// fee-on-transfer hook or a sell-only honeypot triggers on the sell leg and is
+/// caught. Returns a [`RoundTripVerdict`] from the recovered-base ratio.
+///
+/// `fee_bps` must be the pair's real fee (30 for UniV2/SushiSwap). `base_slot`
+/// is `base`'s ERC20 balances mapping slot (WETH = 3). Consumes `state`.
+///
+/// NOTE: end-to-end behaviour is verified by an RPC-backed integration run (a
+/// forked pair), not by unit tests — the pure decision pieces it composes
+/// (`expected_amount_out`, `unpack_v2_reserves`, `encode_v2_swap`,
+/// `classify_round_trip`) are unit-tested.
+#[allow(clippy::too_many_arguments)]
+pub fn screen_token_v2_round_trip(
+    mut state: RpcForkedState,
+    pair: Address,
+    token: Address,
+    base: Address,
+    base_slot: U256,
+    fee_bps: u32,
+    cfg: &FotConfig,
+    max_loss_bps: u32,
+) -> RoundTripVerdict {
+    let eoa = TEST_HOLDER;
+    let token_is_0 = token < base;
+
+    // Reserves from slot 8.
+    let slot8 = state
+        .db
+        .storage_ref(pair, U256::from(V2_RESERVES_SLOT))
+        .unwrap_or_default();
+    let (r0, r1) = unpack_v2_reserves(slot8);
+    let (reserve_token, reserve_base) = if token_is_0 { (r0, r1) } else { (r1, r0) };
+    if reserve_token.is_zero() || reserve_base.is_zero() {
+        return RoundTripVerdict::Inconclusive {
+            reason: "pair has zero reserves".into(),
+        };
+    }
+
+    // Token balances slot (pair holds `reserve_token` of it).
+    let token_slot = {
+        let read = |key: U256| state.db.storage_ref(token, key).unwrap_or_default();
+        match discover_balance_slot(read, pair, reserve_token, cfg.max_slot_probe) {
+            Some(s) => s,
+            None => {
+                return RoundTripVerdict::Inconclusive {
+                    reason: "token balance slot not found".into(),
+                }
+            }
+        }
+    };
+
+    // Size the buy and compute the expected token output.
+    let base_in = (reserve_base.saturating_mul(U256::from(cfg.test_fraction_bps))
+        / U256::from(10_000u64))
+    .max(U256::from(1u64));
+    let amt_t_out = expected_amount_out(base_in, reserve_base, reserve_token, fee_bps);
+    if amt_t_out.is_zero() {
+        return RoundTripVerdict::Inconclusive {
+            reason: "computed zero token-out for buy".into(),
+        };
+    }
+
+    // Fund the pair with `base_in` of base (tax-free => override is faithful).
+    let pair_base_key = erc20_balance_key(pair, base_slot);
+    let pair_base_bal = state.db.storage_ref(base, pair_base_key).unwrap_or_default();
+    let _ = state
+        .db
+        .insert_account_storage(base, pair_base_key, pair_base_bal.saturating_add(base_in));
+
+    let RpcForkedState {
+        db,
+        block_number,
+        block_timestamp,
+        base_fee,
+        chain_id,
+    } = state;
+    let block = BlockEnv {
+        number: U256::from(block_number),
+        timestamp: U256::from(block_timestamp),
+        basefee: base_fee,
+        ..Default::default()
+    };
+
+    // BUY: pair.swap(token out -> eoa).
+    let (a0, a1) = if token_is_0 {
+        (amt_t_out, U256::ZERO)
+    } else {
+        (U256::ZERO, amt_t_out)
+    };
+    let pre_t = read_balance(&db, token, eoa, token_slot);
+    let (ok, reason, db) = v2_transact(
+        db,
+        &block,
+        chain_id,
+        base_fee,
+        eoa,
+        pair,
+        encode_v2_swap(a0, a1, eoa),
+        0,
+        cfg.gas_limit,
+    );
+    if !ok {
+        return RoundTripVerdict::Inconclusive {
+            reason: format!("buy leg failed: {}", reason.unwrap_or_default()),
+        };
+    }
+    let t_received = read_balance(&db, token, eoa, token_slot).saturating_sub(pre_t);
+    if t_received.is_zero() {
+        return RoundTripVerdict::Honeypot {
+            reason: "buy returned zero tokens".into(),
+        };
+    }
+
+    // SELL step 1: real transfer of received tokens into the pair (triggers any
+    // fee-on-transfer / sell restriction).
+    let mut transfer_data = Vec::with_capacity(68);
+    transfer_data.extend_from_slice(&TRANSFER_SELECTOR);
+    let mut to_word = [0u8; 32];
+    to_word[12..32].copy_from_slice(pair.as_slice());
+    transfer_data.extend_from_slice(&to_word);
+    transfer_data.extend_from_slice(&t_received.to_be_bytes::<32>());
+    let (ok_t, reason_t, db) = v2_transact(
+        db,
+        &block,
+        chain_id,
+        base_fee,
+        eoa,
+        token,
+        transfer_data,
+        1,
+        cfg.gas_limit,
+    );
+    if !ok_t {
+        return RoundTripVerdict::Honeypot {
+            reason: format!("sell transfer to pair failed: {}", reason_t.unwrap_or_default()),
+        };
+    }
+
+    // Fresh reserves (the buy swap called `_update`) + the pair's real token
+    // balance after the transfer => the amount actually available to sell.
+    let slot8b = db
+        .storage_ref(pair, U256::from(V2_RESERVES_SLOT))
+        .unwrap_or_default();
+    let (r0b, r1b) = unpack_v2_reserves(slot8b);
+    let (reserve_token_b, reserve_base_b) = if token_is_0 { (r0b, r1b) } else { (r1b, r0b) };
+    let pair_token_bal = read_balance(&db, token, pair, token_slot);
+    let amt_t_in = pair_token_bal.saturating_sub(reserve_token_b);
+    let amt_base_out = expected_amount_out(amt_t_in, reserve_token_b, reserve_base_b, fee_bps);
+    if amt_base_out.is_zero() {
+        return RoundTripVerdict::Honeypot {
+            reason: "pair received ~zero sellable tokens".into(),
+        };
+    }
+
+    // SELL step 2: pair.swap(base out -> eoa).
+    let base_is_0 = !token_is_0;
+    let (sa0, sa1) = if base_is_0 {
+        (amt_base_out, U256::ZERO)
+    } else {
+        (U256::ZERO, amt_base_out)
+    };
+    let pre_b = read_balance(&db, base, eoa, base_slot);
+    let (ok_s, reason_s, db) = v2_transact(
+        db,
+        &block,
+        chain_id,
+        base_fee,
+        eoa,
+        pair,
+        encode_v2_swap(sa0, sa1, eoa),
+        2,
+        cfg.gas_limit,
+    );
+    if !ok_s {
+        return RoundTripVerdict::Honeypot {
+            reason: format!("sell swap reverted: {}", reason_s.unwrap_or_default()),
+        };
+    }
+    let base_out = read_balance(&db, base, eoa, base_slot).saturating_sub(pre_b);
+    let verdict = classify_round_trip(base_in, base_out, fee_bps, true, max_loss_bps);
+    debug!(%token, %pair, %base_in, %base_out, ?verdict, "v2 round-trip screen complete");
+    verdict
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn addr(b: u8) -> Address {
+        Address::repeat_byte(b)
+    }
+
+    #[test]
+    fn balance_key_is_deterministic_and_distinct() {
+        let h1 = addr(0x11);
+        let h2 = addr(0x22);
+        // Stable for the same (holder, slot).
+        assert_eq!(
+            erc20_balance_key(h1, U256::from(3u64)),
+            erc20_balance_key(h1, U256::from(3u64))
+        );
+        // Different holder => different key.
+        assert_ne!(
+            erc20_balance_key(h1, U256::from(3u64)),
+            erc20_balance_key(h2, U256::from(3u64))
+        );
+        // Different slot => different key.
+        assert_ne!(
+            erc20_balance_key(h1, U256::from(3u64)),
+            erc20_balance_key(h1, U256::from(9u64))
+        );
+    }
+
+    #[test]
+    fn expected_amount_out_matches_canonical_v2() {
+        // dy = dx*997*y / (x*1000 + dx*997), here via 10000-basis fee=30bps.
+        // x=1000, y=1000, dx=100 -> 90.661... -> floor 90.
+        let out = expected_amount_out(
+            U256::from(100u64),
+            U256::from(1000u64),
+            U256::from(1000u64),
+            30,
+        );
+        assert_eq!(out, U256::from(90u64));
+        // Degenerate inputs return zero.
+        assert_eq!(
+            expected_amount_out(U256::ZERO, U256::from(1u64), U256::from(1u64), 30),
+            U256::ZERO
+        );
+        assert_eq!(
+            expected_amount_out(U256::from(1u64), U256::from(1u64), U256::from(1u64), 10_000),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn classify_transfer_clean_when_full_received() {
+        assert_eq!(
+            classify_transfer(U256::from(1000u64), U256::from(1000u64), 10),
+            FotVerdict::Clean {
+                observed_tax_bps: 0
+            }
+        );
+        // Received more than sent (reflection credit) is still clean.
+        assert_eq!(
+            classify_transfer(U256::from(1000u64), U256::from(1001u64), 10),
+            FotVerdict::Clean {
+                observed_tax_bps: 0
+            }
+        );
+    }
+
+    #[test]
+    fn classify_transfer_tolerance_absorbs_rounding() {
+        // 1000 -> 999 is 10 bps shortfall; with max_tax_bps=10 it's clean.
+        assert_eq!(
+            classify_transfer(U256::from(1000u64), U256::from(999u64), 10),
+            FotVerdict::Clean {
+                observed_tax_bps: 10
+            }
+        );
+    }
+
+    #[test]
+    fn classify_transfer_flags_fee_on_transfer() {
+        // 5% tax: 10000 -> 9500 = 500 bps > tolerance.
+        assert_eq!(
+            classify_transfer(U256::from(10_000u64), U256::from(9_500u64), 10),
+            FotVerdict::FeeOnTransfer { tax_bps: 500 }
+        );
+    }
+
+    #[test]
+    fn admissible_only_for_clean() {
+        assert!(FotVerdict::Clean {
+            observed_tax_bps: 0
+        }
+        .is_admissible());
+        assert!(!FotVerdict::FeeOnTransfer { tax_bps: 500 }.is_admissible());
+        assert!(!FotVerdict::Honeypot {
+            reason: "x".into()
+        }
+        .is_admissible());
+        assert!(!FotVerdict::Inconclusive {
+            reason: "x".into()
+        }
+        .is_admissible());
+    }
+
+    #[test]
+    fn discover_balance_slot_finds_matching_slot() {
+        let token_holder = addr(0xAB);
+        let known = U256::from(123_456u64);
+        // Fake storage: only slot 7's balances[holder] holds `known`.
+        let mut store: HashMap<U256, U256> = HashMap::new();
+        store.insert(erc20_balance_key(token_holder, U256::from(7u64)), known);
+        let reader = |key: U256| *store.get(&key).unwrap_or(&U256::ZERO);
+
+        assert_eq!(
+            discover_balance_slot(reader, token_holder, known, 40),
+            Some(U256::from(7u64))
+        );
+        // Wrong known-balance => no match.
+        assert_eq!(
+            discover_balance_slot(reader, token_holder, U256::from(999u64), 40),
+            None
+        );
+        // Zero known-balance => None (cannot disambiguate).
+        assert_eq!(discover_balance_slot(reader, token_holder, U256::ZERO, 40), None);
+        // Slot beyond probe budget is not found.
+        assert_eq!(discover_balance_slot(reader, token_holder, known, 7), None);
+    }
+
+    #[test]
+    fn unpack_v2_reserves_splits_112_bit_halves() {
+        let r0 = U256::from(1_000_000u64);
+        let r1 = U256::from(2_500_000u64);
+        let packed = r0 | (r1 << 112);
+        assert_eq!(unpack_v2_reserves(packed), (r0, r1));
+    }
+
+    #[test]
+    fn encode_v2_swap_layout() {
+        let data = encode_v2_swap(U256::ZERO, U256::from(123u64), addr(0x42));
+        assert_eq!(data.len(), 4 + 5 * 32);
+        assert_eq!(&data[0..4], &[0x02, 0x2c, 0x0d, 0x9f]);
+        // amount1Out occupies the second word; low byte == 123.
+        assert_eq!(data[4 + 64 - 1], 123);
+        // `to` lives in the low 20 bytes of the third word.
+        assert_eq!(&data[4 + 64 + 12..4 + 96], addr(0x42).as_slice());
+    }
+
+    #[test]
+    fn round_trip_honeypot_when_sell_fails() {
+        let v = classify_round_trip(U256::from(1000u64), U256::ZERO, 30, false, 200);
+        assert!(matches!(v, RoundTripVerdict::Honeypot { .. }));
+        // Sell "succeeded" but recovered nothing is still a honeypot.
+        let v2 = classify_round_trip(U256::from(1000u64), U256::ZERO, 30, true, 200);
+        assert!(matches!(v2, RoundTripVerdict::Honeypot { .. }));
+    }
+
+    #[test]
+    fn round_trip_clean_for_fee_only_loss() {
+        // 0.3% pool: fee-only recovery = 0.997^2 = 0.994009 -> 9940 bps.
+        // Recover 9930 bps (extra 10 bps slippage) with 200 bps tolerance -> Clean.
+        let base_in = U256::from(1_000_000u64);
+        let base_out = U256::from(993_000u64); // 9930 bps
+        let v = classify_round_trip(base_in, base_out, 30, true, 200);
+        assert!(matches!(v, RoundTripVerdict::Clean { .. }), "got {v:?}");
+    }
+
+    #[test]
+    fn round_trip_flags_sell_tax() {
+        // Recover only 85% — far below the ~99.4% fee-only expectation.
+        let base_in = U256::from(1_000_000u64);
+        let base_out = U256::from(850_000u64);
+        let v = classify_round_trip(base_in, base_out, 30, true, 200);
+        match v {
+            RoundTripVerdict::FeeOnTransfer { loss_bps } => assert!(loss_bps > 200),
+            other => panic!("expected FeeOnTransfer, got {other:?}"),
+        }
+    }
+
+    // =======================================================================
+    // RPC-backed integration tests (live mainnet fork). Gated on ETH_RPC_URL
+    // and #[ignore]d, so default `cargo test` skips them. Run with:
+    //   ETH_RPC_URL="https://eth-mainnet.g.alchemy.com/v2/<KEY>" \
+    //     cargo test -p aether-simulator --lib fee_on_transfer -- --ignored
+    // =======================================================================
+    use crate::fork::RpcForkedState;
+    use alloy::primitives::address;
+    use alloy::providers::{Provider, ProviderBuilder};
+
+    const WETH: Address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
+    const USDC: Address = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    const DAI: Address = address!("6B175474E89094C44Da98b954EedeAC495271d0F");
+    const UNIV2_USDC_WETH: Address = address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc");
+    const UNIV2_DAI_WETH: Address = address!("A478c2975Ab1Ea89e8196811F51A7B7Ade33eB11");
+
+    /// Resolve the mainnet RPC URL from the process env, falling back to the
+    /// repo `.env` (interpolating `${ALCHEMY_API_KEY}`). `None` => skip.
+    fn resolve_rpc_url() -> Option<String> {
+        if let Ok(url) = std::env::var("ETH_RPC_URL") {
+            if !url.trim().is_empty() && !url.contains("${") {
+                return Some(url);
+            }
+        }
+        let env_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../.env");
+        let contents = std::fs::read_to_string(env_path).ok()?;
+        let mut alchemy_key: Option<String> = None;
+        let mut raw_url: Option<String> = None;
+        for line in contents.lines() {
+            let line = line.trim();
+            if let Some(v) = line.strip_prefix("ALCHEMY_API_KEY=") {
+                alchemy_key = Some(v.trim().to_string());
+            } else if let Some(v) = line.strip_prefix("ETH_RPC_URL=") {
+                raw_url = Some(v.trim().to_string());
+            }
+        }
+        let url = raw_url?;
+        Some(match alchemy_key {
+            Some(k) => url.replace("${ALCHEMY_API_KEY}", &k),
+            None => url,
+        })
+    }
+
+    /// Build a fresh forked state at `latest` and run the V2 round-trip screen.
+    /// `base_slot` is `base`'s ERC20 balances mapping slot (WETH = 3).
+    async fn screen(
+        rpc_url: &str,
+        pair: Address,
+        token: Address,
+        base: Address,
+        base_slot: u64,
+    ) -> RoundTripVerdict {
+        let parsed: alloy::transports::http::reqwest::Url =
+            rpc_url.parse().expect("valid RPC URL");
+        let provider = ProviderBuilder::new().connect_http(parsed).erased();
+        let latest = provider.get_block_number().await.expect("block number");
+        // A fresh RpcForkedState is required per run (AlloyDB is !Clone).
+        let state = RpcForkedState::new_at_latest(provider.clone(), latest, 4_000_000_000, 1_000_000_000)
+            .expect("must run inside a multi-thread tokio runtime");
+        // 0.1% probe, 3% round-trip loss tolerance to absorb fee + slippage.
+        screen_token_v2_round_trip(
+            state,
+            pair,
+            token,
+            base,
+            U256::from(base_slot),
+            30,
+            &FotConfig::default(),
+            300,
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires ETH_RPC_URL (live mainnet fork)"]
+    async fn round_trip_usdc_weth_is_clean() {
+        let Some(rpc) = resolve_rpc_url() else {
+            eprintln!("skipping: ETH_RPC_URL unset and repo .env unavailable");
+            return;
+        };
+        // WETH is the base; its _balances slot is 3.
+        let v = screen(&rpc, UNIV2_USDC_WETH, USDC, WETH, 3).await;
+        assert!(v.is_admissible(), "USDC/WETH must screen Clean, got {v:?}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires ETH_RPC_URL (live mainnet fork)"]
+    async fn round_trip_dai_weth_is_clean() {
+        let Some(rpc) = resolve_rpc_url() else {
+            eprintln!("skipping: ETH_RPC_URL unset and repo .env unavailable");
+            return;
+        };
+        let v = screen(&rpc, UNIV2_DAI_WETH, DAI, WETH, 3).await;
+        assert!(v.is_admissible(), "DAI/WETH must screen Clean, got {v:?}");
+    }
+
+    /// Verifies the sell-side detection against a *known* fee-on-transfer or
+    /// honeypot token. Driven by env so a possibly-stale address is never baked
+    /// in as a hard assertion — set all three to run:
+    ///   AETHER_FOT_TEST_PAIR=0x...   (UniswapV2 pair, token paired with WETH)
+    ///   AETHER_FOT_TEST_TOKEN=0x...  (the suspect token)
+    ///   AETHER_FOT_TEST_BASE_SLOT=3  (optional; WETH default 3)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires ETH_RPC_URL + AETHER_FOT_TEST_{PAIR,TOKEN}"]
+    async fn round_trip_flags_configured_fot_token() {
+        let Some(rpc) = resolve_rpc_url() else {
+            eprintln!("skipping: ETH_RPC_URL unavailable");
+            return;
+        };
+        let (Ok(pair_s), Ok(token_s)) = (
+            std::env::var("AETHER_FOT_TEST_PAIR"),
+            std::env::var("AETHER_FOT_TEST_TOKEN"),
+        ) else {
+            eprintln!("skipping: AETHER_FOT_TEST_PAIR / AETHER_FOT_TEST_TOKEN unset");
+            return;
+        };
+        let pair: Address = pair_s.parse().expect("valid pair address");
+        let token: Address = token_s.parse().expect("valid token address");
+        let base_slot: u64 = std::env::var("AETHER_FOT_TEST_BASE_SLOT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3);
+        let v = screen(&rpc, pair, token, WETH, base_slot).await;
+        assert!(
+            !v.is_admissible(),
+            "configured fee-on-transfer/honeypot token must NOT screen Clean, got {v:?}"
+        );
+    }
+}

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bytecode_cache;
 pub mod calldata;
+pub mod fee_on_transfer;
 pub mod fork;
 pub mod mempool_backrun;
 pub mod post_state_replay;

--- a/demo.sh
+++ b/demo.sh
@@ -18,6 +18,13 @@
 #   ./demo.sh --fresh      # truncate demo tables before start
 #   ./demo.sh --no-grafana # skip auto-open of Grafana in browser
 #
+# Run profile (env):
+#   AETHER_ARM=B (default) full pipeline incl. Go executor + revm backrun
+#                          validator.
+#   AETHER_ARM=A           analytical/observability only — predictions +
+#                          reconciler + profit scorer, NO executor and NO
+#                          backrun validator (the Arm-A shadow-run config).
+#
 # Prereqs (script will fail-fast with a clear error if missing):
 #   - .env populated (see DEMO_REQUIRED_ENV below)
 #   - docker / docker compose installed
@@ -170,15 +177,49 @@ export DATABASE_URL="${DATABASE_URL:-postgres://aether:aether@127.0.0.1:5432/aet
 # separates them).
 export MEMPOOL_LEDGER_DSN="${MEMPOOL_LEDGER_DSN:-$DATABASE_URL}"
 
-# AETHER_EXECUTOR_ADDRESS — must point at an address with on-chain
-# bytecode because cmd/executor/main.go runs eth_getCode at startup
-# and aborts on empty account (a production safety check). For the
-# demo we use UniV3 SwapRouter02 as a placeholder — it has bytecode,
-# so the executor's check passes; revm's per-sim bytecode injection
-# (#165) overrides it inside the actual sim so the address itself is
-# functionally irrelevant. Shadow mode never broadcasts, so no risk
-# of sending a real tx to the wrong contract.
-export AETHER_EXECUTOR_ADDRESS="${AETHER_EXECUTOR_ADDRESS:-0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45}"
+# AETHER_ARM selects the run profile (default B preserves prior behaviour).
+AETHER_ARM="${AETHER_ARM:-B}"
+
+if [ "$AETHER_ARM" = "A" ]; then
+  # Arm A: leave AETHER_EXECUTOR_ADDRESS UNSET so the engine logs
+  # "validator disabled" (main.rs gates the backrun validator on this var)
+  # and never burns RPC on per-candidate forks. unset defends against a
+  # stray value inherited from .env.
+  unset AETHER_EXECUTOR_ADDRESS
+  log "AETHER_ARM=A — analytical/observability run (no executor, backrun validator disabled)"
+else
+  # Arm B — AETHER_EXECUTOR_ADDRESS must point at an address with on-chain
+  # bytecode because cmd/executor/main.go runs eth_getCode at startup and
+  # aborts on an empty account. For the demo we use UniV3 SwapRouter02 as a
+  # placeholder — it has bytecode, so the check passes; revm's per-sim
+  # bytecode injection (#165) overrides it inside the actual sim. Shadow mode
+  # never broadcasts, so no risk of sending a real tx to the wrong contract.
+  export AETHER_EXECUTOR_ADDRESS="${AETHER_EXECUTOR_ADDRESS:-0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45}"
+fi
+
+# Hot-token discovery (Part 1) — opt-in via AETHER_DISCOVERY=1. The engine
+# gates the loop on this var (main.rs); it runs off ETH_RPC_URL with its own
+# longer FoT-screen timeout, independent of the latency hot path. Knob defaults
+# (60s cadence, 500-pool cap, 8s screen timeout) already match the run plan.
+#
+# Intended for the *canary* phase only: discovery APPENDS admitted pools to
+# config/pools.toml, which moves the price graph. Per the run methodology,
+# discovery and measurement must be SEQUENTIAL — run discovery during the
+# canary, then FREEZE pools.toml (unset AETHER_DISCOVERY) for the pure-
+# measurement days, else Arm-A profitability inflates as a function of
+# admissions rather than real opportunities.
+if [ "${AETHER_DISCOVERY:-0}" = "1" ]; then
+  export AETHER_DISCOVERY=1
+  # Static ETH-price proxy for the per-venue WETH-liquidity estimate.
+  export AETHER_ETH_PRICE_USD="${AETHER_ETH_PRICE_USD:-3000}"
+  warn "AETHER_DISCOVERY=1 — hot-token discovery ON (canary mode)."
+  warn "  -> appends to config/pools.toml; FREEZE it (unset AETHER_DISCOVERY) for"
+  warn "     the pure-measurement days or Arm-A profit inflates with admissions."
+else
+  # Defend against a stray AETHER_DISCOVERY inherited from .env during a
+  # frozen measurement run.
+  unset AETHER_DISCOVERY
+fi
 
 # Bytecode artifact path — produced by `forge build` in step 4.
 export AETHER_EXECUTOR_BYTECODE_PATH="${AETHER_EXECUTOR_BYTECODE_PATH:-contracts/out/AetherExecutor.sol/AetherExecutor.json}"
@@ -299,6 +340,14 @@ if [ ! -f target/release/aether-rust ]; then
   cargo build --release --bins 2>&1 | tail -3
 fi
 
+# The profit scorer is a Rust bin built by `--bins` above; build it explicitly
+# if the rust build was skipped (aether-rust present but scorer absent) so the
+# profitability ledger always has a producer to supervise.
+if [ ! -f target/release/aether-profit-scorer ]; then
+  log "Building aether-profit-scorer..."
+  cargo build --release --bin aether-profit-scorer 2>&1 | tail -3
+fi
+
 mkdir -p bin
 # Build each Go binary independently — earlier `if [ ! -f bin/aether-executor ]`
 # wrapper skipped the other two when executor existed, leaving demo with
@@ -315,7 +364,9 @@ if [ ! -f contracts/out/AetherExecutor.sol/AetherExecutor.json ]; then
   (cd contracts && forge build) 2>&1 | tail -3
 fi
 
-if [ ! -f "$AETHER_EXECUTOR_BYTECODE_PATH" ]; then
+# The bytecode artifact is only needed when the backrun validator/executor run
+# (Arm B). Arm A is analytical-only, so don't hard-fail on a missing artifact.
+if [ "$AETHER_ARM" != "A" ] && [ ! -f "$AETHER_EXECUTOR_BYTECODE_PATH" ]; then
   err "Bytecode artifact missing at $AETHER_EXECUTOR_BYTECODE_PATH"
   err "Run 'cd contracts && forge build' to produce it."
   exit 1
@@ -351,17 +402,39 @@ spawn_with_restart() {
   local log_file="$LOG_DIR/$name.log"
   shift
   (
+    # Crash-loop guard: count restarts in a rolling 60s window. >=5 restarts
+    # in that window is a crash-loop — emit a loud [ALERT] (log + stderr) and
+    # back off 60s instead of hammering every 5s. We keep retrying (a long
+    # unattended run should self-heal a transient outage) but slowly and
+    # visibly, so an operator or a log-based alert rule can catch it instead
+    # of a silent 5s respawn storm burning RPC/CPU for days.
+    restarts=0
+    window_start=$(date +%s)
     while true; do
       echo "[$(date -u +%FT%TZ)] starting $name: $*" >> "$log_file"
       "$@" >> "$log_file" 2>&1
       ec=$?
-      echo "[$(date -u +%FT%TZ)] $name exited code=$ec; restart in 5s" >> "$log_file"
+      now=$(date +%s)
+      echo "[$(date -u +%FT%TZ)] $name exited code=$ec" >> "$log_file"
       # Rotate if log >100MB.
       if [ -f "$log_file" ] && [ "$(stat -f%z "$log_file" 2>/dev/null || stat -c%s "$log_file" 2>/dev/null || echo 0)" -gt 104857600 ]; then
         mv "$log_file" "$log_file.$(date -u +%FT%TZ)"
         gzip "$log_file."* &
       fi
-      sleep 5
+      if [ $((now - window_start)) -le 60 ]; then
+        restarts=$((restarts + 1))
+      else
+        restarts=1
+        window_start=$now
+      fi
+      if [ "$restarts" -ge 5 ]; then
+        echo "[$(date -u +%FT%TZ)] [ALERT] $name crash-looping: $restarts restarts in <=60s (last exit=$ec); backing off 60s" | tee -a "$log_file" >&2
+        sleep 60
+        restarts=0
+        window_start=$(date +%s)
+      else
+        sleep 5
+      fi
     done
   ) &
   local loop_pid=$!
@@ -374,6 +447,46 @@ spawn_with_restart() {
   PID_VALUES+=("$child_pid")
   log "$name started (loop PID $loop_pid, child PID $child_pid). Log: $log_file"
 }
+
+# Background log janitor — bounds host-process log growth over long
+# (multi-day) shadow runs. spawn_with_restart only rotates a log when its
+# process *exits and restarts*; a process that stays up for days never hits
+# that path, so its log grows without bound. This loop runs independently and
+# copytruncate-rotates any oversized $LOG_DIR/*.log, truncating the file in
+# place so the live appender fd keeps working — a plain mv/rename would orphan
+# it and the process would keep writing to the moved inode while the new file
+# stayed empty. Tracked in CHILD_LOOPS so cleanup() stops it first.
+#   DEMO_LOG_CAP_BYTES          per-log size cap (default 200MB)
+#   DEMO_LOG_JANITOR_INTERVAL_SEC  scan cadence (default 300s)
+start_log_janitor() {
+  local cap_bytes="${DEMO_LOG_CAP_BYTES:-209715200}"
+  local interval="${DEMO_LOG_JANITOR_INTERVAL_SEC:-300}"
+  (
+    while true; do
+      sleep "$interval"
+      for f in "$LOG_DIR"/*.log; do
+        [ -f "$f" ] || continue
+        sz=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+        if [ "$sz" -gt "$cap_bytes" ]; then
+          # copytruncate: snapshot the last generation, then truncate in
+          # place. A few in-flight lines may be lost at the truncate
+          # boundary (same trade-off as logrotate's copytruncate); fine for
+          # forensic logs. Only one generation (.1.gz) is kept, so disk stays
+          # bounded at ~cap + compressed cap per log.
+          cp "$f" "$f.1" 2>/dev/null && : > "$f"
+          gzip -f "$f.1" 2>/dev/null &
+          echo "[$(date -u +%FT%TZ)] log-janitor: rotated $(basename "$f") (was $sz bytes > cap $cap_bytes)" \
+            >> "$LOG_DIR/_janitor.log"
+        fi
+      done
+    done
+  ) &
+  local janitor_pid=$!
+  CHILD_LOOPS+=("$janitor_pid")
+  log "Log janitor started (PID $janitor_pid, cap $((cap_bytes / 1048576))MB, every ${interval}s)"
+}
+
+start_log_janitor
 
 step 6 "Booting Rust core (ingestion + decode + BF + revm sim + gRPC publish)"
 spawn_with_restart aether-rust target/release/aether-rust
@@ -390,15 +503,20 @@ done
 # Step 7 — Go executor (shadow mode → bundles table)
 # ─────────────────────────────────────────────────────────────────────────
 
-step 7 "Booting Go executor in shadow mode"
-spawn_with_restart aether-executor bin/aether-executor
+if [ "$AETHER_ARM" = "A" ]; then
+  step 7 "Arm A — skipping Go executor + backrun validator (analytical only)"
+  log "executor not started; engine running with the backrun validator disabled"
+else
+  step 7 "Booting Go executor in shadow mode"
+  spawn_with_restart aether-executor bin/aether-executor
 
-for i in {1..60}; do
-  if curl -sf http://localhost:9090/metrics > /dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-done
+  for i in {1..60}; do
+    if curl -sf http://localhost:9090/metrics > /dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+fi
 
 # ─────────────────────────────────────────────────────────────────────────
 # Step 8 — Reconciler (newHeads watcher → mempool_reconciliation)
@@ -406,6 +524,14 @@ done
 
 step 8 "Booting Go reconciler (predicted-vs-actual fill)"
 spawn_with_restart aether-reconciler bin/aether-reconciler
+
+# Profit scorer (Rust bin) — writes mempool_profitability, the "would-be
+# profit" headline of the run. Supervised like the others; without it the
+# profitability ledger never fills. Reuses MEMPOOL_LEDGER_DSN + ETH_RPC_URL
+# (already exported); metrics on :9095.
+export PROFIT_SCORER_METRICS_ADDR="${PROFIT_SCORER_METRICS_ADDR:-:9095}"
+export AETHER_GIT_SHA="${AETHER_GIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+spawn_with_restart aether-profit-scorer target/release/aether-profit-scorer
 
 # ─────────────────────────────────────────────────────────────────────────
 # Step 9 — Monitor (HTML dashboard at :8080)

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,5 +1,16 @@
 version: "3.8"
 
+# Bound container log growth for long (multi-day) shadow runs. Docker's
+# default json-file driver has no size cap, so over a week the per-container
+# logs grow without limit and can fill the host disk. Cap each at
+# 50MB x 5 files (~250MB/container) and apply via the `*default-logging`
+# anchor on every long-running service below.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
 services:
   aether-rust:
     build:
@@ -28,6 +39,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   aether-go:
     build:
@@ -51,6 +63,7 @@ services:
       - aether-rust
     networks:
       - aether-net
+    logging: *default-logging
 
   prometheus:
     # Pin to a known-good major to avoid silent breaking upgrades on
@@ -66,6 +79,7 @@ services:
       - alertmanager
     networks:
       - aether-net
+    logging: *default-logging
 
   alertmanager:
     image: prom/alertmanager:v0.27.0
@@ -102,6 +116,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   grafana:
     image: grafana/grafana:10.4.7
@@ -120,6 +135,7 @@ services:
       - prometheus
     networks:
       - aether-net
+    logging: *default-logging
 
   loki:
     image: grafana/loki:2.9.4
@@ -138,6 +154,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   promtail:
     image: grafana/promtail:2.9.4
@@ -153,6 +170,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   tempo:
     image: grafana/tempo:2.6.1
@@ -167,6 +185,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   canary:
     build:
@@ -183,6 +202,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   # Trade-ledger Postgres. Binaries are no-op backward-compatible when
   # DATABASE_URL is unset, so devs not using the ledger should not pay the
@@ -193,6 +213,26 @@ services:
     container_name: aether-postgres
     profiles:
       - ledger
+    # Tuned for the write/delete-heavy mempool ledger over a multi-day run.
+    # The retention sweep (PruneMempoolLedger) deletes old predictions daily,
+    # generating dead tuples in bursts; the aggressive autovacuum settings keep
+    # the high-churn tables from bloating between sweeps. max_connections is
+    # raised to give the engine writer, reconciler, scorer, monitor and ad-hoc
+    # psql headroom over the default 100.
+    command:
+      - "postgres"
+      - "-c"
+      - "max_connections=200"
+      - "-c"
+      - "autovacuum_vacuum_scale_factor=0.05"
+      - "-c"
+      - "autovacuum_analyze_scale_factor=0.02"
+      - "-c"
+      - "autovacuum_vacuum_cost_limit=2000"
+      - "-c"
+      - "autovacuum_naptime=20s"
+      - "-c"
+      - "autovacuum_max_workers=4"
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-aether}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-aether}
@@ -209,6 +249,7 @@ services:
     restart: unless-stopped
     networks:
       - aether-net
+    logging: *default-logging
 
   # Local Ethereum node (opt-in). Start with: docker compose --profile node up -d
   # Shares /tmp/reth via volume so aether-rust can connect over IPC (/tmp/reth.ipc)
@@ -227,6 +268,7 @@ services:
       --ipcpath /tmp/reth.ipc
     networks:
       - aether-net
+    logging: *default-logging
 
 
 volumes:

--- a/deploy/docker/grafana/dashboards/backrun_funnel.json
+++ b/deploy/docker/grafana/dashboards/backrun_funnel.json
@@ -1,0 +1,1062 @@
+{
+  "uid": "aether-backrun-funnel",
+  "title": "Aether \u2014 Backrun Funnel & Diagnostics",
+  "tags": [
+    "aether",
+    "mempool",
+    "backrun",
+    "funnel"
+  ],
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timezone": "",
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "\u2460 Backrun conversion funnel",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Decoded DEX txs (1m rate)",
+      "description": "Pending victim DEX swaps successfully decoded \u2014 funnel input.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_pending_dex_tx_total{job=~\"aether-rust|aether-host-rust\",decoded=\"true\"}[1m]))",
+          "legendFormat": "tx/s"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Arb candidates (1m rate)",
+      "description": "Profitable CYCLES found per decoded victim (pre-simulation estimate). NOTE: this fans out \u2014 one victim tx commonly yields many candidate cycles, so this counter runs far above the decoded-tx count and is NOT a strict funnel stage.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_pending_arb_candidates_total{job=~\"aether-rust|aether-host-rust\"}[1m]))",
+          "legendFormat": "cand/s"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Backrun validated (total)",
+      "description": "Candidates that PASSED the revm two-tx sim (victim+arb both succeed, net>0).",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(aether_mempool_backrun_validated_total{job=~\"aether-rust|aether-host-rust\"}) or vector(0)",
+          "legendFormat": "validated"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Arbs published (total)",
+      "description": "ValidatedArbs handed to the Go executor over gRPC. NOTE: this counter is shared by BOTH the block-driven and mempool-backrun sources \u2014 it is not backrun-exclusive.",
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(aether_arbs_published_total{job=~\"aether-rust|aether-host-rust\"}) or vector(0)",
+          "legendFormat": "published"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 6,
+      "type": "bargauge",
+      "title": "Validation funnel (monotonic): attempted \u2192 accepted \u2192 published",
+      "description": "The genuinely monotonic tail of the pipeline: every candidate cycle handed to the revm validator either accepts or rejects. published \u2264 validated \u2264 attempted. (Upstream, decoded-txs \u2192 candidates is FAN-OUT, not a funnel \u2014 see the stat cards above.) A near-zero stage 2 with a large stage 1 means sims reject nearly everything; the rejection-reason panels below say why.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(aether_mempool_backrun_validation_latency_ms_count{job=~\"aether-rust|aether-host-rust\"}) or vector(0)",
+          "legendFormat": "1 \u00b7 Validations attempted (revm two-tx sim)"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(aether_mempool_backrun_validated_total{job=~\"aether-rust|aether-host-rust\"}) or vector(0)",
+          "legendFormat": "2 \u00b7 Validated (sim-accepted, net>0)"
+        },
+        {
+          "refId": "C",
+          "expr": "sum(aether_arbs_published_total{job=~\"aether-rust|aether-host-rust\"}) or vector(0)",
+          "legendFormat": "3 \u00b7 Published to executor (all sources)"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "valueMode": "color"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "continuous-BlPu"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "\u2461 Rejection & skip diagnostics (THE signal)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Backrun rejections by reason (5m rate)",
+      "description": "Why validated backruns are rejected. sim_error = revm/RPC error during the two-tx sim; victim_reverted = victim leg reverted against fork state; below_min_profit_optimized = net < min after sizing.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(aether_mempool_backrun_rejected_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 9,
+      "type": "piechart",
+      "title": "Backrun rejection share (lifetime)",
+      "description": "Cumulative rejection breakdown since process start.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (aether_mempool_backrun_rejected_total{job=~\"aether-rust|aether-host-rust\"})",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "pieType": "donut",
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Pre-sim skips by reason (5m rate)",
+      "description": "Candidates dropped BEFORE the revm validator: unresolved_executor (1inch/opaque), predictor_low_confidence, pool_not_registered, graph_edge_missing, no_profitable_cycle.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(aether_pending_arb_sim_skipped_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Arb candidates by profit bucket (1m rate)",
+      "description": "Pre-sim estimated profit distribution of candidates.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (profit_bucket) (rate(aether_pending_arb_candidates_total{job=~\"aether-rust|aether-host-rust\"}[1m]))",
+          "legendFormat": "{{profit_bucket}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "\u2462 Simulation health (why sims fail / stall)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Backrun validation latency p50/p95/p99 (ms)",
+      "description": "Target is <5ms. Multi-hundred-ms / multi-second values indicate the revm fork is blocking on cold RPC fetches (AlloyDB cache misses) \u2014 the root cause of most sim_error rejects.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(aether_mempool_backrun_validation_latency_ms_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(aether_mempool_backrun_validation_latency_ms_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(aether_mempool_backrun_validation_latency_ms_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "stacking": {
+              "mode": "none"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Post-state replay outcomes (5m rate)",
+      "description": "Victim post-state prediction via revm replay (V3 / Balancer / Curve). sim_error / read_call_failed here means the RPC-backed reader could not read pool state.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (rate(aether_mempool_post_state_replay_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 15,
+      "type": "stat",
+      "title": "Prewarm cache hit ratio",
+      "description": "Fraction of sims that found warm prewarmed bytecode. Only bytecode is prewarmed \u2014 reserve/balance storage is always a cold RPC fetch.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 40
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_mempool_prewarm_inject_total{job=~\"aether-rust|aether-host-rust\",result=\"hit\"}[5m])) / clamp_min(sum(rate(aether_mempool_prewarm_inject_total{job=~\"aether-rust|aether-host-rust\"}[5m])), 1e-9)",
+          "legendFormat": "hit ratio"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.9
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "EVM sim fallback by reason (5m rate)",
+      "description": "Analytical predictor fell back to a revm replay.",
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 40
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(aether_sim_evm_fallback_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "stacking": {
+              "mode": "none"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 17,
+      "type": "stat",
+      "title": "Raw re-encode mismatches (total)",
+      "description": "Victim raw-tx bundle integrity: nonzero means a captured raw tx did not re-encode to the same hash (would produce an invalid bundle).",
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 40
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(aether_mempool_raw_reencode_mismatch_total{job=~\"aether-rust|aether-host-rust\"}) or vector(0)",
+          "legendFormat": "mismatches"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 18,
+      "type": "row",
+      "title": "\u2463 Block-driven cycle gating",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Cycle-gate drops by reason (5m rate)",
+      "description": "Raw Bellman-Ford cycles filtered out: reserves_too_low (thin liquidity), fingerprint_cluster (duplicate sibling cycles), revm_contradicts (revm disagreed with analytical detection \u2014 true phantom arbs).",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(aether_cycle_gate_dropped_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Cycles detected vs arbs published (5m rate)",
+      "description": "Block-driven detection volume vs what survives to publishing.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_cycles_detected_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "cycles detected"
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(aether_arbs_published_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "arbs published"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "stacking": {
+              "mode": "none"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 21,
+      "type": "row",
+      "title": "\u2464 Mempool decode coverage",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      }
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "Decode success rate",
+      "description": "Share of pending DEX txs the decoders understood.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 58
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * sum(rate(aether_pending_dex_tx_total{job=~\"aether-rust|aether-host-rust\",decoded=\"true\"}[5m])) / clamp_min(sum(rate(aether_pending_dex_tx_total{job=~\"aether-rust|aether-host-rust\"}[5m])), 1e-9)",
+          "legendFormat": "decoded %"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Decoder failures by reason (1m rate)",
+      "description": "unknown_selector / multicall_no_swaps / too_short \u2014 router flows we are not decoding (lost candidate supply).",
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 58
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(aether_pending_decode_errors_total{job=~\"aether-rust|aether-host-rust\"}[1m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Pending DEX tx by protocol (1m rate)",
+      "description": "Decoded victim flow by protocol \u2014 where arbable volume is coming from.",
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 58
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (protocol) (rate(aether_pending_dex_tx_total{job=~\"aether-rust|aether-host-rust\"}[1m]))",
+          "legendFormat": "{{protocol}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    }
+  ]
+}

--- a/deploy/docker/prometheus/alerts.yml
+++ b/deploy/docker/prometheus/alerts.yml
@@ -99,3 +99,67 @@ groups:
         annotations:
           summary: "Alertmanager scrape target is down"
           description: "Prometheus has been unable to scrape alertmanager:9093 for 2m. Slack delivery is offline. Check the alertmanager container logs and SLACK_WEBHOOK_URL config."
+
+  # Unattended-run health for the public-mempool shadow soak (Arm A). These
+  # watch the observability pipeline (predictions -> reconciliation ->
+  # profitability) rather than the execution path, so they apply whether or
+  # not the executor/backrun validator is running.
+  - name: aether.shadow.rules
+    interval: 30s
+    rules:
+
+      # Fires only for a target that was scraped within the last hour and is
+      # now down — so a never-deployed target (wrong compose profile, or the
+      # executor in an Arm-A run) is silent by design, while a producer that
+      # actually died (or crash-loops past spawn_with_restart's backoff) pages.
+      - alert: AetherProducerDown
+        expr: |
+          up{job=~"aether-rust|aether-go|aether-host-rust|aether-host-reconciler|aether-host-scorer|aether-host-monitor"} == 0
+          and on(job, instance)
+          max_over_time(up{job=~"aether-rust|aether-go|aether-host-rust|aether-host-reconciler|aether-host-scorer|aether-host-monitor"}[1h]) > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Aether producer {{ $labels.job }} is down"
+          description: "Prometheus could not scrape {{ $labels.job }} ({{ $labels.instance }}) for >2m after previously being up. A supervised process is down or crash-looping past its restart window — grep its log for an '[ALERT] crash-looping' line."
+
+      # Catches a silently-dead mempool WS subscription that does NOT crash the
+      # engine (so AetherProducerDown stays quiet): predictions simply stop
+      # being written. The 15m window + 15m `for` already gives ~30m of grace,
+      # and the boot suppression is belt-and-suspenders (no-op if the rust
+      # client does not export process_start_time_seconds).
+      - alert: MempoolPredictionsStalled
+        expr: |
+          sum(rate(aether_mempool_predictions_persisted_total[15m])) == 0
+          unless on() (
+            (time() - min(process_start_time_seconds{job=~"aether-rust|aether-host-rust"})) < 1800
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No mempool predictions persisted in 15m"
+          description: "aether_mempool_predictions_persisted_total has been flat for 15m while the engine is up — likely a dead WS subscription or a dropped MEMPOOL_LEDGER_DSN. The Arm-A headline ledger is not filling."
+
+      # PruneMempoolLedger errors usually mean Postgres connectivity/permission
+      # trouble; left unattended the predictions ledger then grows unbounded.
+      - alert: MempoolRetentionErrors
+        expr: increase(aether_mempool_retention_errors_total[15m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Mempool retention sweep is failing"
+          description: "PruneMempoolLedger errored {{ $value }} time(s) in 15m. The predictions ledger may grow unbounded; check Postgres reachability and the reconciler logs."
+
+      # Reconciliation writer channel saturated (or Postgres slow) — coverage
+      # gaps in the reconciliation table follow.
+      - alert: MempoolReconcilerDrops
+        expr: increase(aether_mempool_reconciler_drops_total[10m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Reconciler is dropping writes"
+          description: "{{ $value }} reconciliation row(s) dropped in 10m — the writer channel saturated or Postgres is slow. Reconciliation coverage will have gaps."

--- a/internal/db/mempool_reconciliation_pg.go
+++ b/internal/db/mempool_reconciliation_pg.go
@@ -15,6 +15,10 @@
 //   - MarkStaleAsDropped: batch SQL that inserts `outcome='dropped'` rows
 //     for every prediction past its 12-block grace window without a
 //     reconciliation row.
+//   - PruneMempoolLedger: time-based retention sweep. Deletes predictions
+//     older than a horizon; the ON DELETE CASCADE FKs drop the matching
+//     reconciliation + profitability rows, keeping the ledger bounded over a
+//     long unattended shadow run.
 //
 // See migrations/0004_mempool_reconciliation.sql for the schema.
 
@@ -80,16 +84,16 @@ type PendingPrediction struct {
 // public constants so callers can switch on a stable identifier instead of
 // re-typing the literal each time.
 type NewReconciliation struct {
-	PredictionID       uuid.UUID
-	ResolutionTs       time.Time
-	Outcome            string
-	ActualTargetBlock  *uint64
-	ActualTxIndex      *int
-	BlockDelta         *int
-	OrderingCorrect    *bool
-	PoolPathCorrect    *bool
-	ReplacedByTxHash   *[32]byte
-	FailureReason      *string
+	PredictionID      uuid.UUID
+	ResolutionTs      time.Time
+	Outcome           string
+	ActualTargetBlock *uint64
+	ActualTxIndex     *int
+	BlockDelta        *int
+	OrderingCorrect   *bool
+	PoolPathCorrect   *bool
+	ReplacedByTxHash  *[32]byte
+	FailureReason     *string
 }
 
 const (
@@ -199,9 +203,9 @@ func (r *PgMempoolReconciliation) LookupPredictionByTxHash(
 	`, txHash[:])
 
 	var (
-		pred       PendingPrediction
-		poolBytes  []byte
-		targetBlk  int64
+		pred      PendingPrediction
+		poolBytes []byte
+		targetBlk int64
 	)
 	if err := row.Scan(&pred.PredictionID, &pred.Protocol, &poolBytes, &targetBlk); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -277,6 +281,33 @@ func (r *PgMempoolReconciliation) MarkStaleAsDropped(
 		r.metrics.ReconciledTotal.WithLabelValues(OutcomeDropped).Add(float64(rows))
 	}
 	return rows, nil
+}
+
+// PruneMempoolLedger deletes `mempool_predictions` rows whose `decoded_at` is
+// older than `retain`, returning the number of prediction rows removed. The
+// ON DELETE CASCADE FKs on `mempool_reconciliation` and `mempool_profitability`
+// (migrations 0004 / 0005) drop the matching child rows in the same statement,
+// so one DELETE bounds all three tables.
+//
+// The cutoff is computed from the client clock (matching the client-set
+// `decoded_at` policy), and `decoded_at` is indexed (migrations/0003), so the
+// WHERE is an index range scan rather than a full table scan. A 48h-class
+// horizon is far past the reconciliation/scoring window (minutes), so pruned
+// rows are always fully resolved — retention never races the reconciler or
+// scorer for an in-flight prediction.
+func (r *PgMempoolReconciliation) PruneMempoolLedger(
+	ctx context.Context,
+	retain time.Duration,
+) (int64, error) {
+	cutoff := time.Now().Add(-retain)
+	tag, err := r.pool.Exec(ctx, `
+		DELETE FROM mempool_predictions
+		WHERE decoded_at < $1
+	`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("prune mempool ledger: %w", err)
+	}
+	return tag.RowsAffected(), nil
 }
 
 func (r *PgMempoolReconciliation) dispatch(ctx context.Context) {


### PR DESCRIPTION
Net-new features for the unattended public-mempool **shadow run**, landed on develop's foundation. No submission path is touched — all of this is observability / discovery / ops hardening.

## What's included
- **Hot-token discovery** (`AETHER_DISCOVERY=1`, off by default) — `HotTokenTracker` records every decoded mempool swap; the discovery loop screens frequently-traded candidates with a fee-on-transfer round-trip (revm, own timeout), qualifies venue liquidity, and appends admitted pools to `pools.toml` + reloads the registry (capped at `AETHER_MAX_ADMITTED_POOLS`). Wired **additively** into `SimContext` (new field + a `record()` hook in the decode loop) — develop's backrun design is untouched.
- **WS idle keepalive** — `subscribe_once` gains an idle-watchdog arm (`MEMPOOL_WS_IDLE_TIMEOUT_SECS`, default 60, 0=off) that drops+reconnects on a silent TCP half-close. Registers `MempoolIngestMetrics` so `idle_reconnect_total` + the re-encode counter populate.
- **Mempool retention sweep** — `PruneMempoolLedger` + `runRetentionLoop` in the reconciler (`MEMPOOL_RETENTION_HOURS` def 48 / `_INTERVAL_MINS` def 60; children dropped `ON DELETE CASCADE`).
- **demo.sh** — `AETHER_ARM` gating (A = analytical-only), profit-scorer under `spawn_with_restart` with a crash-loop bound, `start_log_janitor` (copytruncate, independent of respawn), and `AETHER_DISCOVERY` opt-in carrying the *discovery→canary / freeze-`pools.toml`→measurement* guardrail.
- **Alerting** — `aether.shadow.rules` group (producer-down, predictions-stalled, retention-errors, reconciler-drops).
- **Postgres tuning** — aggressive autovacuum + `max_connections=200`; `x-logging` json-file 50MB×5 caps on all compose services.
- **Backrun funnel & diagnostics** Grafana dashboard (auto-provisioned).

## Foundation-adaptation notes
- develop's foundation is treated as **canonical**. The 6 foundation files that diverged (`router_decoder`, `mempool_backrun`, `fork`, `mempool_pipeline`, `metrics`, `mempool`) plus `engine.rs`/`cycle_gating.rs`/`price_graph.rs`/`pools.toml` use **develop's** version; only net-new feature deltas are layered on.
- The **dynamic-gas oracle was dropped**: develop's backrun sizes with a fixed `input_amount_wei` and prices gas in the revm sim — there is no static pre-revm coarse gate for it to make dynamic, so the feature is obsolete here.

## Validation
`cargo clippy --workspace` clean · grpc-server (75) / ingestion (82) / simulator (96) / `*-bins` tests green · `go build`/`vet`/`test` · `bash -n demo.sh` · `docker compose --profile ledger --profile node config` · `promtool` (12 rules).