### PR TITLE
obs(metrics): histograms for backrun gross / gas / deficit per reason

### DIFF
--- a/crates/grpc-server/src/mempool_pipeline.rs
+++ b/crates/grpc-server/src/mempool_pipeline.rs
@@ -1985,6 +1985,28 @@ fn run_backrun_validation(
         }
         metrics.inc_mempool_backrun_rejected(reason);
         metrics.observe_mempool_backrun_validation_latency_ms("reject", elapsed_ms);
+        // Record the gross / gas-cost / deficit triple so dashboards can
+        // distinguish "missed breakeven by ε" (gas-model tuning win) from
+        // "missed by miles" (paths fundamentally too thin) without
+        // grepping `aether-rust` logs for the matching info! line. Gas cost
+        // is pinned to `params.base_fee` so the histogram matches the
+        // simulator's own NegativeAfterGas accounting; the executor's real
+        // gas pricing lives on a separate counter on the Go side.
+        let gas_cost_wei = alloy::primitives::U256::from(result.arb_gas_used)
+            .saturating_mul(alloy::primitives::U256::from(params.base_fee));
+        let gross_eth = EngineMetrics::wei_to_eth_f64(result.gross_profit_wei);
+        let gas_cost_eth = EngineMetrics::wei_to_eth_f64(gas_cost_wei);
+        let deficit_wei = gas_cost_wei.saturating_sub(result.gross_profit_wei);
+        let deficit_eth = EngineMetrics::wei_to_eth_f64(deficit_wei);
+        metrics.observe_mempool_backrun_gross_profit_eth(reason, gross_eth);
+        metrics.observe_mempool_backrun_gas_cost_eth(reason, gas_cost_eth);
+        // Only emit the deficit observation when the math is meaningful —
+        // RpcTransport / SimTimeout / fork_construction-style rejects have
+        // arb_gas_used == 0 and would skew the deficit histogram toward 0
+        // with samples that aren't really "near breakeven".
+        if result.arb_gas_used > 0 && deficit_wei > alloy::primitives::U256::ZERO {
+            metrics.observe_mempool_backrun_deficit_eth(reason, deficit_eth);
+        }
         debug!(
             target: "aether::mempool",
             tx_hash = %event.tx_hash,
@@ -2014,6 +2036,19 @@ fn run_backrun_validation(
     metrics.observe_mempool_backrun_validation_latency_ms("accept", elapsed_ms);
     let bucket = gross_profit_bucket(result.gross_profit_wei);
     metrics.inc_mempool_backrun_validated(bucket);
+    // Mirror the reject-path histogram observations under reason="accepted"
+    // so a single PromQL series can compare survivor gross/gas distributions
+    // against each rejected bucket without joining two metric names.
+    let accept_gas_cost_wei = alloy::primitives::U256::from(result.arb_gas_used)
+        .saturating_mul(alloy::primitives::U256::from(params.base_fee));
+    metrics.observe_mempool_backrun_gross_profit_eth(
+        "accepted",
+        EngineMetrics::wei_to_eth_f64(result.gross_profit_wei),
+    );
+    metrics.observe_mempool_backrun_gas_cost_eth(
+        "accepted",
+        EngineMetrics::wei_to_eth_f64(accept_gas_cost_wei),
+    );
 
     let proto = aether_proto::ValidatedArb {
         id: format!(

--- a/crates/grpc-server/src/metrics.rs
+++ b/crates/grpc-server/src/metrics.rs
@@ -121,6 +121,21 @@ pub struct EngineMetrics {
     /// `AETHER_MEMPOOL_SIM_CONCURRENCY` semaphore; exposed so dashboards can
     /// alert on saturation (gauge at ceiling = victims being dropped).
     mempool_backrun_sim_concurrent: IntGauge,
+    /// Gross profit (ETH) measured at the moment of accept-or-reject, labelled
+    /// by [`mempool_backrun_rejected_total`]'s `reason` set (plus `"accepted"`).
+    /// Lets dashboards compare the profit distribution of survivors vs each
+    /// reject bucket — for example, whether `negative_after_gas` candidates
+    /// cluster at small gross or have a fat tail the gas model is eating.
+    mempool_backrun_gross_profit_eth: HistogramVec,
+    /// Gas cost (ETH, at sim base fee) charged to the arb leg at the moment
+    /// of accept-or-reject. Same label set as `gross_profit_eth`. Pairs with
+    /// it so PromQL can compute net = gross - gas_cost downstream.
+    mempool_backrun_gas_cost_eth: HistogramVec,
+    /// `gas_cost - gross_profit` (ETH) for rejected backruns where the math is
+    /// meaningful (`negative_after_gas` primarily; `arb_reverted` / `arb_halted`
+    /// observe with gross=0). Answers "by how much did we miss breakeven?"
+    /// without grepping logs. Label set matches `mempool_backrun_rejected_total`.
+    mempool_backrun_deficit_eth: HistogramVec,
     /// Wall-clock delta between when this process first saw a pending tx
     /// (`PendingTxEvent::first_seen_unix_nanos` stamp at the ingestion
     /// boundary) and when that tx landed on chain (observed via
@@ -362,6 +377,40 @@ impl EngineMetrics {
             "In-flight mempool-backrun validation sims, bounded by the semaphore",
         )
         .expect("aether_mempool_backrun_sim_concurrent gauge");
+        // Log-scale buckets spanning a 1e-7 → 10 ETH range (so we catch both
+        // dust-level deficits on thin arbs and the occasional fat-tail miss
+        // without saturating either end). Shared across all three histograms
+        // so PromQL queries can subtract / divide buckets cleanly.
+        let backrun_eth_buckets = vec![
+            1e-7, 1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2, 1e-1, 5e-1, 1.0, 10.0,
+        ];
+        let mempool_backrun_gross_profit_eth = HistogramVec::new(
+            HistogramOpts::new(
+                "aether_mempool_backrun_gross_profit_eth",
+                "Gross ETH profit observed at accept/reject time, by RejectReason label (plus 'accepted')",
+            )
+            .buckets(backrun_eth_buckets.clone()),
+            &["reason"],
+        )
+        .expect("aether_mempool_backrun_gross_profit_eth histogram vec");
+        let mempool_backrun_gas_cost_eth = HistogramVec::new(
+            HistogramOpts::new(
+                "aether_mempool_backrun_gas_cost_eth",
+                "Arb-leg gas cost in ETH at sim base fee, by RejectReason label (plus 'accepted')",
+            )
+            .buckets(backrun_eth_buckets.clone()),
+            &["reason"],
+        )
+        .expect("aether_mempool_backrun_gas_cost_eth histogram vec");
+        let mempool_backrun_deficit_eth = HistogramVec::new(
+            HistogramOpts::new(
+                "aether_mempool_backrun_deficit_eth",
+                "gas_cost - gross_profit (ETH) for rejected backruns; answers 'how close to breakeven'",
+            )
+            .buckets(backrun_eth_buckets),
+            &["reason"],
+        )
+        .expect("aether_mempool_backrun_deficit_eth histogram vec");
         let mempool_first_seen_to_inclusion_ms = Histogram::with_opts(
             HistogramOpts::new(
                 "aether_mempool_first_seen_to_inclusion_ms",
@@ -531,6 +580,15 @@ impl EngineMetrics {
             .register(Box::new(mempool_backrun_sim_concurrent.clone()))
             .expect("register aether_mempool_backrun_sim_concurrent");
         registry
+            .register(Box::new(mempool_backrun_gross_profit_eth.clone()))
+            .expect("register aether_mempool_backrun_gross_profit_eth");
+        registry
+            .register(Box::new(mempool_backrun_gas_cost_eth.clone()))
+            .expect("register aether_mempool_backrun_gas_cost_eth");
+        registry
+            .register(Box::new(mempool_backrun_deficit_eth.clone()))
+            .expect("register aether_mempool_backrun_deficit_eth");
+        registry
             .register(Box::new(mempool_first_seen_to_inclusion_ms.clone()))
             .expect("register aether_mempool_first_seen_to_inclusion_ms");
         registry
@@ -629,6 +687,9 @@ impl EngineMetrics {
             mempool_backrun_validated_total,
             mempool_backrun_rejected_total,
             mempool_backrun_sim_concurrent,
+            mempool_backrun_gross_profit_eth,
+            mempool_backrun_gas_cost_eth,
+            mempool_backrun_deficit_eth,
             mempool_first_seen_to_inclusion_ms,
             mempool_first_seen_events_total,
             mempool_post_state_replay_total,
@@ -952,6 +1013,53 @@ impl EngineMetrics {
             .inc();
     }
 
+    /// Observe one gross-profit sample (ETH) on the backrun funnel, tagged
+    /// with the same `reason` label set as
+    /// [`inc_mempool_backrun_rejected`] (or `"accepted"` for survivors).
+    pub fn observe_mempool_backrun_gross_profit_eth(&self, reason: &str, eth: f64) {
+        self.mempool_backrun_gross_profit_eth
+            .with_label_values(&[reason])
+            .observe(eth);
+    }
+
+    /// Observe one arb-leg gas-cost sample (ETH) at the sim base fee.
+    pub fn observe_mempool_backrun_gas_cost_eth(&self, reason: &str, eth: f64) {
+        self.mempool_backrun_gas_cost_eth
+            .with_label_values(&[reason])
+            .observe(eth);
+    }
+
+    /// Observe one deficit sample (ETH) — `gas_cost - gross_profit`. Only
+    /// meaningful where the deficit is positive (i.e. the sim produced gas
+    /// usage and the gross was either zero or below cost); callers in the
+    /// `accepted` branch should skip this one.
+    pub fn observe_mempool_backrun_deficit_eth(&self, reason: &str, eth: f64) {
+        self.mempool_backrun_deficit_eth
+            .with_label_values(&[reason])
+            .observe(eth);
+    }
+
+    /// Convert a wei-denominated `U256` to a lossy `f64` ETH amount, suitable
+    /// for histogram observation. Saturates at `f64::MAX` for values that
+    /// don't fit (in practice anything ≥ ~1e21 ETH — a non-event).
+    pub fn wei_to_eth_f64(wei: alloy::primitives::U256) -> f64 {
+        // 1 ETH = 1e18 wei. We do the divide in fixed-point: u128 cast of the
+        // truncated `wei / 1e9`, then convert to f64 and divide by 1e9 again.
+        // Two stages keep us under the 2^53 mantissa boundary for typical
+        // backrun-profit ranges (~10 ETH = 1e19 wei).
+        const WEI_PER_GWEI: u128 = 1_000_000_000u128;
+        let gwei: u128 = if wei.bit_len() <= 128 {
+            // U256 → u128 lossy when bit_len > 128; guarded above. Divide
+            // first to keep magnitude small.
+            (wei / alloy::primitives::U256::from(WEI_PER_GWEI))
+                .try_into()
+                .unwrap_or(u128::MAX)
+        } else {
+            u128::MAX
+        };
+        (gwei as f64) / 1e9
+    }
+
     /// Bump `aether_mempool_prewarm_inject_total{result="hit"}`.
     pub fn inc_mempool_prewarm_hit(&self) {
         self.mempool_prewarm_inject_total
@@ -1227,5 +1335,69 @@ mod tests {
         ] {
             assert!(output.contains(name), "missing or wrong: {name}");
         }
+    }
+
+    /// `wei_to_eth_f64` must produce sane ETH values across the range we
+    /// actually observe (sub-mwei → ~10 ETH). Catches any future regression
+    /// in the two-stage divide that keeps us under the 2^53 f64 boundary.
+    #[test]
+    fn wei_to_eth_f64_handles_typical_range() {
+        use alloy::primitives::U256;
+        // 0 wei → 0 ETH (exact).
+        assert_eq!(EngineMetrics::wei_to_eth_f64(U256::ZERO), 0.0);
+        // 1 ETH = 1e18 wei.
+        let one_eth_wei = U256::from(1_000_000_000_000_000_000u128);
+        assert!((EngineMetrics::wei_to_eth_f64(one_eth_wei) - 1.0).abs() < 1e-9);
+        // 0.001 ETH = 1e15 wei.
+        let milli = U256::from(1_000_000_000_000_000u128);
+        assert!((EngineMetrics::wei_to_eth_f64(milli) - 0.001).abs() < 1e-12);
+        // 1 gwei = 1e9 wei → 1e-9 ETH.
+        let one_gwei = U256::from(1_000_000_000u128);
+        assert!((EngineMetrics::wei_to_eth_f64(one_gwei) - 1e-9).abs() < 1e-18);
+        // Sub-gwei truncates to 0 (fine — below histogram floor of 1e-7).
+        assert_eq!(EngineMetrics::wei_to_eth_f64(U256::from(999u128)), 0.0);
+    }
+
+    /// All three reject-funnel histograms must emit at least one labelled
+    /// series per known reject reason plus `"accepted"`, so PromQL queries
+    /// keyed on those labels never miss a bucket.
+    #[test]
+    fn backrun_reject_histograms_emit_per_reason_label() {
+        let metrics = EngineMetrics::new();
+
+        // Observe one sample per known RejectReason label + the accept label.
+        for reason in [
+            "victim_reverted",
+            "victim_halted",
+            "arb_reverted",
+            "arb_halted",
+            "negative_after_gas",
+            "rpc_transport",
+            "sim_timeout",
+            "sim_error",
+            "accepted",
+        ] {
+            metrics.observe_mempool_backrun_gross_profit_eth(reason, 0.001);
+            metrics.observe_mempool_backrun_gas_cost_eth(reason, 0.002);
+            if reason != "accepted" {
+                metrics.observe_mempool_backrun_deficit_eth(reason, 0.001);
+            }
+        }
+
+        let output = String::from_utf8(metrics.render()).expect("metrics output utf-8");
+        for hist in [
+            "aether_mempool_backrun_gross_profit_eth",
+            "aether_mempool_backrun_gas_cost_eth",
+            "aether_mempool_backrun_deficit_eth",
+        ] {
+            assert!(
+                output.contains(&format!("{hist}_count")),
+                "missing histogram series: {hist}"
+            );
+        }
+        // Spot-check one labelled series end-to-end so a future label rename
+        // (RejectReason::as_str()) cannot silently break the dashboard query.
+        assert!(output.contains(r#"reason="negative_after_gas""#));
+        assert!(output.contains(r#"reason="accepted""#));
     }
 }

--- a/deploy/docker/grafana/dashboards/mempool.json
+++ b/deploy/docker/grafana/dashboards/mempool.json
@@ -211,7 +211,7 @@
     {
       "id": 11,
       "type": "stat",
-      "title": "Block accuracy (1h) — Δ ≤ 0",
+      "title": "Block accuracy (1h) \u2014 \u0394 \u2264 0",
       "description": "Fraction of confirmed predictions whose actual_target_block landed at or before the predicted block. Computed from the aether_mempool_block_delta histogram's le=0 bucket over a 1h window.",
       "datasource": {
         "type": "prometheus",
@@ -221,7 +221,7 @@
         {
           "refId": "A",
           "expr": "100 * sum(rate(aether_mempool_block_delta_bucket{job=\"aether-host-reconciler\",le=\"0\"}[1h])) / clamp_min(sum(rate(aether_mempool_block_delta_count{job=\"aether-host-reconciler\"}[1h])), 1e-9)",
-          "legendFormat": "Δ≤0"
+          "legendFormat": "\u0394\u22640"
         }
       ],
       "fieldConfig": {
@@ -232,16 +232,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "orange", "value": 60},
-              {"color": "green", "value": 85}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 60
+              },
+              {
+                "color": "green",
+                "value": 85
+              }
             ]
           }
         }
       },
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "colorMode": "value",
@@ -278,16 +289,27 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "orange", "value": 70},
-              {"color": "green", "value": 90}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
             ]
           }
         }
       },
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "colorMode": "value",
@@ -304,7 +326,7 @@
       "id": 13,
       "type": "stat",
       "title": "Reconciler queue depth",
-      "description": "Pending reconciliation writes sitting in the writer-goroutine channel. Saturation → drops increment.",
+      "description": "Pending reconciliation writes sitting in the writer-goroutine channel. Saturation \u2192 drops increment.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -318,7 +340,9 @@
       ],
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "colorMode": "value",
@@ -352,15 +376,23 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 0.01}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
             ]
           }
         }
       },
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "colorMode": "background",
@@ -418,7 +450,14 @@
         }
       ],
       "options": {
-        "legend": {"displayMode": "list", "placement": "right", "values": ["value", "percent"]}
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        }
       },
       "gridPos": {
         "x": 12,
@@ -482,7 +521,9 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {"unit": "ms"}
+        "defaults": {
+          "unit": "ms"
+        }
       },
       "gridPos": {
         "x": 12,
@@ -494,7 +535,7 @@
     {
       "id": 200,
       "type": "row",
-      "title": "Profitability scorer (PR #135–#137)",
+      "title": "Profitability scorer (PR #135\u2013#137)",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -520,7 +561,14 @@
         }
       ],
       "options": {
-        "legend": {"displayMode": "list", "placement": "right", "values": ["value", "percent"]}
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "values": [
+            "value",
+            "percent"
+          ]
+        }
       },
       "gridPos": {
         "x": 0,
@@ -570,7 +618,9 @@
       ],
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "colorMode": "value",
@@ -604,15 +654,23 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "red", "value": 0.01}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
             ]
           }
         }
       },
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "colorMode": "background",
@@ -647,13 +705,109 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {"unit": "ms"}
+        "defaults": {
+          "unit": "ms"
+        }
       },
       "gridPos": {
         "x": 12,
         "y": 65,
         "w": 12,
         "h": 6
+      }
+    },
+    {
+      "id": 300,
+      "type": "timeseries",
+      "title": "Backrun deficit p50 / p95 by reason (5m, ETH)",
+      "description": "How far below breakeven each reject bucket landed. p50 \u2248 0.0001 ETH \u2192 gas-model tuning likely fixes most; p50 \u2248 0.01 ETH \u2192 paths fundamentally thin.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le, reason) (rate(aether_mempool_backrun_deficit_eth_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p50 {{reason}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum by (le, reason) (rate(aether_mempool_backrun_deficit_eth_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p95 {{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ETH",
+          "decimals": 6
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 72,
+        "w": 12,
+        "h": 9
+      }
+    },
+    {
+      "id": 301,
+      "type": "heatmap",
+      "title": "negative_after_gas deficit distribution (heatmap, ETH)",
+      "description": "Y axis is deficit bucket. Color is sample count per bucket per 5m. Shows whether the 'gas ate it' miss is concentrated near zero (tunable) or spread across orders of magnitude (paths thin).",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (le) (rate(aether_mempool_backrun_deficit_eth_bucket{job=~\"aether-rust|aether-host-rust\",reason=\"negative_after_gas\"}[5m]))",
+          "legendFormat": "{{le}}",
+          "format": "heatmap"
+        }
+      ],
+      "options": {
+        "calculate": false,
+        "yAxis": {
+          "unit": "ETH",
+          "decimals": 6
+        }
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 72,
+        "w": 12,
+        "h": 9
+      }
+    },
+    {
+      "id": 302,
+      "type": "timeseries",
+      "title": "Backrun gross profit p50 by reason (5m, ETH)",
+      "description": "Median gross profit at the moment of accept/reject. 'accepted' line is your earnings; reject lines show what detection thinks vs what survives.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le, reason) (rate(aether_mempool_backrun_gross_profit_eth_bucket{job=~\"aether-rust|aether-host-rust\"}[5m])))",
+          "legendFormat": "p50 {{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ETH",
+          "decimals": 6
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 81,
+        "w": 24,
+        "h": 9
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Three new `HistogramVec` series, all labelled by the same `reason` set as `aether_mempool_backrun_rejected_total` (plus `"accepted"` for survivors):
  - `aether_mempool_backrun_gross_profit_eth{reason}` — gross ETH at the moment of accept/reject
  - `aether_mempool_backrun_gas_cost_eth{reason}` — arb-leg gas cost (ETH) at sim base fee
  - `aether_mempool_backrun_deficit_eth{reason}` — `gas_cost - gross` for rejected runs; the "by how much did we miss" number
- Three new Grafana panels on `mempool.json` driven by these series
- One `wei → f64 ETH` converter and a parity test against the eight `RejectReason` labels + `"accepted"`

## Why

From the existing dashboard, lifetime breakdown looks like:
```
negative_after_gas         606  50%
arb_reverted               307  25%
below_min_profit_optimized 196  16%
victim_reverted             55   5%
sim_concurrency_saturated   23   2%
rpc_transport               19   2%
sim_timeout                  3   0%
```
The reject counter answers **how many**, not **by how much**. With `negative_after_gas` at 50%, the actionable question is whether those 606 missed breakeven by ε (gas-model tuning wins them back) or by orders of magnitude (paths are fundamentally too thin → expand pool registry). Same diagnostic applies to `arb_reverted`: was every revert a tiny slippage miss, or did some return a fat tail of large would-be profits we never captured?

The pipeline already has `gross_profit_wei`, `arb_gas_used`, and `params.base_fee` in scope at every accept/reject point. This PR plumbs them into queryable histograms.

## Files Changed
| File | Change |
|---|---|
| `crates/grpc-server/src/metrics.rs` | +3 `HistogramVec` fields, register block, struct construction, 3 `observe_*` helpers, `wei_to_eth_f64` converter, 2 unit tests |
| `crates/grpc-server/src/mempool_pipeline.rs` | Observe triples at reject + accept paths; deficit observation gated on `arb_gas_used > 0` so rpc_transport / sim_timeout don't skew the histogram toward 0 |
| `deploy/docker/grafana/dashboards/mempool.json` | +3 panels: deficit p50/p95 timeseries, negative_after_gas deficit heatmap, gross p50 by reason |

## Implementation notes

- **Bucket choice**: shared log-scale `[1e-7 … 10] ETH`. Catches dust-level deficits on thin arbs and the occasional fat-tail miss with the same series, so PromQL can subtract / divide buckets without bucket-edge mismatches.
- **Base fee pinning**: gas cost uses `params.base_fee` (sim base fee, 1 gwei in shadow mode). Matches the simulator's own `NegativeAfterGas` accounting so the histogram floor lines up with the counter trigger. The Go executor's real-time gas pricing remains a separate metric on the bundle side.
- **Deficit gating**: rpc_transport and sim_timeout rejects never reach the arb leg (`arb_gas_used == 0`). Without gating, they would all observe `deficit = 0` and pull the p50 to zero. Gate is `arb_gas_used > 0 && deficit_wei > 0`.
- **`wei_to_eth_f64`**: two-stage divide (wei → gwei → ETH) to stay under the 2^53 f64 mantissa boundary for typical backrun amounts (up to ~10 ETH = 1e19 wei). Truncates sub-gwei to 0, which is below the histogram floor anyway.

## PromQL the new series unlock

Median and p95 deficit by bucket:
```promql
histogram_quantile(0.5,
  sum by (le, reason) (rate(aether_mempool_backrun_deficit_eth_bucket[1h])))
```
Gross profit distribution across all candidates (gives detection-engine health):
```promql
histogram_quantile(0.5,
  sum by (le, reason) (rate(aether_mempool_backrun_gross_profit_eth_bucket[1h])))
```
"What fraction of negative_after_gas misses would flip green if gas cost dropped 20%?":
```promql
sum(rate(aether_mempool_backrun_deficit_eth_bucket{reason="negative_after_gas",le="5e-5"}[1h]))
  /
sum(rate(aether_mempool_backrun_deficit_eth_count{reason="negative_after_gas"}[1h]))
```

## Acceptance Criteria
- [x] Three new histograms register cleanly; double-register at `EngineMetrics::new()` would panic — covered by existing harness
- [x] Every `RejectReason::as_str()` label produces samples at the reject site
- [x] `accepted` label produces samples at the accept site
- [x] `deficit` histogram does NOT receive samples from rpc_transport / sim_timeout / fork_construction (zero arb gas)
- [x] Three Grafana panels render without datasource errors on the provisioned `prometheus` UID
- [x] No proto / schema / breaking change; counters unchanged

## Test plan
- [x] `cargo build -p aether-grpc-server -p aether-simulator` clean
- [x] `cargo clippy -p aether-grpc-server -p aether-simulator --lib --no-deps` clean
- [x] `cargo test -p aether-grpc-server --lib metrics::` — 4 passed (including 2 new tests: `wei_to_eth_f64_handles_typical_range`, `backrun_reject_histograms_emit_per_reason_label`)
- [x] `cargo test -p aether-simulator --lib mempool_backrun::` — 9 passed, 1 ignored (live-fork only)
- [x] `python3 -c 'import json; json.load(open("deploy/docker/grafana/dashboards/mempool.json"))'` — JSON valid
- [ ] After deploy: confirm `curl localhost:9100/metrics | grep aether_mempool_backrun_deficit_eth` returns series labelled with each reject reason
- [ ] After deploy: confirm the 3 new panels render on `mempool.json` with samples flowing