### PR TITLE
obs(sim): surface backrun reject reasons in stdout by default

### DIFF
--- a/crates/simulator/src/mempool_backrun.rs
+++ b/crates/simulator/src/mempool_backrun.rs
@@ -370,7 +370,7 @@ where
             };
         }
         Ok(ExecutionResult::Halt { reason, gas_used }) => {
-            debug!(?reason, gas_used, "mempool-backrun: victim halted");
+            info!(?reason, gas_used, "mempool-backrun: victim halted");
             return BackrunSimResult::rejected(RejectReason::VictimHalted, gas_used, 0);
         }
         Err(e) => {
@@ -414,9 +414,11 @@ where
                 // here saves a publish + a downstream pipeline step.
                 let gas_cost_wei = U256::from(gas_used).saturating_mul(U256::from(params.base_fee));
                 if gross <= gas_cost_wei {
-                    debug!(
+                    info!(
                         %gross,
                         %gas_cost_wei,
+                        deficit_wei = %gas_cost_wei.saturating_sub(gross),
+                        arb_gas_used = gas_used,
                         "mempool-backrun: gross profit does not cover gas at sim base fee"
                     );
                     return BackrunSimResult::rejected(
@@ -446,10 +448,11 @@ where
             ExecutionResult::Revert { gas_used, output } => {
                 let selector = revert_selector(&output);
                 let reason = decode_revert_reason(&output);
-                debug!(
+                info!(
                     gas_used,
                     reason = %reason,
-                    ?selector,
+                    selector = %alloy::hex::encode(selector),
+                    output_hex = %alloy::primitives::hex::encode(output.as_ref()),
                     "mempool-backrun: arb leg reverted"
                 );
                 BackrunSimResult {
@@ -462,7 +465,7 @@ where
                 }
             }
             ExecutionResult::Halt { reason, gas_used } => {
-                debug!(?reason, gas_used, "mempool-backrun: arb leg halted");
+                info!(?reason, gas_used, "mempool-backrun: arb leg halted");
                 BackrunSimResult::rejected(RejectReason::ArbHalted, victim_gas_used, gas_used)
             }
         },


### PR DESCRIPTION
## Summary
- Promote four `debug!` reject-path log lines in `mempool_backrun.rs` to `info!` so the ABI-decoded revert string + gas/profit context surface in docker logs / Loki without flipping `RUST_LOG=debug`
- `victim_reverted` was already at `info!` from an earlier change; `arb_reverted` + `negative_after_gas` were the two biggest blind spots, jointly ~75% of recent rejects (606 / 307 / 1209)
- Enriches `negative_after_gas` with `deficit_wei` + `arb_gas_used` so the median miss-by amount is visible without adding a histogram
- Enriches `arb_reverted` with `output_hex` so the full revert payload (not just the prefix) is recoverable from logs

## Files Changed
| File | Change |
|---|---|
| `crates/simulator/src/mempool_backrun.rs` | 4 log lines `debug!` → `info!`; 2 extra fields on the negative-after-gas + arb-reverted branches |

## Why

Triage today: when the funnel shows `attempted: 384 → validated: 0`, the `aether_mempool_backrun_rejected_total{reason=...}` counter tells us which of the 8 buckets ate the 384, but the actual Solidity revert string (`"Insufficient output amount"`, `"INSUFFICIENT_LIQUIDITY"`, etc.) for the `arb_reverted` bucket lived only at `RUST_LOG=debug`. That's enough to identify a category but not enough to tell whether 50 reverts share one root cause or are 50 different slippage misses.

The code already captures `revert_reason` into `BackrunSimResult` on every non-success branch — only the log level was hiding it.

## Volume impact

Current lifetime distribution from prod dashboard:
```
negative_after_gas   606  50%
arb_reverted         307  25%
below_min_profit     196  16%
victim_reverted       55   5%
sim_concurrency       23   2%
rpc_transport         19   2%
sim_timeout            3   0%
```

At the observed 5m rate (max ~0.2 c/s for negative_after_gas, ~0.03 c/s for arb_reverted), this is ~10–15 info lines/min sustained — well inside Loki's comfort zone and far below the host JSON-logger's per-second budget.

Happy-path `arb leg accepted` (line 429) stays at `debug!` — would flood under heavy throughput and the validated counter already tracks it.

## Acceptance Criteria
- [x] `negative_after_gas` log line emits `gross`, `gas_cost_wei`, `deficit_wei`, `arb_gas_used` at info level
- [x] `arb_reverted` log line emits decoded `reason`, hex `selector`, full `output_hex` at info level
- [x] `victim_halted` + `arb_halted` log halt opcode + gas at info level
- [x] No changes to reject metric label set (`reject_reason_label_matches_metric_label_set` test still passes)
- [x] No new dependencies, no schema change

## Test plan
- [x] `cargo build -p aether-simulator` clean
- [x] `cargo clippy -p aether-simulator --lib --no-deps` clean (no warnings)
- [x] `cargo test -p aether-simulator --lib mempool_backrun` → 9 passed, 0 failed, 1 ignored (live mainnet fork)
- [ ] After deploy: confirm Loki query `{job=~"aether-rust"} |= "mempool-backrun: arb leg reverted"` returns lines with `reason=` field populated