### PR TITLE
fix(mempool): make backrun arbs executable + edge quarantine + multi-venue pools

### DIFF
--- a/config/pools.toml
+++ b/config/pools.toml
@@ -1176,3 +1176,71 @@ tier = "warm"
 # token1 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC
 # fee_bps = 1
 # tier = "cold"
+
+# ---------------------------------------------------------------------------
+# Extra venues for high-traction pairs — gives the most-traded pairs >=2
+# *executable* venues (UniV2/V3/Sushi; the mempool-backrun path builds calldata
+# only for these). Every address verified on-chain (getCode + token0/token1 +
+# fee) at block ~25.24M via cast against mainnet before being added.
+#   - USDC/USDT had only same-family UniV3 tiers → add UniV2 (cross-AMM).
+#   - WETH/USDT, DAI/USDC, WBTC/WETH, wstETH/WETH → add the missing UniV3 tier.
+#   - DAI/USDT was unlisted → add UniV2 + UniV3 so the pair itself is 2-venue
+#     and the USDC/USDT/DAI stable triangle is denser.
+# fee_bps convention: UniV3 fee / 100 (fee 100→1, 500→5, 3000→30, 10000→100).
+# ---------------------------------------------------------------------------
+
+[[pools]]
+protocol = "uniswap_v2"
+address = "0x3041CbD36888bECc7bbCBc0045E3B1f144466f5f"
+token0 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC
+token1 = "0xdAC17F958D2ee523a2206206994597C13D831ec7"  # USDT
+fee_bps = 30
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v3"
+address = "0xC5aF84701f98Fa483eCe78aF83F11b6C38ACA71D"
+token0 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH
+token1 = "0xdAC17F958D2ee523a2206206994597C13D831ec7"  # USDT
+fee_bps = 100  # UniV3 1.0%
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v3"
+address = "0x6c6Bc977E13Df9b0de53b251522280BB72383700"
+token0 = "0x6B175474E89094C44Da98b954EedeAC495271d0F"  # DAI
+token1 = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"  # USDC
+fee_bps = 5  # UniV3 0.05%
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v3"
+address = "0xD340B57AAcDD10F96FC1CF10e15921936F41E29c"
+token0 = "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"  # wstETH
+token1 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH
+fee_bps = 5  # UniV3 0.05%
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v3"
+address = "0x6Ab3bba2F41e7eAA262fa5A1A9b3932fA161526F"
+token0 = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"  # WBTC
+token1 = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"  # WETH
+fee_bps = 100  # UniV3 1.0%
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v2"
+address = "0xB20bd5D04BE54f870D5C0d3cA85d82b34B836405"
+token0 = "0x6B175474E89094C44Da98b954EedeAC495271d0F"  # DAI
+token1 = "0xdAC17F958D2ee523a2206206994597C13D831ec7"  # USDT
+fee_bps = 30
+tier = "hot"
+
+[[pools]]
+protocol = "uniswap_v3"
+address = "0x48DA0965ab2d2cbf1C17C09cFB5Cbe67Ad5B1406"
+token0 = "0x6B175474E89094C44Da98b954EedeAC495271d0F"  # DAI
+token1 = "0xdAC17F958D2ee523a2206206994597C13D831ec7"  # USDT
+fee_bps = 1  # UniV3 0.01%
+tier = "hot"

--- a/crates/grpc-server/src/engine.rs
+++ b/crates/grpc-server/src/engine.rs
@@ -1429,6 +1429,9 @@ impl AetherEngine {
         let mut fetched: u32 = 0;
         {
             let mut graph = self.working_graph.lock().await;
+            // Stamp the block so update_edge_from_reserves records each edge's
+            // freshness (used by quarantine_stale_edges' age backstop).
+            graph.set_current_block(self.current_block.load().number);
             for reserve in all_results {
                 match reserve {
                     ReserveResult::V2 { pool_addr, meta, r0, r1 } => {
@@ -1872,9 +1875,28 @@ impl AetherEngine {
         // update would never trigger a detection scan (TOCTOU on dirty flags).
         let (detection_graph, block_number, timestamp_ns) = {
             let mut graph = self.working_graph.lock().await;
+            let block = (**self.current_block.load()).clone();
+            // Stamp the block, then quarantine never-updated placeholder edges
+            // (always) plus, if AETHER_EDGE_MAX_AGE_BLOCKS>0, missed-event-stale
+            // edges. Filtered edges are skipped by Bellman-Ford, so this kills
+            // the placeholder rate=1.0 phantom-cycle source before detection.
+            // Done under the lock before the clone so the filter both feeds this
+            // cycle's detection_graph and persists in the working graph.
+            graph.set_current_block(block.number);
+            let max_age_blocks = std::env::var("AETHER_EDGE_MAX_AGE_BLOCKS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
+            let quarantined = graph.quarantine_stale_edges(max_age_blocks);
+            if quarantined > 0 {
+                debug!(
+                    quarantined,
+                    block = block.number,
+                    "quarantined stale/placeholder edges before detection"
+                );
+            }
             let snapshot_graph = graph.clone();
             graph.clear_dirty();
-            let block = (**self.current_block.load()).clone();
             (snapshot_graph, block.number, block.timestamp as i64)
         };
 
@@ -3737,6 +3759,7 @@ fee_bps = 30
             reserve_in: 0.0,
             reserve_out: 0.0,
             filtered: false,
+            last_update_block: 0,
         }
     }
 

--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -37,7 +37,9 @@ use aether_pools::{
     predict_post_state_with_replay, Pool, PoolState, PoolStateCache, ReplayProtocol,
     UnifiedPostState,
 };
-use aether_simulator::calldata::build_execute_arb_calldata;
+use aether_simulator::calldata::{
+    build_execute_arb_calldata, build_univ2_swap_calldata, build_univ3_swap_calldata,
+};
 use aether_simulator::mempool_backrun::{
     validate_backrun_rpc, ArbTx, RejectReason, ValidatorParams, VictimTx,
 };
@@ -1190,7 +1192,10 @@ fn try_post_state_scan(
                 metrics,
                 publisher,
                 cfg,
-                &snapshot.graph,
+                // Post-victim clone the cycle was detected & gated on — so
+                // cycle_to_swap_steps routes the victim hop through the SAME
+                // pool Bellman-Ford scored (was &snapshot.graph = pre-victim).
+                &graph,
                 ctx.token_index.load().as_ref(),
                 best,
                 event,
@@ -1491,7 +1496,10 @@ fn try_post_state_scan_bancor_multihop(
                 metrics,
                 publisher,
                 cfg,
-                &snapshot.graph,
+                // Post-victim clone the cycle was detected & gated on — so
+                // cycle_to_swap_steps routes the victim hop through the SAME
+                // pool Bellman-Ford scored (was &snapshot.graph = pre-victim).
+                &graph,
                 ctx.token_index.load().as_ref(),
                 best,
                 event,
@@ -1598,14 +1606,36 @@ fn try_post_state_replay(
     // so the dashboard separates dispatch-time failures from per-protocol
     // reader failures.
     let started = Instant::now();
-    let result: Result<UnifiedPostState, &'static str> = match protocol {
-        ReplayProtocol::UniswapV3 => {
-            let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
+    // Pin the detection-time replay fork to the SAME block the validating sim
+    // defaults to (`block_number`), so the analytical victim post-state that
+    // shapes the detection graph is computed against the same state the pinned
+    // sim executes against — no detection-vs-sim block asymmetry.
+    // `AETHER_BACKRUN_FORK_LATEST=1` falls back to chain HEAD in lockstep with
+    // the validator (the Anvil-fork escape hatch).
+    let fork_latest = std::env::var("AETHER_BACKRUN_FORK_LATEST")
+        .ok()
+        .as_deref()
+        == Some("1");
+    let make_replay_fork = || {
+        if fork_latest {
+            aether_simulator::fork::RpcForkedState::new_at_latest(
                 provider.clone(),
                 block_number,
                 now_secs,
                 1_000_000_000,
-            ) {
+            )
+        } else {
+            aether_simulator::fork::RpcForkedState::new(
+                provider.clone(),
+                block_number,
+                now_secs,
+                1_000_000_000,
+            )
+        }
+    };
+    let result: Result<UnifiedPostState, &'static str> = match protocol {
+        ReplayProtocol::UniswapV3 => {
+            let state = match make_replay_fork() {
                 Some(s) => s,
                 None => {
                     metrics.inc_mempool_post_state_replay("sim_error");
@@ -1635,12 +1665,7 @@ fn try_post_state_replay(
                 metrics.inc_mempool_post_state_replay("decode_failed");
                 return None;
             };
-            let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
-                provider.clone(),
-                block_number,
-                now_secs,
-                1_000_000_000,
-            ) {
+            let state = match make_replay_fork() {
                 Some(s) => s,
                 None => {
                     metrics.inc_mempool_post_state_replay("sim_error");
@@ -1668,12 +1693,7 @@ fn try_post_state_replay(
                 metrics.inc_mempool_post_state_replay("decode_failed");
                 return None;
             };
-            let state = match aether_simulator::fork::RpcForkedState::new_at_latest(
-                provider.clone(),
-                block_number,
-                now_secs,
-                1_000_000_000,
-            ) {
+            let state = match make_replay_fork() {
                 Some(s) => s,
                 None => {
                     metrics.inc_mempool_post_state_replay("sim_error");
@@ -1836,6 +1856,43 @@ fn run_backrun_validation(
         SizingOutcome::Fallback => cfg.input_amount_wei,
     };
 
+    // Populate each hop's inner swap calldata. The AetherExecutor runs
+    // `step.pool.call(step.data)` verbatim — an EMPTY `data` reverts
+    // (SwapFailed), so this MUST happen before the sim/publish (leaving it
+    // empty made every backrun sim revert). Build it AFTER sizing so the V2
+    // amountOut reflects the optimizer-sized per-hop input; overlay the
+    // victim pool's post-victim reserves so the requested amountOut matches
+    // what the pool yields after the victim swap lands.
+    for step in steps.iter_mut() {
+        let Some(entry) = pool_states.get(&step.pool_address) else {
+            metrics.inc_mempool_backrun_rejected("pool_state_missing_calldata");
+            return None;
+        };
+        let mut ps = entry.value().as_ref().clone();
+        drop(entry);
+        if step.pool_address == victim_pool {
+            if let PoolState::UniswapV2(p) | PoolState::SushiSwap(p) = &mut ps {
+                if let Some((r0, r1)) =
+                    victim_post_reserves(p, victim_token_in, victim_post_in, victim_post_out)
+                {
+                    p.update_state(r0, r1);
+                }
+            }
+        }
+        match build_inner_swap_calldata(&ps, step, cfg.executor_address) {
+            Some((cd, plabel)) => {
+                step.calldata = cd;
+                metrics.inc_mempool_backrun_calldata_built(plabel);
+            }
+            None => {
+                // Curve/Balancer/Bancor hop with no inner-calldata builder:
+                // drop rather than publish a bundle that reverts on-chain.
+                metrics.inc_mempool_backrun_rejected("unsupported_protocol_calldata");
+                return None;
+            }
+        }
+    }
+
     // Deadline: now + 24s (~2 blocks of mainnet slot time). Mirrors the
     // block-driven path's deadline convention.
     let now_secs = std::time::SystemTime::now()
@@ -1843,13 +1900,26 @@ fn run_backrun_validation(
         .unwrap_or_default()
         .as_secs();
     let deadline = U256::from(now_secs + 24);
-    let calldata = build_execute_arb_calldata(
+    // SIM calldata uses tipBps=0 so 100% of profit lands at
+    // owner()==profit_recipient and the measured balance delta is the FULL arb
+    // profit (not the ~10% the owner keeps after a 90% coinbase tip). The
+    // PUBLISHED calldata carries the real builder tip so the submitted bundle
+    // still pays the coinbase — the two are deliberately separate.
+    let sim_calldata = build_execute_arb_calldata(
         &steps,
         flashloan_token,
         flashloan_amount,
         deadline,
         cfg.min_profit_wei,
-        U256::from(9000u64), // 90% tip share — conservative starting point
+        U256::ZERO,
+    );
+    let exec_calldata = build_execute_arb_calldata(
+        &steps,
+        flashloan_token,
+        flashloan_amount,
+        deadline,
+        cfg.min_profit_wei,
+        U256::from(9000u64), // 90% tip share — what the on-chain bundle pays
     );
 
     let victim = VictimTx {
@@ -1866,7 +1936,8 @@ fn run_backrun_validation(
         // A flashloan + multi-hop arb (Aave ~80k + per-hop swaps + executor
         // overhead) routinely exceeds 1.5M for 3+ hops, OOG-halting a valid
         // arb leg. 3M matches the live-fork integration test's budget.
-        data: calldata,
+        // tipBps=0 sim calldata so the sim measures FULL profit (see above).
+        data: sim_calldata,
         gas_limit: 3_000_000,
     };
     let params = ValidatorParams {
@@ -2002,7 +2073,27 @@ fn run_backrun_validation(
     // over-estimating profit versus what revm actually realized against the
     // (pinned) forked state — a stale-snapshot signature. Drop before
     // publishing rather than handing the executor a contradicted arb.
-    let actual_profit_u128: u128 = result.gross_profit_wei.try_into().unwrap_or(u128::MAX);
+    // Align units before the gate. revm reports FULL gross profit (the sim ran
+    // with tipBps=0 so 100% lands at the recipient); subtract the sim's gas
+    // cost so it is a NET figure comparable to the optimizer's net
+    // `expected_net_wei`. Without this the gate compared net-vs-gross (and,
+    // pre-fix, full-net-vs-10%-owner-share), producing frac_diff ~0.9 and
+    // dropping genuine marginal arbs as revm_contradicts.
+    let sim_gas_cost_wei =
+        U256::from(result.arb_gas_used).saturating_mul(U256::from(params.base_fee));
+    let actual_net_wei = result.gross_profit_wei.saturating_sub(sim_gas_cost_wei);
+    let actual_profit_u128: u128 = actual_net_wei.try_into().unwrap_or(u128::MAX);
+    // Discrepancy gauge: revm-actual NET vs optimizer-expected NET. Clusters at
+    // ~1.0 when detection-state matches sim-state. Only meaningful when the
+    // optimizer sized the arb; the Fallback path leaves expected_net_wei == 0
+    // and bypasses the cross-check entirely (tracked separately).
+    if expected_net_wei > 0 {
+        metrics.observe_mempool_backrun_profit_ratio(
+            actual_profit_u128 as f64 / expected_net_wei as f64,
+        );
+    } else {
+        metrics.inc_mempool_post_sim_gate_bypassed();
+    }
     if let PostSimGateVerdict::Drop(_) =
         cycle_gating::gate_post_sim(expected_net_wei, actual_profit_u128, &gating, metrics)
     {
@@ -2026,12 +2117,14 @@ fn run_backrun_validation(
                 .unwrap_or(0)
         ),
         hops: vec![], // detailed hop info lives on the SwapStep list below
+        // FULL arb profit (sim ran tipBps=0 so the recipient delta is the
+        // whole profit, not the post-tip owner share).
         total_profit_wei: u256_bytes(result.gross_profit_wei),
         total_gas: result.arb_gas_used,
-        gas_cost_wei: u256_bytes(
-            U256::from(result.arb_gas_used).saturating_mul(U256::from(params.base_fee)),
-        ),
-        net_profit_wei: u256_bytes(result.gross_profit_wei),
+        gas_cost_wei: u256_bytes(sim_gas_cost_wei),
+        // Net = full gross − gas (previously duplicated gross with no gas
+        // subtraction, overstating net to the reconciler/executor).
+        net_profit_wei: u256_bytes(actual_net_wei),
         block_number,
         timestamp_ns: now_secs as i64 * 1_000_000_000,
         flashloan_token: flashloan_token.to_vec().into(),
@@ -2041,7 +2134,9 @@ fn run_backrun_validation(
         // the reconciler would compare against the wrong size.
         flashloan_amount: u256_bytes(flashloan_amount),
         steps: steps.into_iter().map(swap_step_to_proto).collect(),
-        calldata: arb.data.into(),
+        // Publish the EXECUTION calldata (real builder tip), NOT the tipBps=0
+        // calldata the sim ran for full-profit measurement.
+        calldata: exec_calldata.into(),
         source: aether_proto::ArbSource::MempoolBackrun as i32,
         victim_tx_hash: event.tx_hash.0.to_vec().into(),
         target_block: block_number.saturating_add(1),
@@ -2157,6 +2252,74 @@ fn poolstate_quote(ps: &PoolState, token_in: Address, amount_in: U256) -> Option
         PoolState::Curve(p) => p.get_amount_out(token_in, amount_in),
         PoolState::Balancer(p) => p.get_amount_out(token_in, amount_in),
         PoolState::Bancor(p) => p.get_amount_out(token_in, amount_in),
+    }
+}
+
+/// Build the protocol-specific inner swap calldata the `AetherExecutor`
+/// executes verbatim via `pool.call(step.data)`. EMPTY calldata reverts
+/// on-chain (`SwapFailed`), so every published hop MUST carry this — leaving
+/// it empty is what made every backrun sim revert (false negatives).
+///
+/// V2/Sushi: `swap(amount0Out, amount1Out, executor, "")` with the exact
+/// per-hop output (quoted against `ps`, which the caller has already overlaid
+/// with the post-victim reserves for the victim pool so the requested
+/// `amountOut` matches what the pool yields after the victim swap). V3:
+/// exact-input `swap(executor, zeroForOne, +amountIn, sqrtPriceLimit, "")`.
+///
+/// Curve / Balancer / Bancor have no inner-calldata builder yet — returns
+/// `None` so the caller drops the candidate with a distinct reject reason
+/// rather than publishing a bundle that reverts.
+// TODO: add Curve/Balancer/Bancor inner-swap calldata builders so those hops
+// can be backrun instead of dropped.
+fn build_inner_swap_calldata(
+    ps: &PoolState,
+    step: &aether_common::types::SwapStep,
+    executor: Address,
+) -> Option<(Vec<u8>, &'static str)> {
+    match (step.protocol, ps) {
+        (
+            ProtocolType::UniswapV2 | ProtocolType::SushiSwap,
+            PoolState::UniswapV2(p) | PoolState::SushiSwap(p),
+        ) => {
+            let out = poolstate_quote(ps, step.token_in, step.amount_in)?;
+            if out.is_zero() {
+                return None;
+            }
+            // amountOut goes to the slot of the OUTPUT token; token_in==token0
+            // means we receive token1 (amount1Out), and vice-versa.
+            let zero_for_one = step.token_in == p.token0;
+            let (amount0_out, amount1_out) = if zero_for_one {
+                (U256::ZERO, out)
+            } else {
+                (out, U256::ZERO)
+            };
+            let label = if step.protocol == ProtocolType::SushiSwap {
+                "sushiswap"
+            } else {
+                "uniswap_v2"
+            };
+            Some((
+                build_univ2_swap_calldata(amount0_out, amount1_out, executor),
+                label,
+            ))
+        }
+        (ProtocolType::UniswapV3, PoolState::UniswapV3(p)) => {
+            let zero_for_one = step.token_in == p.token0;
+            // Exact-input swap: positive amountSpecified; price limit set to
+            // the extreme tick in the swap direction (MIN_SQRT_RATIO+1 /
+            // MAX_SQRT_RATIO-1), matching `aether_profit_scorer`.
+            let sqrt_limit = if zero_for_one {
+                U256::from(4_295_128_740u64)
+            } else {
+                (U256::from(1u8) << 160) - U256::from(2u8)
+            };
+            let amt = i128::try_from(step.amount_in.saturating_to::<u128>()).ok()?;
+            Some((
+                build_univ3_swap_calldata(executor, zero_for_one, amt, sqrt_limit),
+                "uniswap_v3",
+            ))
+        }
+        _ => None,
     }
 }
 
@@ -2967,6 +3130,107 @@ mod tests {
             100,
             4,
         ))
+    }
+
+    // ── FIX 1 (empty-calldata) regression: cycle_to_swap_steps / the
+    // run_backrun_validation calldata loop MUST populate step.data, or the
+    // AetherExecutor's `pool.call(step.data)` reverts SwapFailed and every
+    // backrun sim is a false negative. These prove build_inner_swap_calldata
+    // emits non-empty, direction-correct calldata for V2/V3 and refuses
+    // protocols with no builder. ──
+    #[test]
+    fn build_inner_swap_calldata_v2_nonempty_and_direction_dependent() {
+        use aether_pools::uniswap_v2::UniswapV2Pool;
+        let t0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
+        let t1 = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"); // WETH
+        let pool = address!("B4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc");
+        let executor = address!("00000000000000000000000000000000000000aa");
+        let mut p = UniswapV2Pool::new(pool, t0, t1, 30);
+        p.reserve0 = U256::from(1_000_000_000_000_000_000u128);
+        p.reserve1 = U256::from(1_000_000_000_000_000_000u128);
+        let ps = PoolState::UniswapV2(p);
+
+        let step_fwd = aether_common::types::SwapStep {
+            protocol: ProtocolType::UniswapV2,
+            pool_address: pool,
+            token_in: t0,
+            token_out: t1,
+            amount_in: U256::from(1_000_000_000_000_000u128),
+            min_amount_out: U256::ZERO,
+            calldata: Vec::new(),
+        };
+        let (cd_fwd, label) =
+            build_inner_swap_calldata(&ps, &step_fwd, executor).expect("V2 calldata must build");
+        assert_eq!(label, "uniswap_v2");
+        assert!(
+            !cd_fwd.is_empty() && cd_fwd.len() >= 4,
+            "calldata must NOT be empty — empty data reverts SwapFailed on-chain"
+        );
+
+        // Flipping token_in moves amountOut to the other slot → different bytes.
+        let step_rev = aether_common::types::SwapStep {
+            protocol: ProtocolType::UniswapV2,
+            pool_address: pool,
+            token_in: t1,
+            token_out: t0,
+            amount_in: U256::from(1_000_000_000_000_000u128),
+            min_amount_out: U256::ZERO,
+            calldata: Vec::new(),
+        };
+        let (cd_rev, _) =
+            build_inner_swap_calldata(&ps, &step_rev, executor).expect("V2 reverse must build");
+        assert_ne!(
+            cd_fwd, cd_rev,
+            "amount0Out/amount1Out orientation must depend on swap direction"
+        );
+    }
+
+    #[test]
+    fn build_inner_swap_calldata_v3_nonempty() {
+        let ps = synthetic_v3_pool_state();
+        let (t0, t1) = match &ps {
+            PoolState::UniswapV3(p) => (p.token0, p.token1),
+            _ => unreachable!(),
+        };
+        let step = aether_common::types::SwapStep {
+            protocol: ProtocolType::UniswapV3,
+            pool_address: address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            token_in: t0,
+            token_out: t1,
+            amount_in: U256::from(1_000_000_000_000_000_000u128),
+            min_amount_out: U256::ZERO,
+            calldata: Vec::new(),
+        };
+        let (cd, label) =
+            build_inner_swap_calldata(&ps, &step, address!("00000000000000000000000000000000000000aa"))
+                .expect("V3 calldata must build");
+        assert_eq!(label, "uniswap_v3");
+        assert!(!cd.is_empty() && cd.len() >= 4);
+    }
+
+    #[test]
+    fn build_inner_swap_calldata_unsupported_protocol_returns_none() {
+        let t0 = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        let t1 = address!("dAC17F958D2ee523a2206206994597C13D831ec7");
+        let ps = synthetic_curve_pool_state([t0, t1]);
+        let step = aether_common::types::SwapStep {
+            protocol: ProtocolType::Curve,
+            pool_address: address!("bEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7"),
+            token_in: t0,
+            token_out: t1,
+            amount_in: U256::from(1_000_000u128),
+            min_amount_out: U256::ZERO,
+            calldata: Vec::new(),
+        };
+        assert!(
+            build_inner_swap_calldata(
+                &ps,
+                &step,
+                address!("00000000000000000000000000000000000000aa")
+            )
+            .is_none(),
+            "Curve/Balancer/Bancor have no inner-calldata builder → must drop, not emit empty"
+        );
     }
 
     /// Build a synthetic 80/20-weight Balancer `PoolState` so the

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -221,6 +221,21 @@ pub struct EngineMetrics {
     /// signal that the configured Multicall3 deployment is unreachable on
     /// this chain.
     prewarm_multicall_fallbacks_total: IntCounter,
+    /// Discrepancy gauge: ratio of revm-measured actual NET profit to the
+    /// optimizer's expected NET profit for validated mempool backruns. After
+    /// the calldata/tip/gas-unit fixes this clusters at ~1.0; a fat left tail
+    /// means detection-state and sim-state disagree (stale-snapshot signature).
+    mempool_backrun_profit_ratio: Histogram,
+    /// Count of mempool-backrun sims where the post-sim profit cross-check was
+    /// bypassed because the optimizer fell back (expected_net == 0). These
+    /// arbs publish on the sim's own accept criteria with no detector-vs-revm
+    /// cross-check, so operators should watch this share.
+    mempool_post_sim_gate_bypassed_total: IntCounter,
+    /// Inner swap calldata successfully built per hop, by protocol. Proves the
+    /// AetherExecutor receives non-empty `step.data` (empty data reverts
+    /// SwapFailed). Curve/Balancer/Bancor have no builder yet and instead bump
+    /// `mempool_backrun_rejected_total{reason="unsupported_protocol_calldata"}`.
+    mempool_backrun_calldata_built_total: IntCounterVec,
 }
 
 impl EngineMetrics {
@@ -472,6 +487,29 @@ impl EngineMetrics {
             "Multicall3 batches that errored and forced a per-pool eth_getStorageAt fallback",
         )
         .expect("aether_prewarm_multicall_fallbacks_total counter");
+        let mempool_backrun_profit_ratio = Histogram::with_opts(
+            HistogramOpts::new(
+                "aether_mempool_backrun_profit_ratio",
+                "Ratio of revm actual net profit to optimizer expected net profit for validated mempool backruns",
+            )
+            .buckets(vec![
+                0.1, 0.25, 0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 2.0, 3.0,
+            ]),
+        )
+        .expect("aether_mempool_backrun_profit_ratio histogram");
+        let mempool_post_sim_gate_bypassed_total = IntCounter::new(
+            "aether_mempool_post_sim_gate_bypassed_total",
+            "Mempool-backrun sims where the post-sim profit cross-check was bypassed (expected_net == 0)",
+        )
+        .expect("aether_mempool_post_sim_gate_bypassed_total counter");
+        let mempool_backrun_calldata_built_total = IntCounterVec::new(
+            Opts::new(
+                "aether_mempool_backrun_calldata_built_total",
+                "Inner swap calldata built per hop for the mempool-backrun path, by protocol",
+            ),
+            &["protocol"],
+        )
+        .expect("aether_mempool_backrun_calldata_built_total counter vec");
 
         registry
             .register(Box::new(detection_latency_ms.clone()))
@@ -578,6 +616,15 @@ impl EngineMetrics {
         registry
             .register(Box::new(prewarm_multicall_fallbacks_total.clone()))
             .expect("register aether_prewarm_multicall_fallbacks_total");
+        registry
+            .register(Box::new(mempool_backrun_profit_ratio.clone()))
+            .expect("register aether_mempool_backrun_profit_ratio");
+        registry
+            .register(Box::new(mempool_post_sim_gate_bypassed_total.clone()))
+            .expect("register aether_mempool_post_sim_gate_bypassed_total");
+        registry
+            .register(Box::new(mempool_backrun_calldata_built_total.clone()))
+            .expect("register aether_mempool_backrun_calldata_built_total");
 
         // Pre-touch every label so dashboards see zero rows from boot.
         for ev in &[
@@ -645,6 +692,9 @@ impl EngineMetrics {
             prewarm_multicall_batches_total,
             prewarm_multicall_v2_slots_total,
             prewarm_multicall_fallbacks_total,
+            mempool_backrun_profit_ratio,
+            mempool_post_sim_gate_bypassed_total,
+            mempool_backrun_calldata_built_total,
         }
     }
 
@@ -949,6 +999,24 @@ impl EngineMetrics {
     pub fn inc_mempool_backrun_rejected(&self, reason: &str) {
         self.mempool_backrun_rejected_total
             .with_label_values(&[reason])
+            .inc();
+    }
+
+    /// Observe the revm-actual / optimizer-expected NET profit ratio for a
+    /// validated mempool backrun. ~1.0 means detection-state matched sim-state.
+    pub fn observe_mempool_backrun_profit_ratio(&self, ratio: f64) {
+        self.mempool_backrun_profit_ratio.observe(ratio);
+    }
+
+    /// Bump `aether_mempool_post_sim_gate_bypassed_total`.
+    pub fn inc_mempool_post_sim_gate_bypassed(&self) {
+        self.mempool_post_sim_gate_bypassed_total.inc();
+    }
+
+    /// Bump `aether_mempool_backrun_calldata_built_total{protocol}`.
+    pub fn inc_mempool_backrun_calldata_built(&self, protocol: &str) {
+        self.mempool_backrun_calldata_built_total
+            .with_label_values(&[protocol])
             .inc();
     }
 

--- a/crates/state/src/price_graph.rs
+++ b/crates/state/src/price_graph.rs
@@ -31,10 +31,22 @@ pub struct PriceEdge {
     pub reserve_out: f64,
     /// `true` when this edge is excluded from arbitrage detection because the
     /// backing pool's liquidity is below the configured minimum-liquidity floor
-    /// (see [`PriceGraph::set_min_liquidity_weth`]). Bellman-Ford skips filtered
-    /// edges during relaxation, so dead/drained pools never produce phantom
-    /// cycles. Placeholder edges (no real reserves) are never filtered.
+    /// (see [`PriceGraph::set_min_liquidity_weth`]) OR it was quarantined as a
+    /// never-updated placeholder (see [`PriceGraph::quarantine_stale_edges`]).
+    /// Bellman-Ford skips filtered edges during relaxation, so dead/drained
+    /// pools never produce phantom cycles.
     pub filtered: bool,
+    /// Chain block height at which this edge last received a real reserve
+    /// update via [`update_edge_from_reserves`]. `0` = never updated — i.e. a
+    /// placeholder edge from [`add_edge`] that carries no real reserves.
+    ///
+    /// NOTE: for an AMM, an edge with no *recent* update is NOT stale — a quiet
+    /// pool's cached reserves are still exact, because reserves only change when
+    /// the pool trades (and a trade emits the event that updates this edge). So
+    /// raw age is a liveness signal, not a corruption signal;
+    /// [`PriceGraph::quarantine_stale_edges`] treats it as an opt-in
+    /// missed-event backstop only, never the primary filter.
+    pub last_update_block: u64,
 }
 
 /// Directed price graph for arbitrage detection.
@@ -68,6 +80,12 @@ pub struct PriceGraph {
     /// for a WETH-paired pool's edges to participate in detection. `0.0` (the
     /// default) disables the floor.
     min_liquidity_weth: f64,
+    /// Most recent chain block the writer has applied updates for. Stamped onto
+    /// each edge by [`update_edge_from_reserves`] and read by
+    /// [`quarantine_stale_edges`]. `0` until the writer calls
+    /// [`set_current_block`]; while `0`, edge age is unknown so the age backstop
+    /// is inert (placeholder quarantine still works — it is block-independent).
+    current_block: u64,
 }
 
 impl PriceGraph {
@@ -82,6 +100,7 @@ impl PriceGraph {
             token_decimals: vec![DEFAULT_TOKEN_DECIMALS; num_vertices],
             weth_vertex: None,
             min_liquidity_weth: 0.0,
+            current_block: 0,
         }
     }
 
@@ -126,6 +145,9 @@ impl PriceGraph {
             // Placeholder edges carry no real reserves and are never floored;
             // the follow-up `update_edge_from_reserves` sets the real flag.
             filtered: false,
+            // 0 = never updated. `quarantine_stale_edges` filters such edges
+            // until `update_edge_from_reserves` stamps a real block.
+            last_update_block: 0,
         };
 
         // Try to update an existing edge with matching (from, to, pool_id).
@@ -185,6 +207,9 @@ impl PriceGraph {
         if reserve_in <= 0.0 || reserve_out <= 0.0 {
             return;
         }
+        // Capture before the mutable edge borrow below (can't read &self while
+        // self.edges is borrowed mutably).
+        let cur_block = self.current_block;
         let dec_in = self
             .token_decimals
             .get(from)
@@ -243,6 +268,7 @@ impl PriceGraph {
             existing.reserve_in = reserve_in;
             existing.reserve_out = reserve_out;
             existing.filtered = filtered;
+            existing.last_update_block = cur_block;
             // Mirror the update in the flat edge list via O(1) index lookup.
             // Direct indexing: panics if the key is missing, which is correct —
             // the adjacency list found the edge, so edge_index must agree.
@@ -251,6 +277,7 @@ impl PriceGraph {
             self.all_edges[idx].reserve_in = reserve_in;
             self.all_edges[idx].reserve_out = reserve_out;
             self.all_edges[idx].filtered = filtered;
+            self.all_edges[idx].last_update_block = cur_block;
             self.dirty[idx] = true;
         }
     }
@@ -282,6 +309,84 @@ impl PriceGraph {
             self.all_edges[idx].filtered = filtered;
             self.dirty[idx] = true;
         }
+    }
+
+    /// Record the chain block the writer is currently applying updates for.
+    /// Subsequent [`update_edge_from_reserves`] calls stamp this onto each
+    /// edge's `last_update_block`, and [`quarantine_stale_edges`] uses it to
+    /// compute edge age. Set it once per block before applying that block's
+    /// reserve updates.
+    pub fn set_current_block(&mut self, block: u64) {
+        self.current_block = block;
+    }
+
+    /// The most recent block recorded via [`set_current_block`] (`0` if unset).
+    #[inline]
+    pub fn current_block(&self) -> u64 {
+        self.current_block
+    }
+
+    /// Quarantine stale / corrupt edges by setting their `filtered` flag so
+    /// Bellman-Ford skips them — preventing the placeholder rate=1.0 edge from
+    /// [`add_edge`] from chaining into phantom cycles (the same failure
+    /// [`set_edge_filtered`] guards at boot).
+    ///
+    /// Two signals, deliberately asymmetric:
+    ///
+    /// * **Never-updated placeholders** (`reserve_in <= 0 || reserve_out <= 0`)
+    ///   are ALWAYS quarantined. These carry no real reserves — they are the
+    ///   genuine corruption source. This signal is block-independent and safe.
+    ///
+    /// * **Raw age** (`current_block - last_update_block > max_age_blocks`) is
+    ///   an OPT-IN backstop, applied ONLY when `max_age_blocks > 0` and ONLY to
+    ///   edges that already hold real reserves. It is OFF by default
+    ///   (`max_age_blocks == 0`) because for an AMM a quiet pool's reserves stay
+    ///   exact between trades — age means "no recent trade", not "wrong data".
+    ///   Enable it only as a missed-event / lost-subscription safety net, where
+    ///   dropping coverage on genuinely quiet pools is an acceptable trade.
+    ///
+    /// Quarantine is additive: it only ever SETS `filtered = true`; it never
+    /// clears it. A subsequent [`update_edge_from_reserves`] re-derives
+    /// `filtered` from the liquidity floor, so a quarantined edge that receives
+    /// fresh reserves automatically heals. Returns the number of edges newly
+    /// quarantined by this call.
+    pub fn quarantine_stale_edges(&mut self, max_age_blocks: u64) -> usize {
+        let cur = self.current_block;
+        let mut count = 0usize;
+        for idx in 0..self.all_edges.len() {
+            let (from, to, pool_id, already, reserve_in, reserve_out, last_update) = {
+                let e = &self.all_edges[idx];
+                (
+                    e.from,
+                    e.to,
+                    e.pool_id,
+                    e.filtered,
+                    e.reserve_in,
+                    e.reserve_out,
+                    e.last_update_block,
+                )
+            };
+            if already {
+                continue;
+            }
+            let is_placeholder = reserve_in <= 0.0 || reserve_out <= 0.0;
+            let is_too_old = max_age_blocks > 0
+                && cur > 0
+                && last_update > 0
+                && cur.saturating_sub(last_update) > max_age_blocks;
+            if is_placeholder || is_too_old {
+                self.all_edges[idx].filtered = true;
+                self.dirty[idx] = true;
+                if let Some(adj) = self.edges[from]
+                    .iter_mut()
+                    .find(|x| x.to == to && x.pool_id == pool_id)
+                {
+                    adj.filtered = true;
+                }
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Get all outgoing edges from a vertex.
@@ -1425,5 +1530,73 @@ mod tests {
             (edge.weight - expected_weight).abs() < 1e-12,
             "18/18 decimal pair must match pre-change weight"
         );
+    }
+
+    // --------------- Stale / placeholder quarantine ---------------
+
+    #[test]
+    fn quarantine_filters_never_updated_placeholder() {
+        // add_edge alone leaves reserves at 0 (placeholder). Quarantine with the
+        // age backstop OFF must still filter it on the placeholder signal.
+        let mut g = PriceGraph::new(2);
+        let pool_id = make_pool_id(1, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 1.0, pool_id, Address::repeat_byte(1), ProtocolType::UniswapV2, U256::from(1u64));
+        assert!(!g.edges_from(0)[0].filtered, "placeholder starts unfiltered");
+
+        let n = g.quarantine_stale_edges(0);
+        assert_eq!(n, 1, "the one placeholder edge should be quarantined");
+        assert!(g.edges_from(0)[0].filtered, "placeholder must be filtered");
+        assert!(g.all_edges()[0].filtered, "mirror in all_edges must agree");
+    }
+
+    #[test]
+    fn quarantine_keeps_updated_edge_regardless_of_age_when_backstop_off() {
+        // A real, updated edge that has not traded for many blocks is NOT stale
+        // for an AMM — its reserves are still exact. With the age backstop off
+        // (max_age_blocks = 0) it must be kept.
+        let mut g = PriceGraph::new(2);
+        let pool_id = make_pool_id(2, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 1.0, pool_id, Address::repeat_byte(2), ProtocolType::UniswapV2, U256::from(1u64));
+        g.set_current_block(100);
+        g.update_edge_from_reserves(0, 1, pool_id, 1_000.0, 2_000.0, 0.997);
+        // Chain advanced far past the last update.
+        g.set_current_block(1_000_000);
+
+        let n = g.quarantine_stale_edges(0);
+        assert_eq!(n, 0, "quiet-but-valid edge must NOT be filtered when age backstop is off");
+        assert!(!g.edges_from(0)[0].filtered);
+        assert_eq!(g.all_edges()[0].last_update_block, 100, "stamp records the update block");
+    }
+
+    #[test]
+    fn quarantine_age_backstop_is_opt_in() {
+        let mut g = PriceGraph::new(2);
+        let pool_id = make_pool_id(3, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 1.0, pool_id, Address::repeat_byte(3), ProtocolType::UniswapV2, U256::from(1u64));
+        g.set_current_block(100);
+        g.update_edge_from_reserves(0, 1, pool_id, 1_000.0, 2_000.0, 0.997);
+        g.set_current_block(100 + 51); // 51 blocks since update
+
+        // max_age 50 → 51 > 50 → filtered (opt-in backstop enabled).
+        let n = g.quarantine_stale_edges(50);
+        assert_eq!(n, 1, "updated edge older than max_age must be filtered when backstop enabled");
+        assert!(g.edges_from(0)[0].filtered);
+    }
+
+    #[test]
+    fn quarantine_self_heals_on_fresh_update() {
+        // A quarantined placeholder that later receives real reserves must
+        // un-filter (update_edge_from_reserves re-derives filtered from the
+        // liquidity floor, which is disabled here → false).
+        let mut g = PriceGraph::new(2);
+        let pool_id = make_pool_id(4, ProtocolType::UniswapV2);
+        g.add_edge(0, 1, 1.0, pool_id, Address::repeat_byte(4), ProtocolType::UniswapV2, U256::from(1u64));
+        g.quarantine_stale_edges(0);
+        assert!(g.edges_from(0)[0].filtered, "placeholder quarantined");
+
+        g.set_current_block(500);
+        g.update_edge_from_reserves(0, 1, pool_id, 1_000.0, 2_000.0, 0.997);
+        assert!(!g.edges_from(0)[0].filtered, "fresh reserves must clear the quarantine");
+        assert_eq!(g.edges_from(0)[0].last_update_block, 500);
     }
 }

--- a/deploy/docker/grafana/dashboards/backrun_funnel.json
+++ b/deploy/docker/grafana/dashboards/backrun_funnel.json
@@ -1057,6 +1057,166 @@
         },
         "overrides": []
       }
+    },
+    {
+      "id": 25,
+      "type": "row",
+      "title": "⑥ Arb reality & discrepancy (detection vs revm)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      }
+    },
+    {
+      "id": 26,
+      "type": "timeseries",
+      "title": "Profit ratio: revm-actual ÷ optimizer-expected (p50/p95)",
+      "description": "THE discrepancy gauge. revm-measured NET profit divided by the optimizer's expected NET profit for validated backruns. ~1.0 = detection-state matches sim-state (no discrepancy). A persistent left tail (<<1.0) means stale snapshot / unit mismatch.",
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 67
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(aether_mempool_backrun_profit_ratio_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(aether_mempool_backrun_profit_ratio_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 27,
+      "type": "timeseries",
+      "title": "Inner swap calldata built by protocol (5m rate)",
+      "description": "Proves the AetherExecutor receives non-empty step.data per hop (empty data reverts SwapFailed). uniswap_v2 / uniswap_v3 / sushiswap build; curve/balancer/bancor have no builder and instead show under rejections as unsupported_protocol_calldata.",
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 67
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (protocol) (rate(aether_mempool_backrun_calldata_built_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "{{protocol}}"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            },
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 28,
+      "type": "timeseries",
+      "title": "Post-sim cross-check bypassed (5m rate)",
+      "description": "Backruns published WITHOUT the detector-vs-revm profit cross-check because the optimizer fell back (expected_net == 0). Watch this share — these rely on the sim's own accept criteria only.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 67
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(aether_mempool_post_sim_gate_bypassed_total{job=~\"aether-rust|aether-host-rust\"}[5m]))",
+          "legendFormat": "bypassed/s"
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Makes the live mempool-backrun path actually produce executable, profitable arbs, fixes the discrepancy/staleness sources that suppressed real candidates, and adds the observability + venue coverage to see and act on them. Findings came from an adversarial audit (file:line proof, skeptic-verified); each confirmed defect is fixed with tests.

## Commits

- **feat(metrics):** 3 funnel metrics + dashboard §⑥ — `aether_mempool_backrun_profit_ratio` (revm-actual ÷ optimizer-expected net; the discrepancy gauge, ~1.0 = consistent), `…_calldata_built_total{protocol}`, `…_post_sim_gate_bypassed_total`.
- **fix(mempool):** the core fixes —
  - **Empty `SwapStep.calldata`** (dominant "publishes 0" cause): the executor runs `pool.call(step.data)` verbatim, so empty data reverted (`SwapFailed`) and *every* sim was a false negative. Now builds V2/V3/Sushi inner calldata after sizing; drops Curve/Balancer/Bancor hops (no builder yet) with reason `unsupported_protocol_calldata` instead of publishing a reverting bundle.
  - **Tip accounting:** simulate with `tipBps=0` so the recipient delta is the *full* profit (was the ~10% left after a 90% coinbase tip); publish the real-tip calldata separately; `net = gross − gas`.
  - **`gate_post_sim` units:** subtract sim gas from revm gross so both sides are net (was net-vs-gross → `frac_diff≈0.9` → dropped marginal arbs as `revm_contradicts`).
  - **Routing:** select steps on the post-victim graph the cycle was scored on.
  - **Replay fork:** pin the detection-time post-state replay to the snapshot block (gated on `AETHER_BACKRUN_FORK_LATEST`), matching the validating sim.
- **feat(state):** `quarantine_stale_edges` — never-updated placeholder edges (zero reserves, the rate=1.0 phantom-cycle source) are filtered out of Bellman-Ford. Raw edge age is an **opt-in, off-by-default** backstop (`AETHER_EDGE_MAX_AGE_BLOCKS`): for an AMM a quiet pool's reserves stay exact between trades, so age alone isn't a corruption signal and must not drop valid quiet pools.
- **feat(pools):** +7 UniV2/V3 venues, all verified on-chain (getCode + token0/token1 + fee), so high-traction pairs have ≥2 *executable* venues — notably USDC/USDT gains a cross-AMM venue (was UniV3 tiers only).

## Verification

- `cargo build` / `clippy` (grpc-server + state): clean, zero warnings.
- Tests: `aether-state` 64 pass (incl. 4 new quarantine tests); `aether-grpc-server` 78 pass (incl. 3 new calldata tests). The one failing test (`provider::test_provider_run_with_shutdown`) is a pre-existing timing flake that fails identically on the base branch.
- New pool addresses verified against mainnet via `cast` at block ~25.24M; `pools.toml` parses (135 pools, no dup addresses).

## Known follow-ups (out of scope here)

- The **block-driven** path shares the same empty-calldata + net-vs-gross gate bug (separate fix).
- Curve/Balancer/Bancor have no inner-calldata builder yet, so those hops are dropped (observable via `unsupported_protocol_calldata`) rather than backrun.

## Notes

Rebased onto `develop` (was developed against an older base); merges cleanly. `AETHER_EDGE_MAX_AGE_BLOCKS` defaults to 0 (placeholder-only quarantine); set >0 only as a missed-event backstop.